### PR TITLE
Group hive inspection display into structured sections

### DIFF
--- a/src/Controller/HiveInspectionController.php
+++ b/src/Controller/HiveInspectionController.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\hivelog\Controller;
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\hivelog\Entity\Hive;
 use Drupal\hivelog\Entity\HiveInspection;
@@ -25,8 +26,45 @@ class HiveInspectionController extends ControllerBase {
    * Displays a hive inspection.
    */
   public function view(HiveInspection $hive_inspection) {
-    $view_builder = $this->entityTypeManager()->getViewBuilder('hive_inspection');
-    return $view_builder->view($hive_inspection);
+    return [
+      'overview' => $this->buildSection($this->t('Overview'), $hive_inspection, [
+        'hive',
+        'inspection_date',
+        'uid',
+      ]),
+      'external_check' => $this->buildSection($this->t('External check'), $hive_inspection, [
+        'external_check',
+      ]),
+      'queen_status' => $this->buildSection($this->t('Queen status'), $hive_inspection, [
+        'queen_seen',
+        'queen_cells',
+        'eggs_seen',
+      ]),
+      'brood_and_stores' => $this->buildSection($this->t('Brood, honey and pollen'), $hive_inspection, [
+        'brood_pattern',
+        'queen_brood',
+        'honey_stores',
+        'pollen_stores',
+      ]),
+      'colony_condition' => $this->buildSection($this->t('Colony condition'), $hive_inspection, [
+        'temperament',
+        'population',
+      ]),
+      'health' => $this->buildSection($this->t('Varroa and disease'), $hive_inspection, [
+        'varroa_check',
+        'varroa_count',
+        'disease_signs',
+      ]),
+      'management' => $this->buildSection($this->t('Management'), $hive_inspection, [
+        'fed',
+        'feed_type',
+        'supers',
+        'action_taken',
+      ]),
+      'notes' => $this->buildSection($this->t('Notes'), $hive_inspection, [
+        'notes',
+      ]),
+    ];
   }
 
   /**
@@ -34,6 +72,116 @@ class HiveInspectionController extends ControllerBase {
    */
   public function title(HiveInspection $hive_inspection) {
     return $hive_inspection->label();
+  }
+
+  /**
+   * Builds a consistently formatted inspection section.
+   */
+  protected function buildSection($title, HiveInspection $hive_inspection, array $fields): array {
+    return [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['hivelog-inspection-section'],
+      ],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $title,
+      ],
+      'table' => [
+        '#type' => 'table',
+        '#header' => [
+          $this->t('Field'),
+          $this->t('Value'),
+        ],
+        '#rows' => $this->buildRows($hive_inspection, $fields),
+        '#attributes' => [
+          'class' => ['hivelog-inspection-table'],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Builds rows for a section table.
+   */
+  protected function buildRows(HiveInspection $hive_inspection, array $fields): array {
+    $rows = [];
+
+    foreach ($fields as $field_name) {
+      $rows[] = [
+        [
+          'data' => [
+            '#plain_text' => (string) $hive_inspection->get($field_name)->getFieldDefinition()->getLabel(),
+          ],
+        ],
+        [
+          'data' => $this->buildFieldValue($hive_inspection, $field_name),
+        ],
+      ];
+    }
+
+    return $rows;
+  }
+
+  /**
+   * Builds the display value for a single inspection field.
+   */
+  protected function buildFieldValue(HiveInspection $hive_inspection, string $field_name): array {
+    $field = $hive_inspection->get($field_name);
+
+    if ($field->isEmpty()) {
+      return [
+        '#plain_text' => (string) $this->t('—'),
+      ];
+    }
+
+    switch ($field_name) {
+      case 'hive':
+      case 'uid':
+        return $field->entity ? $field->entity->toLink()->toRenderable() : [
+          '#plain_text' => (string) $this->t('—'),
+        ];
+
+      case 'inspection_date':
+        $timestamp = strtotime($field->value . ' 00:00:00 UTC');
+        return [
+          '#plain_text' => $timestamp !== FALSE ? \Drupal::service('date.formatter')->format($timestamp, 'custom', 'Y-m-d') : (string) $field->value,
+        ];
+
+      case 'queen_seen':
+      case 'queen_cells':
+      case 'eggs_seen':
+      case 'queen_brood':
+      case 'varroa_check':
+      case 'fed':
+        return [
+          '#plain_text' => $field->value ? (string) $this->t('Yes') : (string) $this->t('No'),
+        ];
+
+      case 'brood_pattern':
+      case 'honey_stores':
+      case 'pollen_stores':
+      case 'temperament':
+      case 'population':
+      case 'disease_signs':
+        $allowed_values = $field->getSetting('allowed_values');
+        return [
+          '#plain_text' => (string) ($allowed_values[$field->value] ?? $field->value),
+        ];
+
+      case 'external_check':
+      case 'action_taken':
+      case 'notes':
+        return [
+          '#markup' => nl2br(Html::escape((string) $field->value)),
+        ];
+
+      default:
+        return [
+          '#plain_text' => (string) $field->value,
+        ];
+    }
   }
 
 }

--- a/tests/src/Kernel/HiveInspectionTest.php
+++ b/tests/src/Kernel/HiveInspectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\hivelog\Kernel;
 
+use Drupal\hivelog\Controller\HiveInspectionController;
 use Drupal\hivelog\Entity\Apiary;
 use Drupal\hivelog\Entity\Hive;
 use Drupal\hivelog\Entity\HiveInspection;
@@ -288,6 +289,63 @@ class HiveInspectionTest extends KernelTestBase {
 
     $inspection->delete();
     $this->assertNull(HiveInspection::load($id));
+  }
+
+  /**
+   * Tests the grouped inspection view layout.
+   */
+  public function testInspectionViewIsGroupedIntoSections(): void {
+    $inspection = HiveInspection::create([
+      'hive' => $this->hive->id(),
+      'inspection_date' => '2024-06-15',
+      'external_check' => 'Strong flight activity with pollen coming in.',
+      'queen_seen' => TRUE,
+      'queen_cells' => FALSE,
+      'eggs_seen' => TRUE,
+      'brood_pattern' => 'good',
+      'queen_brood' => FALSE,
+      'honey_stores' => 'adequate',
+      'pollen_stores' => 'abundant',
+      'temperament' => 'calm',
+      'population' => 'strong',
+      'varroa_check' => TRUE,
+      'varroa_count' => 2,
+      'disease_signs' => 'none',
+      'fed' => FALSE,
+      'feed_type' => '',
+      'supers' => 1,
+      'action_taken' => 'Added a super.',
+      'notes' => 'Colony developing well.',
+      'uid' => $this->user->id(),
+    ]);
+    $inspection->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveInspectionController::class);
+    $build = $controller->view($inspection);
+
+    $this->assertArrayHasKey('overview', $build);
+    $this->assertArrayHasKey('external_check', $build);
+    $this->assertArrayHasKey('queen_status', $build);
+    $this->assertArrayHasKey('brood_and_stores', $build);
+    $this->assertArrayHasKey('colony_condition', $build);
+    $this->assertArrayHasKey('health', $build);
+    $this->assertArrayHasKey('management', $build);
+    $this->assertArrayHasKey('notes', $build);
+
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('Overview', $html);
+    $this->assertStringContainsString('External check', $html);
+    $this->assertStringContainsString('Queen status', $html);
+    $this->assertStringContainsString('Brood, honey and pollen', $html);
+    $this->assertStringContainsString('Colony condition', $html);
+    $this->assertStringContainsString('Varroa and disease', $html);
+    $this->assertStringContainsString('Management', $html);
+    $this->assertStringContainsString('Field', $html);
+    $this->assertStringContainsString('Value', $html);
+    $this->assertStringContainsString('Strong flight activity with pollen coming in.', $html);
+    $this->assertStringContainsString('Added a super.', $html);
+    $this->assertStringContainsString('Colony developing well.', $html);
   }
 
 }


