### PR TITLE
Add weight field (kg) to hive inspections

### DIFF
--- a/hivelog.install
+++ b/hivelog.install
@@ -1,3 +1,27 @@
+
+/**
+ * Add weight field to hive inspections.
+ */
+function hivelog_update_10004(&$sandbox) {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+
+  $field_definitions = \Drupal\hivelog\Entity\HiveInspection::baseFieldDefinitions(
+    $entity_type_manager->getDefinition('hive_inspection')
+  );
+
+  if (isset($field_definitions['weight'])) {
+    $entity_definition_update_manager->installFieldStorageDefinition(
+      'weight',
+      'hive_inspection',
+      'hivelog',
+      $field_definitions['weight']
+    );
+  }
+
+  return t('Added weight field to hive inspections.');
+}
+
 <?php
 
 /**

--- a/hivelog.install
+++ b/hivelog.install
@@ -1,27 +1,3 @@
-
-/**
- * Add weight field to hive inspections.
- */
-function hivelog_update_10004(&$sandbox) {
-  $entity_type_manager = \Drupal::entityTypeManager();
-  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
-
-  $field_definitions = \Drupal\hivelog\Entity\HiveInspection::baseFieldDefinitions(
-    $entity_type_manager->getDefinition('hive_inspection')
-  );
-
-  if (isset($field_definitions['weight'])) {
-    $entity_definition_update_manager->installFieldStorageDefinition(
-      'weight',
-      'hive_inspection',
-      'hivelog',
-      $field_definitions['weight']
-    );
-  }
-
-  return t('Added weight field to hive inspections.');
-}
-
 <?php
 
 /**
@@ -187,4 +163,27 @@ function hivelog_update_10003(&$sandbox) {
   }
 
   return t('Added external check field to hive inspections.');
+}
+
+/**
+ * Add weight field to hive inspections.
+ */
+function hivelog_update_10004(&$sandbox) {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+
+  $field_definitions = \Drupal\hivelog\Entity\HiveInspection::baseFieldDefinitions(
+    $entity_type_manager->getDefinition('hive_inspection')
+  );
+
+  if (isset($field_definitions['weight'])) {
+    $entity_definition_update_manager->installFieldStorageDefinition(
+      'weight',
+      'hive_inspection',
+      'hivelog',
+      $field_definitions['weight']
+    );
+  }
+
+  return t('Added weight field to hive inspections.');
 }

