### PR TITLE
Group hive inspection edit form into structured sections

### DIFF
--- a/src/Form/HiveInspectionForm.php
+++ b/src/Form/HiveInspectionForm.php
@@ -13,6 +13,88 @@ class HiveInspectionForm extends ContentEntityForm {
   /**
    * {@inheritdoc}
    */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    $form['inspection_sections'] = [
+      '#type' => 'vertical_tabs',
+      '#title' => $this->t('Inspection sections'),
+      '#weight' => 2,
+    ];
+
+    $sections = [
+      'overview' => [
+        'title' => $this->t('Overview'),
+        'weight' => 0,
+        'open' => TRUE,
+        'fields' => ['hive', 'inspection_date', 'uid'],
+      ],
+      'external_check_section' => [
+        'title' => $this->t('External check'),
+        'weight' => 1,
+        'open' => FALSE,
+        'fields' => ['external_check'],
+      ],
+      'queen_status' => [
+        'title' => $this->t('Queen status'),
+        'weight' => 2,
+        'open' => FALSE,
+        'fields' => ['queen_seen', 'queen_cells', 'eggs_seen'],
+      ],
+      'brood_and_stores' => [
+        'title' => $this->t('Brood, honey and pollen'),
+        'weight' => 3,
+        'open' => FALSE,
+        'fields' => ['brood_pattern', 'queen_brood', 'honey_stores', 'pollen_stores'],
+      ],
+      'colony_condition' => [
+        'title' => $this->t('Colony condition'),
+        'weight' => 4,
+        'open' => FALSE,
+        'fields' => ['temperament', 'population'],
+      ],
+      'health' => [
+        'title' => $this->t('Varroa and disease'),
+        'weight' => 5,
+        'open' => FALSE,
+        'fields' => ['varroa_check', 'varroa_count', 'disease_signs'],
+      ],
+      'management' => [
+        'title' => $this->t('Management'),
+        'weight' => 6,
+        'open' => FALSE,
+        'fields' => ['fed', 'feed_type', 'supers', 'action_taken'],
+      ],
+      'notes_section' => [
+        'title' => $this->t('Notes'),
+        'weight' => 7,
+        'open' => FALSE,
+        'fields' => ['notes'],
+      ],
+    ];
+
+    foreach ($sections as $section_key => $section) {
+      $form[$section_key] = [
+        '#type' => 'details',
+        '#title' => $section['title'],
+        '#group' => 'inspection_sections',
+        '#weight' => $section['weight'],
+        '#open' => $section['open'],
+      ];
+
+      foreach ($section['fields'] as $field_name) {
+        if (isset($form[$field_name])) {
+          $form[$field_name]['#group'] = $section_key;
+        }
+      }
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function save(array $form, FormStateInterface $form_state) {
     $entity = $this->entity;
     $status = $entity->save();

--- a/tests/src/Kernel/HiveInspectionTest.php
+++ b/tests/src/Kernel/HiveInspectionTest.php
@@ -59,6 +59,7 @@ class HiveInspectionTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->installConfig(['system']);
     $this->installEntitySchema('user');
     $this->installEntitySchema('apiary');
     $this->installEntitySchema('hive');
@@ -289,6 +290,36 @@ class HiveInspectionTest extends KernelTestBase {
 
     $inspection->delete();
     $this->assertNull(HiveInspection::load($id));
+  }
+
+  /**
+   * Tests that the inspection form is grouped into structured sections.
+   */
+  public function testInspectionFormIsGroupedIntoSections(): void {
+    $inspection = HiveInspection::create([
+      'hive' => $this->hive->id(),
+      'inspection_date' => '2024-06-15',
+    ]);
+
+    $form = \Drupal::service('entity.form_builder')->getForm($inspection, 'add');
+
+    $this->assertEquals('vertical_tabs', $form['inspection_sections']['#type']);
+    $this->assertArrayHasKey('overview', $form);
+    $this->assertArrayHasKey('external_check_section', $form);
+    $this->assertArrayHasKey('queen_status', $form);
+    $this->assertArrayHasKey('brood_and_stores', $form);
+    $this->assertArrayHasKey('colony_condition', $form);
+    $this->assertArrayHasKey('health', $form);
+    $this->assertArrayHasKey('management', $form);
+    $this->assertArrayHasKey('notes_section', $form);
+
+    $this->assertEquals('overview', $form['hive']['#group']);
+    $this->assertEquals('overview', $form['inspection_date']['#group']);
+    $this->assertEquals('queen_status', $form['queen_seen']['#group']);
+    $this->assertEquals('brood_and_stores', $form['honey_stores']['#group']);
+    $this->assertEquals('health', $form['disease_signs']['#group']);
+    $this->assertEquals('management', $form['action_taken']['#group']);
+    $this->assertEquals('notes_section', $form['notes']['#group']);
   }
 
   /**


### PR DESCRIPTION
Fixes #9

## Changes

- organize the hive inspection add/edit form into grouped vertical-tab sections
- group related fields into Overview, External check, Queen status, Brood/Honey/Pollen, Colony condition, Varroa and disease, Management, and Notes
- keep the existing save behavior unchanged
- add kernel coverage for the grouped form layout

## Verification

- `ddev drush cr`
- `ddev exec bash -c "SIMPLETEST_DB='mysql://db:db@db/db' phpunit -c /var/www/html/web/core /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php"`
- verified runtime form structure includes `vertical_tabs` and the expected field groups

---
[Warp conversation](https://app.warp.dev/conversation/2251d63b-aa49-4405-bfe3-b113d8d86e29)

Co-Authored-By: Oz <oz-agent@warp.dev>