### PR DESCRIPTION
Fixes #7

## Changes

- replace the default hive inspection field dump with grouped, consistent field/value tables
- group inspection details into Overview, External check, Queen status, Brood/Honey/Pollen, Colony condition, Varroa and disease, Management, and Notes
- keep multiline text fields readable in the rendered output
- add kernel coverage for the grouped inspection view

## Verification

- 
- HTML output directory sites/simpletest/browser_output is not a writable directory.

PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.18
Configuration: /var/www/html/web/core/phpunit.xml.dist

DDDDDDDDDD                                                        10 / 10 (100%)

Time: 00:18.321, Memory: 14.00 MB

10 tests triggered 2 deprecations:

1) /var/www/html/web/core/lib/Drupal/Core/Plugin/Discovery/AttributeDiscoveryWithAnnotations.php:98
Using @FieldType annotation for plugin with ID geofield is deprecated and is removed from drupal:13.0.0. Use a Drupal\Core\Field\Attribute\FieldType attribute instead. See https://www.drupal.org/node/3395575

Triggered by:

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testBroodPatternOptions
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:206

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testCreateFullInspection
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:87

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testDeleteInspection
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:282

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testDiseaseSignOptions
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:224

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testFeedingFields
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:242

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testHiveRelationship
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:139

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testInspectionLabel
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:160

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testInspectionViewIsGroupedIntoSections
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:297

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testMultipleInspectionsPerHive
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:176

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testUpdateInspection
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:259

2) /var/www/html/web/core/lib/Drupal/Core/Plugin/DefaultPluginManager.php:169
Not supporting attribute discovery in Drupal\geofield\Plugin\GeofieldBackendManager is deprecated in drupal:11.2.0 and is removed from drupal:12.0.0. Provide an Attribute class and an Annotation class for BC. See https://www.drupal.org/node/3395582

Triggered by:

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testBroodPatternOptions
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:206

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testCreateFullInspection
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:87

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testDeleteInspection
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:282

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testDiseaseSignOptions
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:224

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testFeedingFields
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:242

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testHiveRelationship
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:139

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testInspectionLabel
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:160

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testInspectionViewIsGroupedIntoSections
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:297

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testMultipleInspectionsPerHive
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:176

* Drupal\Tests\hivelog\Kernel\HiveInspectionTest::testUpdateInspection
  /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php:259

OK, but there were issues!
Tests: 10, Assertions: 129, Deprecations: 2.
- verified rendered output contains grouped section headings and table structure

---
[Warp conversation](https://app.warp.dev/conversation/2251d63b-aa49-4405-bfe3-b113d8d86e29)

Co-Authored-By: Oz <oz-agent@warp.dev>