--- a/src/Controller/HiveInspectionController.php
+++ b/src/Controller/HiveInspectionController.php
@@ -55,6 +55,7 @@ class HiveInspectionController extends ControllerBase {
         'disease_signs',
       ]),
       'management' => $this->buildSection($this->t('Management'), $hive_inspection, [
+        'weight',
         'fed',
         'feed_type',
         'supers',
@@ -146,6 +147,11 @@ class HiveInspectionController extends ControllerBase {
         $timestamp = strtotime($field->value . ' 00:00:00 UTC');
         return [
           '#plain_text' => $timestamp !== FALSE ? \Drupal::service('date.formatter')->format($timestamp, 'custom', 'Y-m-d') : (string) $field->value,
+        ];
+
+      case 'weight':
+        return [
+          '#plain_text' => $field->value . ' kg',
         ];
 
       case 'queen_seen':

--- a/src/Entity/HiveInspection.php
+++ b/src/Entity/HiveInspection.php
@@ -373,6 +373,28 @@ class HiveInspection extends ContentEntityBase implements EntityChangedInterface
       ->setDisplayConfigurable('view', TRUE);
 
     // Management fields.
+    $fields['weight'] = BaseFieldDefinition::create('float')
+      ->setLabel(t('Weight'))
+      ->setDescription(t('Weight of the hive in kilograms.'))
+      ->setSetting('min', 0)
+      ->setDisplayOptions('form', [
+        'type' => 'number',
+        'weight' => 14,
+        'settings' => [
+          'placeholder' => 'kg',
+        ],
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'number_decimal',
+        'weight' => 14,
+        'settings' => [
+          'suffix' => ' kg',
+        ],
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
     $fields['fed'] = BaseFieldDefinition::create('boolean')
       ->setLabel(t('Fed'))
       ->setDescription(t('Was the colony fed during this inspection?'))

--- a/src/Form/HiveInspectionForm.php
+++ b/src/Form/HiveInspectionForm.php
@@ -63,7 +63,7 @@ class HiveInspectionForm extends ContentEntityForm {
         'title' => $this->t('Management'),
         'weight' => 6,
         'open' => FALSE,
-        'fields' => ['fed', 'feed_type', 'supers', 'action_taken'],
+        'fields' => ['weight', 'fed', 'feed_type', 'supers', 'action_taken'],
       ],
       'notes_section' => [
         'title' => $this->t('Notes'),

--- a/tests/src/Kernel/HiveInspectionTest.php
+++ b/tests/src/Kernel/HiveInspectionTest.php
@@ -101,6 +101,7 @@ class HiveInspectionTest extends KernelTestBase {
       'varroa_check' => TRUE,
       'varroa_count' => 3,
       'disease_signs' => 'none',
+      'weight' => 32.5,
       'fed' => FALSE,
       'feed_type' => '',
       'supers' => 2,
@@ -127,6 +128,7 @@ class HiveInspectionTest extends KernelTestBase {
     $this->assertEquals(TRUE, (bool) $loaded->get('varroa_check')->value);
     $this->assertEquals(3, $loaded->get('varroa_count')->value);
     $this->assertEquals('none', $loaded->get('disease_signs')->value);
+    $this->assertEquals(32.5, (float) $loaded->get('weight')->value);
     $this->assertEquals(FALSE, (bool) $loaded->get('fed')->value);
     $this->assertEquals(2, $loaded->get('supers')->value);
     $this->assertEquals('Added super, checked for swarm cells.', $loaded->get('action_taken')->value);
@@ -320,6 +322,7 @@ class HiveInspectionTest extends KernelTestBase {
     $this->assertEquals('queen_status', $form['queen_seen']['#group']);
     $this->assertEquals('brood_and_stores', $form['honey_stores']['#group']);
     $this->assertEquals('health', $form['disease_signs']['#group']);
+    $this->assertEquals('management', $form['weight']['#group']);
     $this->assertEquals('management', $form['action_taken']['#group']);
     $this->assertEquals('notes_section', $form['notes']['#group']);
   }
@@ -344,6 +347,7 @@ class HiveInspectionTest extends KernelTestBase {
       'varroa_check' => TRUE,
       'varroa_count' => 2,
       'disease_signs' => 'none',
+      'weight' => 28.75,
       'fed' => FALSE,
       'feed_type' => '',
       'supers' => 1,
@@ -378,8 +382,35 @@ class HiveInspectionTest extends KernelTestBase {
     $this->assertStringContainsString('Value', $html);
     $this->assertStringNotContainsString('Queen Brood', $html);
     $this->assertStringContainsString('Strong flight activity with pollen coming in.', $html);
+    $this->assertStringContainsString('28.75 kg', $html);
     $this->assertStringContainsString('Added a super.', $html);
     $this->assertStringContainsString('Colony developing well.', $html);
+  }
+
+  /**
+   * Tests the weight field stores and retrieves floating-point values.
+   */
+  public function testWeightField(): void {
+    // Test with a decimal value.
+    $inspection = HiveInspection::create([
+      'hive' => $this->hive->id(),
+      'inspection_date' => '2024-07-15',
+      'weight' => 45.3,
+    ]);
+    $inspection->save();
+
+    $loaded = HiveInspection::load($inspection->id());
+    $this->assertEquals(45.3, (float) $loaded->get('weight')->value);
+
+    // Test that weight is optional (nullable).
+    $inspection2 = HiveInspection::create([
+      'hive' => $this->hive->id(),
+      'inspection_date' => '2024-07-16',
+    ]);
+    $inspection2->save();
+
+    $loaded2 = HiveInspection::load($inspection2->id());
+    $this->assertTrue($loaded2->get('weight')->isEmpty());
   }
 
 }


### PR DESCRIPTION
## Summary

Add an optional float field for recording hive weight in kilograms during inspections. The field appears as the first item under the Management section in both the form and canonical view.

Closes #13

## Changes

- **Entity** (`src/Entity/HiveInspection.php`): new `weight` float base field with min=0, form placeholder 'kg', view suffix ' kg'
- **Form** (`src/Form/HiveInspectionForm.php`): `weight` added as first field in the Management tab
- **Controller** (`src/Controller/HiveInspectionController.php`): `weight` rendered with 'kg' suffix in the inspection view's Management section
- **Install** (`hivelog.install`): `hivelog_update_10004()` installs the new field storage on existing sites
- **Tests** (`tests/src/Kernel/HiveInspectionTest.php`): updated existing tests to include weight data; added dedicated `testWeightField()` covering decimal storage and nullable behaviour

## Testing

All 56 tests pass (386 assertions, 0 failures).

After deploying, run `drush updb -y && drush cr` to install the new field.

## Notes

The float field type is compatible with the planned follow-up issue for graphing hive weights over time.

---
[Warp conversation](https://app.warp.dev/conversation/2251d63b-aa49-4405-bfe3-b113d8d86e29)

Co-Authored-By: Oz <oz-agent@warp.dev>