### PR TITLE
Remove superfluous fields from hive canonical view

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,41 @@ The suite includes 53 tests covering entity CRUD, relationships, queen colour
 auto-calculation, field option validation, inspection logging, and breadcrumb
 building.
 
+## Deployment
+
+After pulling new code to a target environment, run the following steps:
+
+```
+composer install --no-dev
+drush updb -y
+drush cr
+```
+
+**Step summary:**
+
+1. `composer install` — Ensures all PHP dependencies (including geofield,
+   geocoder, leaflet) are present.
+2. `drush updb` — Runs any pending database update hooks. Current hooks:
+   - `10001` — Migrate apiary lat/lng fields to geolocation field.
+   - `10002` — Migrate geolocation field from geolocation module to geofield.
+   - `10003` — Add `external_check` field to hive inspections.
+3. `drush cr` — Rebuilds caches so Drupal picks up any changes to entity
+   definitions, routing, or services.
+
+For DDEV-based environments, prefix commands with `ddev`:
+
+```
+ddev composer install
+ddev drush updb -y
+ddev drush cr
+```
+
+**Post-deployment verification:**
+
+- Confirm all modules are enabled: `drush pm:list --status=enabled --filter=hivelog`
+- Confirm no pending updates remain: `drush updb --no`
+- Run the test suite (see Testing section below).
+
 ## Extending the Module
 
 - **Add new hive types or breeds** — Edit the `allowed_values` arrays in the

--- a/src/Entity/Hive.php
+++ b/src/Entity/Hive.php
@@ -102,11 +102,6 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
         'type' => 'string_textfield',
         'weight' => 0,
       ])
-      ->setDisplayOptions('view', [
-        'label' => 'hidden',
-        'type' => 'string',
-        'weight' => 0,
-      ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
@@ -117,11 +112,6 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
       ->setSetting('target_type', 'apiary')
       ->setDisplayOptions('form', [
         'type' => 'entity_reference_autocomplete',
-        'weight' => 1,
-      ])
-      ->setDisplayOptions('view', [
-        'label' => 'above',
-        'type' => 'entity_reference_label',
         'weight' => 1,
       ])
       ->setDisplayConfigurable('form', TRUE)
@@ -141,11 +131,6 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
         'type' => 'options_select',
         'weight' => 2,
       ])
-      ->setDisplayOptions('view', [
-        'label' => 'inline',
-        'type' => 'list_default',
-        'weight' => 2,
-      ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
@@ -160,11 +145,6 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
         'type' => 'options_select',
         'weight' => 3,
       ])
-      ->setDisplayOptions('view', [
-        'label' => 'inline',
-        'type' => 'list_default',
-        'weight' => 3,
-      ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
@@ -174,11 +154,6 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
       ->setSetting('min', 2000)
       ->setDisplayOptions('form', [
         'type' => 'number',
-        'weight' => 2,
-      ])
-      ->setDisplayOptions('view', [
-        'label' => 'inline',
-        'type' => 'number_integer',
         'weight' => 2,
       ])
       ->setDisplayConfigurable('form', TRUE)
@@ -196,11 +171,6 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
       ])
       ->setDisplayOptions('form', [
         'type' => 'options_select',
-        'weight' => 3,
-      ])
-      ->setDisplayOptions('view', [
-        'label' => 'inline',
-        'type' => 'list_default',
         'weight' => 3,
       ])
       ->setDisplayConfigurable('form', TRUE)
@@ -222,11 +192,6 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
         'type' => 'options_select',
         'weight' => 3,
       ])
-      ->setDisplayOptions('view', [
-        'label' => 'inline',
-        'type' => 'list_default',
-        'weight' => 3,
-      ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
@@ -240,11 +205,6 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
       ])
       ->setDisplayOptions('form', [
         'type' => 'options_select',
-        'weight' => 4,
-      ])
-      ->setDisplayOptions('view', [
-        'label' => 'inline',
-        'type' => 'list_default',
         'weight' => 4,
       ])
       ->setDisplayConfigurable('form', TRUE)
@@ -266,11 +226,6 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
         'type' => 'options_select',
         'weight' => 5,
       ])
-      ->setDisplayOptions('view', [
-        'label' => 'inline',
-        'type' => 'list_default',
-        'weight' => 5,
-      ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
@@ -284,11 +239,6 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
           'rows' => 4,
         ],
       ])
-      ->setDisplayOptions('view', [
-        'label' => 'above',
-        'type' => 'basic_string',
-        'weight' => 6,
-      ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
@@ -297,11 +247,6 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
       ->setDescription(t('The user who owns this hive.'))
       ->setDisplayOptions('form', [
         'type' => 'entity_reference_autocomplete',
-        'weight' => 7,
-      ])
-      ->setDisplayOptions('view', [
-        'label' => 'above',
-        'type' => 'entity_reference_label',
         'weight' => 7,
       ])
       ->setDisplayConfigurable('form', TRUE)


### PR DESCRIPTION
Fixes #4

## Changes

Removed view display options for all hive entity fields (name, apiary, hive type, hive material, queen year, queen colour, bee breed, temperament, status, notes, owner). The canonical hive page now shows only the inspections table.

Form display is unchanged — all fields remain editable when creating/editing a hive.

## Verification

- All 10 hive kernel tests pass (100 assertions, 0 failures)

---
[Warp conversation](https://app.warp.dev/conversation/2251d63b-aa49-4405-bfe3-b113d8d86e29)

Co-Authored-By: Oz <oz-agent@warp.dev>