### PR TITLE
Add weight column to inspection list before Queen

### DIFF
--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -63,6 +63,7 @@ class HiveController extends ControllerBase {
 
     $header = [
       $this->t('Date'),
+      $this->t('Weight'),
       $this->t('Queen'),
       $this->t('Brood'),
       $this->t('Honey'),
@@ -73,8 +74,10 @@ class HiveController extends ControllerBase {
 
     $rows = [];
     foreach ($inspections as $inspection) {
+      $weight = $inspection->get('weight')->value;
       $rows[] = [
         $inspection->get('inspection_date')->value ?: $this->t('N/A'),
+        $weight !== NULL ? $weight . ' kg' : '',
         $inspection->get('queen_seen')->value ? $this->t('Yes') : $this->t('No'),
         $inspection->get('brood_pattern')->value ? $inspection->get('brood_pattern')->getSetting('allowed_values')[$inspection->get('brood_pattern')->value] ?? '' : '',
         $inspection->get('honey_stores')->value ? $inspection->get('honey_stores')->getSetting('allowed_values')[$inspection->get('honey_stores')->value] ?? '' : '',

--- a/src/HiveInspectionListBuilder.php
+++ b/src/HiveInspectionListBuilder.php
@@ -16,6 +16,7 @@ class HiveInspectionListBuilder extends EntityListBuilder {
   public function buildHeader() {
     $header['date'] = $this->t('Date');
     $header['hive'] = $this->t('Hive');
+    $header['weight'] = $this->t('Weight');
     $header['queen'] = $this->t('Queen Seen');
     $header['honey'] = $this->t('Honey');
     $header['inspector'] = $this->t('Inspector');
@@ -29,6 +30,8 @@ class HiveInspectionListBuilder extends EntityListBuilder {
     $row['date'] = $entity->get('inspection_date')->value ?: $this->t('N/A');
     $hive = $entity->get('hive')->entity;
     $row['hive'] = $hive ? $hive->toLink() : '';
+    $weight = $entity->get('weight')->value;
+    $row['weight'] = $weight !== NULL ? $weight . ' kg' : '';
     $row['queen'] = $entity->get('queen_seen')->value ? $this->t('Yes') : $this->t('No');
     $honey = $entity->get('honey_stores')->value;
     $row['honey'] = $honey ? ($entity->get('honey_stores')->getSetting('allowed_values')[$honey] ?? $honey) : '';

--- a/tests/src/Kernel/HiveTest.php
+++ b/tests/src/Kernel/HiveTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\hivelog\Kernel;
 
+use Drupal\hivelog\Controller\HiveController;
 use Drupal\hivelog\Entity\Apiary;
 use Drupal\hivelog\Entity\Hive;
+use Drupal\hivelog\Entity\HiveInspection;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\User;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
@@ -272,6 +275,52 @@ class HiveTest extends KernelTestBase {
 
     $hive->delete();
     $this->assertNull(Hive::load($id));
+  }
+
+  /**
+   * Tests that the hive view inspection table includes weight before queen.
+   */
+  public function testHiveViewInspectionTableWeightColumn(): void {
+    $this->installConfig(['system']);
+
+    $user = User::create([
+      'name' => 'tester',
+      'mail' => 'tester@example.com',
+    ]);
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    $hive = Hive::create([
+      'name' => 'Weight Column Hive',
+      'apiary' => $this->apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    $inspection = HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2024-06-15',
+      'weight' => 32.5,
+      'queen_seen' => TRUE,
+    ]);
+    $inspection->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+
+    // Verify the Weight header and value are present.
+    $this->assertStringContainsString('Weight', $html);
+    $this->assertStringContainsString('32.5 kg', $html);
+
+    // Verify Weight column appears before Queen column in the header.
+    $weight_pos = strpos($html, '>Weight<');
+    $queen_pos = strpos($html, '>Queen<');
+    $this->assertNotFalse($weight_pos);
+    $this->assertNotFalse($queen_pos);
+    $this->assertLessThan($queen_pos, $weight_pos, 'Weight column should appear before Queen column.');
   }
 
 }


### PR DESCRIPTION
## Summary

Display the hive weight (kg) in the inspection table on the hive canonical page and in the entity collection list builder, positioned before the Queen column.

Closes #16

## Changes

- **HiveController** (`src/Controller/HiveController.php`): added `Weight` header and formatted row value (`<value> kg`) before the Queen column in the hive page's inspection table
- **HiveInspectionListBuilder** (`src/HiveInspectionListBuilder.php`): added `Weight` header and row value before Queen Seen in the entity collection list
- **HiveTest** (`tests/src/Kernel/HiveTest.php`): new `testHiveViewInspectionTableWeightColumn()` verifying column presence, value rendering, and ordering (Weight before Queen)

## Testing

All 57 tests pass (397 assertions, 0 failures).

---
[Warp conversation](https://app.warp.dev/conversation/2251d63b-aa49-4405-bfe3-b113d8d86e29)

Co-Authored-By: Oz <oz-agent@warp.dev>