### PR TITLE
Hide duplicate queen brood inspection entry

### DIFF
--- a/src/Controller/HiveInspectionController.php
+++ b/src/Controller/HiveInspectionController.php
@@ -42,7 +42,6 @@ class HiveInspectionController extends ControllerBase {
       ]),
       'brood_and_stores' => $this->buildSection($this->t('Brood, honey and pollen'), $hive_inspection, [
         'brood_pattern',
-        'queen_brood',
         'honey_stores',
         'pollen_stores',
       ]),
@@ -152,7 +151,6 @@ class HiveInspectionController extends ControllerBase {
       case 'queen_seen':
       case 'queen_cells':
       case 'eggs_seen':
-      case 'queen_brood':
       case 'varroa_check':
       case 'fed':
         return [

--- a/src/Form/HiveInspectionForm.php
+++ b/src/Form/HiveInspectionForm.php
@@ -45,7 +45,7 @@ class HiveInspectionForm extends ContentEntityForm {
         'title' => $this->t('Brood, honey and pollen'),
         'weight' => 3,
         'open' => FALSE,
-        'fields' => ['brood_pattern', 'queen_brood', 'honey_stores', 'pollen_stores'],
+        'fields' => ['brood_pattern', 'honey_stores', 'pollen_stores'],
       ],
       'colony_condition' => [
         'title' => $this->t('Colony condition'),
@@ -87,6 +87,12 @@ class HiveInspectionForm extends ContentEntityForm {
           $form[$field_name]['#group'] = $section_key;
         }
       }
+    }
+
+    // Keep the field storage for backward compatibility, but do not expose the
+    // duplicate queen_brood input on the form.
+    if (isset($form['queen_brood'])) {
+      $form['queen_brood']['#access'] = FALSE;
     }
 
     return $form;

--- a/tests/src/Kernel/HiveInspectionTest.php
+++ b/tests/src/Kernel/HiveInspectionTest.php
@@ -315,6 +315,8 @@ class HiveInspectionTest extends KernelTestBase {
 
     $this->assertEquals('overview', $form['hive']['#group']);
     $this->assertEquals('overview', $form['inspection_date']['#group']);
+    $this->assertArrayHasKey('queen_brood', $form);
+    $this->assertFalse($form['queen_brood']['#access']);
     $this->assertEquals('queen_status', $form['queen_seen']['#group']);
     $this->assertEquals('brood_and_stores', $form['honey_stores']['#group']);
     $this->assertEquals('health', $form['disease_signs']['#group']);
@@ -374,6 +376,7 @@ class HiveInspectionTest extends KernelTestBase {
     $this->assertStringContainsString('Management', $html);
     $this->assertStringContainsString('Field', $html);
     $this->assertStringContainsString('Value', $html);
+    $this->assertStringNotContainsString('Queen Brood', $html);
     $this->assertStringContainsString('Strong flight activity with pollen coming in.', $html);
     $this->assertStringContainsString('Added a super.', $html);
     $this->assertStringContainsString('Colony developing well.', $html);


### PR DESCRIPTION
Fixes #11

## Changes

- hide the duplicate `queen_brood` field on the inspection add/edit form
- remove `queen_brood` from the structured inspection display
- keep the underlying field storage intact for backward compatibility
- add test assertions for the hidden form field and absent display row

## Verification

- `ddev drush cr`
- `ddev exec bash -c "SIMPLETEST_DB='mysql://db:db@db/db' phpunit -c /var/www/html/web/core /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php"`
- verified runtime results:
  - `queen_brood access=HIDDEN`
  - `display has Queen Brood=NO`

---
[Warp conversation](https://app.warp.dev/conversation/2251d63b-aa49-4405-bfe3-b113d8d86e29)

Co-Authored-By: Oz <oz-agent@warp.dev>
