### PR TITLE
Add weight histogram to hive inspection list

### DIFF
--- a/css/hivelog.weight-histogram.css
+++ b/css/hivelog.weight-histogram.css
@@ -1,0 +1,43 @@
+/**
+ * @file
+ * Styles for the inspection weight histogram on the hive view page.
+ */
+
+.hivelog-weight-histogram {
+  margin: 1.5rem 0;
+}
+
+.hivelog-weight-histogram__title {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #333;
+}
+
+/* Letterbox: wide aspect ratio with centered content and subtle frame. */
+.hivelog-weight-histogram--letterboxed .hivelog-weight-histogram__frame {
+  width: 100%;
+  aspect-ratio: 8 / 3;
+  background: #111;
+  border-radius: 4px;
+  padding: 1rem;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hivelog-weight-histogram__frame svg {
+  width: 100%;
+  height: 100%;
+  background: #fdf6e3;
+  border-radius: 2px;
+}
+
+.hivelog-weight-histogram__bar {
+  transition: fill 0.15s ease-in-out;
+}
+
+.hivelog-weight-histogram__bar:hover {
+  fill: #d98e1a;
+}

--- a/hivelog.libraries.yml
+++ b/hivelog.libraries.yml
@@ -1,0 +1,5 @@
+weight_histogram:
+  version: 1.x
+  css:
+    component:
+      css/hivelog.weight-histogram.css: {}

--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -61,6 +61,13 @@ class HiveController extends ControllerBase {
       ->getStorage('hive_inspection')
       ->loadMultiple($inspection_ids);
 
+    // Render a letterboxed weight histogram for the year of the most recent
+    // inspection (placed above the inspection list).
+    $histogram = $this->buildWeightHistogram($inspections);
+    if (!empty($histogram)) {
+      $build['weight_histogram'] = $histogram + ['#weight' => 11.5];
+    }
+
     $header = [
       $this->t('Date'),
       $this->t('Weight'),
@@ -121,6 +128,119 @@ class HiveController extends ControllerBase {
    */
   public function title(Hive $hive) {
     return $hive->label();
+  }
+
+  /**
+   * Builds a letterboxed vertical histogram of inspection weights.
+   *
+   * Restricted to the year of the most recent inspection that has data.
+   *
+   * @param \Drupal\hivelog\Entity\HiveInspection[] $inspections
+   *   Inspections belonging to the current hive.
+   *
+   * @return array
+   *   A render array for the histogram, or an empty array if there is nothing
+   *   to display.
+   */
+  protected function buildWeightHistogram(array $inspections): array {
+    // Identify the most recent inspection date to determine the target year.
+    $most_recent = NULL;
+    foreach ($inspections as $inspection) {
+      $date = $inspection->get('inspection_date')->value;
+      if ($date && (!$most_recent || $date > $most_recent)) {
+        $most_recent = $date;
+      }
+    }
+    if (!$most_recent) {
+      return [];
+    }
+    $year = substr($most_recent, 0, 4);
+
+    // Collect data points for that year.
+    $points = [];
+    foreach ($inspections as $inspection) {
+      $date = $inspection->get('inspection_date')->value;
+      $weight = $inspection->get('weight')->value;
+      if (!$date || $weight === NULL || $weight === '') {
+        continue;
+      }
+      if (substr($date, 0, 4) !== $year) {
+        continue;
+      }
+      $points[] = [
+        'date' => $date,
+        'mmdd' => substr($date, 5, 2) . '/' . substr($date, 8, 2),
+        'weight' => (float) $weight,
+      ];
+    }
+    if (empty($points)) {
+      return [];
+    }
+
+    // Sort chronologically so bars read left to right.
+    usort($points, fn($a, $b) => strcmp($a['date'], $b['date']));
+
+    // SVG layout constants.
+    $svg_width = 800;
+    $svg_height = 300;
+    $padding_top = 40;
+    $padding_bottom = 40;
+    $padding_x = 20;
+    $chart_height = $svg_height - $padding_top - $padding_bottom;
+    $chart_width = $svg_width - (2 * $padding_x);
+    $slot_width = $chart_width / max(count($points), 1);
+    $bar_width = (int) min($slot_width * 0.6, 60);
+    $max_weight = max(array_column($points, 'weight')) ?: 1.0;
+    $axis_y = $padding_top + $chart_height;
+
+    $bars = [];
+    foreach ($points as $i => $point) {
+      $center_x = $padding_x + ($slot_width * ($i + 0.5));
+      $bar_height = ($point['weight'] / $max_weight) * $chart_height;
+      $bar_y = $padding_top + ($chart_height - $bar_height);
+      $bars[] = [
+        'x' => (int) round($center_x - ($bar_width / 2)),
+        'y' => (int) round($bar_y),
+        'height' => (int) round($bar_height),
+        'label_x' => (int) round($center_x),
+        'value_y' => max((int) round($bar_y) - 6, $padding_top - 4),
+        'date_y' => $axis_y + 16,
+        'mmdd' => $point['mmdd'],
+        'weight_label' => rtrim(rtrim(number_format($point['weight'], 2, '.', ''), '0'), '.') . ' kg',
+      ];
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => [
+          'hivelog-weight-histogram',
+          'hivelog-weight-histogram--letterboxed',
+        ],
+      ],
+      '#attached' => [
+        'library' => ['hivelog/weight_histogram'],
+      ],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h4',
+        '#value' => $this->t('Inspection weights for @year', ['@year' => $year]),
+        '#attributes' => ['class' => ['hivelog-weight-histogram__title']],
+      ],
+      'chart' => [
+        '#type' => 'inline_template',
+        '#template' => '<div class="hivelog-weight-histogram__frame"><svg viewBox="0 0 {{ svg_width }} {{ svg_height }}" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="{{ label }}"><title>{{ label }}</title>{% for bar in bars %}<rect class="hivelog-weight-histogram__bar" x="{{ bar.x }}" y="{{ bar.y }}" width="{{ bar_width }}" height="{{ bar.height }}" fill="#f2a42e" /><text class="hivelog-weight-histogram__value" x="{{ bar.label_x }}" y="{{ bar.value_y }}" text-anchor="middle" font-size="12" fill="#333">{{ bar.weight_label }}</text><text class="hivelog-weight-histogram__date" x="{{ bar.label_x }}" y="{{ bar.date_y }}" text-anchor="middle" font-size="11" fill="#333">{{ bar.mmdd }}</text>{% endfor %}<line x1="{{ padding_x }}" y1="{{ axis_y }}" x2="{{ svg_width - padding_x }}" y2="{{ axis_y }}" stroke="#666" stroke-width="1" /></svg></div>',
+        '#context' => [
+          'label' => $this->t('Inspection weights for @year', ['@year' => $year]),
+          'svg_width' => $svg_width,
+          'svg_height' => $svg_height,
+          'padding_x' => $padding_x,
+          'axis_y' => $axis_y,
+          'bar_width' => $bar_width,
+          'bars' => $bars,
+        ],
+      ],
+    ];
   }
 
 }

--- a/tests/src/Kernel/HiveTest.php
+++ b/tests/src/Kernel/HiveTest.php
@@ -278,6 +278,119 @@ class HiveTest extends KernelTestBase {
   }
 
   /**
+   * Tests that the weight histogram renders above the inspection list.
+   */
+  public function testHiveViewWeightHistogram(): void {
+    $this->installConfig(['system']);
+
+    $user = User::create([
+      'name' => 'histogram-tester',
+      'mail' => 'histogram-tester@example.com',
+    ]);
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    $hive = Hive::create([
+      'name' => 'Histogram Hive',
+      'apiary' => $this->apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    // Most recent year: 2025 — two inspections with weights.
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2025-05-03',
+      'weight' => 28.5,
+    ])->save();
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2025-07-12',
+      'weight' => 35.25,
+    ])->save();
+    // Earlier year inspection — should be excluded from the histogram.
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2024-06-01',
+      'weight' => 22.0,
+    ])->save();
+    // Inspection in the most recent year without a weight — should be ignored.
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2025-06-06',
+    ])->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+
+    $this->assertArrayHasKey('weight_histogram', $build);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+
+    // Letterboxed container is present.
+    $this->assertStringContainsString('hivelog-weight-histogram--letterboxed', $html);
+    $this->assertStringContainsString('<svg', $html);
+    // Heading references the most recent year.
+    $this->assertStringContainsString('Inspection weights for 2025', $html);
+    // Bars for the two 2025 inspections with weights.
+    $this->assertStringContainsString('28.5 kg', $html);
+    $this->assertStringContainsString('35.25 kg', $html);
+    // mm/dd labels.
+    $this->assertStringContainsString('05/03', $html);
+    $this->assertStringContainsString('07/12', $html);
+
+    // Isolate the SVG markup so we can assert the 2024 inspection weight
+    // (22 kg) is not drawn as a bar in the histogram. It is still expected
+    // to appear later in the inspections table row for that entry.
+    $svg_start = strpos($html, '<svg');
+    $svg_end = strpos($html, '</svg>');
+    $this->assertNotFalse($svg_start);
+    $this->assertNotFalse($svg_end);
+    $svg = substr($html, $svg_start, $svg_end - $svg_start);
+    $this->assertStringNotContainsString('22 kg', $svg);
+    $this->assertStringNotContainsString('06/01', $svg);
+
+    // Histogram must appear before the inspections table.
+    $histogram_pos = strpos($html, 'hivelog-weight-histogram');
+    $table_pos = strpos($html, '<table');
+    $this->assertNotFalse($histogram_pos);
+    $this->assertNotFalse($table_pos);
+    $this->assertLessThan($table_pos, $histogram_pos, 'Histogram should appear before the inspections table.');
+  }
+
+  /**
+   * Tests that no histogram is rendered when no inspections have weights.
+   */
+  public function testHiveViewWeightHistogramAbsentWhenNoData(): void {
+    $this->installConfig(['system']);
+
+    $user = User::create([
+      'name' => 'no-histogram-tester',
+      'mail' => 'no-histogram-tester@example.com',
+    ]);
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    $hive = Hive::create([
+      'name' => 'No Weight Hive',
+      'apiary' => $this->apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2025-05-03',
+    ])->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+
+    $this->assertArrayNotHasKey('weight_histogram', $build);
+  }
+
+  /**
    * Tests that the hive view inspection table includes weight before queen.
    */
   public function testHiveViewInspectionTableWeightColumn(): void {


### PR DESCRIPTION
## Summary

Render a letterboxed vertical histogram of recorded inspection weights above the inspection list on the hive view page. The histogram shows all weighed inspections for the year of the most recent inspection, with mm/dd date labels and per-bar kg values.

Closes #18

## Changes

- **HiveController** (`src/Controller/HiveController.php`):
  - new `buildWeightHistogram()` method renders an SVG bar chart via an `inline_template` render array
  - chart is gated on having at least one inspection-in-year with a recorded weight
  - placed between the `Add Inspection` action and the inspections table (`#weight => 11.5`)
- **Library**: new `hivelog/weight_histogram` library with CSS that provides the letterboxed frame and bar hover styling
  - `hivelog.libraries.yml`
  - `css/hivelog.weight-histogram.css`
- **HiveTest** (`tests/src/Kernel/HiveTest.php`):
  - `testHiveViewWeightHistogram()` verifies chart presence, correct bars, exclusion of other years / weightless inspections, and that the histogram precedes the inspections table
  - `testHiveViewWeightHistogramAbsentWhenNoData()` verifies nothing is rendered when no inspections have weight data

## Testing

All 59 tests pass (425 assertions, 0 failures).

---
[Warp conversation](https://app.warp.dev/conversation/2251d63b-aa49-4405-bfe3-b113d8d86e29)

Co-Authored-By: Oz <oz-agent@warp.dev>