### PR TITLE
Add image uploads for hives and inspections

### DIFF
--- a/css/hivelog.images.css
+++ b/css/hivelog.images.css
@@ -1,0 +1,48 @@
+/**
+ * @file
+ * Styles for the hive hero image and inspection photo grid.
+ */
+
+/* Hive hero: a letterboxed frame showing a section of the first picture. */
+.hivelog-hive-hero {
+  margin: 0 0 1.5rem;
+}
+
+.hivelog-hive-hero--letterboxed .hivelog-hive-hero__frame {
+  width: 100%;
+  aspect-ratio: 21 / 9;
+  background-color: #111;
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+  border-radius: 4px;
+}
+
+/* Inspection photos: responsive grid of thumbnails linking to the original. */
+.hivelog-inspection-photos__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 0.75rem;
+  margin: 0.5rem 0 1.25rem;
+}
+
+.hivelog-inspection-photos__item {
+  display: block;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  border-radius: 4px;
+  background: #f3f3f3;
+}
+
+.hivelog-inspection-photos__item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.15s ease-in-out;
+}
+
+.hivelog-inspection-photos__item:hover img,
+.hivelog-inspection-photos__item:focus img {
+  transform: scale(1.03);
+}

--- a/hivelog.info.yml
+++ b/hivelog.info.yml
@@ -4,6 +4,7 @@ description: 'Beekeeping activity logger for managing apiaries, hives, and inspe
 core_version_requirement: ^11
 package: Custom
 dependencies:
+  - drupal:image
   - geofield:geofield
   - geocoder:geocoder
   - leaflet:leaflet

--- a/hivelog.install
+++ b/hivelog.install
@@ -187,3 +187,49 @@ function hivelog_update_10004(&$sandbox) {
 
   return t('Added weight field to hive inspections.');
 }
+
+/**
+ * Add images field to hives.
+ */
+function hivelog_update_10005(&$sandbox) {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+
+  $field_definitions = \Drupal\hivelog\Entity\Hive::baseFieldDefinitions(
+    $entity_type_manager->getDefinition('hive')
+  );
+
+  if (isset($field_definitions['images'])) {
+    $entity_definition_update_manager->installFieldStorageDefinition(
+      'images',
+      'hive',
+      'hivelog',
+      $field_definitions['images']
+    );
+  }
+
+  return t('Added images field to hives.');
+}
+
+/**
+ * Add images field to hive inspections.
+ */
+function hivelog_update_10006(&$sandbox) {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+
+  $field_definitions = \Drupal\hivelog\Entity\HiveInspection::baseFieldDefinitions(
+    $entity_type_manager->getDefinition('hive_inspection')
+  );
+
+  if (isset($field_definitions['images'])) {
+    $entity_definition_update_manager->installFieldStorageDefinition(
+      'images',
+      'hive_inspection',
+      'hivelog',
+      $field_definitions['images']
+    );
+  }
+
+  return t('Added images field to hive inspections.');
+}

--- a/hivelog.libraries.yml
+++ b/hivelog.libraries.yml
@@ -3,3 +3,9 @@ weight_histogram:
   css:
     component:
       css/hivelog.weight-histogram.css: {}
+
+images:
+  version: 1.x
+  css:
+    component:
+      css/hivelog.images.css: {}

--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -28,9 +28,17 @@ class HiveController extends ControllerBase {
   public function view(Hive $hive) {
     $build = [];
 
+    // Letterbox hero image (first attached picture), rendered above the
+    // hive entity details when present.
+    $hero = $this->buildHero($hive);
+    if (!empty($hero)) {
+      $build['hero'] = $hero;
+    }
+
     // Render the hive entity fields.
     $view_builder = $this->entityTypeManager()->getViewBuilder('hive');
     $build['hive'] = $view_builder->view($hive);
+    $build['hive']['#weight'] = 5;
 
     // Add inspections heading and action link.
     $build['inspections_heading'] = [
@@ -128,6 +136,45 @@ class HiveController extends ControllerBase {
    */
   public function title(Hive $hive) {
     return $hive->label();
+  }
+
+  /**
+   * Builds a letterboxed hero render array from the hive's first image.
+   */
+  protected function buildHero(Hive $hive): array {
+    if ($hive->get('images')->isEmpty()) {
+      return [];
+    }
+
+    $file = $hive->get('images')->entity;
+    if (!$file) {
+      return [];
+    }
+
+    $url = \Drupal::service('file_url_generator')->generateAbsoluteString($file->getFileUri());
+    $alt = (string) ($hive->get('images')->alt ?? $hive->label());
+
+    return [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => [
+          'hivelog-hive-hero',
+          'hivelog-hive-hero--letterboxed',
+        ],
+      ],
+      '#weight' => -10,
+      '#attached' => [
+        'library' => ['hivelog/images'],
+      ],
+      'frame' => [
+        '#type' => 'inline_template',
+        '#template' => '<div class="hivelog-hive-hero__frame" style="background-image: url({{ url }});" role="img" aria-label="{{ alt }}"></div>',
+        '#context' => [
+          'url' => $url,
+          'alt' => $alt,
+        ],
+      ],
+    ];
   }
 
   /**

--- a/src/Controller/HiveInspectionController.php
+++ b/src/Controller/HiveInspectionController.php
@@ -70,7 +70,65 @@ class HiveInspectionController extends ControllerBase {
       ]),
     ];
 
+    // Photos grid (displayed after the notes section when images are present).
+    $photos = $this->buildPhotosGrid($hive_inspection);
+    if (!empty($photos)) {
+      $build['photos'] = $photos;
+    }
+
     return $build;
+  }
+
+  /**
+   * Builds a grid of inspection photos with links to the full-size image.
+   */
+  protected function buildPhotosGrid(HiveInspection $hive_inspection): array {
+    if ($hive_inspection->get('images')->isEmpty()) {
+      return [];
+    }
+
+    $file_url_generator = \Drupal::service('file_url_generator');
+    $items = [];
+    foreach ($hive_inspection->get('images') as $delta => $item) {
+      /** @var \Drupal\file\FileInterface|null $file */
+      $file = $item->entity;
+      if (!$file) {
+        continue;
+      }
+      $full_url = $file_url_generator->generateAbsoluteString($file->getFileUri());
+      $alt = (string) ($item->alt ?? '');
+      $items[] = [
+        'full_url' => $full_url,
+        'thumb_url' => $full_url,
+        'alt' => $alt,
+      ];
+    }
+
+    if (empty($items)) {
+      return [];
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['hivelog-inspection-section', 'hivelog-inspection-photos'],
+      ],
+      '#attached' => [
+        'library' => ['hivelog/images'],
+      ],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Photos'),
+      ],
+      'grid' => [
+        '#type' => 'inline_template',
+        '#template' => '<div class="hivelog-inspection-photos__grid">{% for item in items %}<a class="hivelog-inspection-photos__item" href="{{ item.full_url }}" target="_blank" rel="noopener"><img src="{{ item.thumb_url }}" alt="{{ item.alt }}" loading="lazy" /></a>{% endfor %}</div>',
+        '#context' => [
+          'items' => $items,
+        ],
+      ],
+    ];
   }
 
   /**

--- a/src/Entity/Hive.php
+++ b/src/Entity/Hive.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityChangedInterface;
 use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\hivelog\Form\HiveDeleteForm;
 use Drupal\hivelog\Form\HiveForm;
@@ -228,6 +229,24 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
       ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
+
+    $fields['images'] = BaseFieldDefinition::create('image')
+      ->setLabel(t('Pictures'))
+      ->setDescription(t('One or more pictures of the hive. The first picture is shown as a letterbox hero on the hive view page.'))
+      ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+      ->setSetting('file_directory', 'hivelog/hive')
+      ->setSetting('file_extensions', 'png gif jpg jpeg webp')
+      ->setSetting('alt_field', TRUE)
+      ->setSetting('alt_field_required', FALSE)
+      ->setDisplayOptions('form', [
+        'type' => 'image_image',
+        'weight' => 5,
+        'settings' => [
+          'progress_indicator' => 'throbber',
+          'preview_image_style' => 'thumbnail',
+        ],
+      ])
+      ->setDisplayConfigurable('form', TRUE);
 
     $fields['notes'] = BaseFieldDefinition::create('string_long')
       ->setLabel(t('Notes'))

--- a/src/Entity/HiveInspection.php
+++ b/src/Entity/HiveInspection.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityChangedInterface;
 use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\hivelog\Form\HiveInspectionDeleteForm;
 use Drupal\hivelog\Form\HiveInspectionForm;
@@ -460,6 +461,34 @@ class HiveInspection extends ContentEntityBase implements EntityChangedInterface
         'label' => 'above',
         'type' => 'basic_string',
         'weight' => 18,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['images'] = BaseFieldDefinition::create('image')
+      ->setLabel(t('Pictures'))
+      ->setDescription(t('Photos taken during this inspection.'))
+      ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+      ->setSetting('file_directory', 'hivelog/inspection')
+      ->setSetting('file_extensions', 'png gif jpg jpeg webp')
+      ->setSetting('alt_field', TRUE)
+      ->setSetting('alt_field_required', FALSE)
+      ->setDisplayOptions('form', [
+        'type' => 'image_image',
+        'weight' => 19,
+        'settings' => [
+          'progress_indicator' => 'throbber',
+          'preview_image_style' => 'thumbnail',
+        ],
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'hidden',
+        'type' => 'image',
+        'weight' => 19,
+        'settings' => [
+          'image_style' => 'medium',
+          'image_link' => 'file',
+        ],
       ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);

--- a/src/Form/HiveInspectionForm.php
+++ b/src/Form/HiveInspectionForm.php
@@ -71,6 +71,12 @@ class HiveInspectionForm extends ContentEntityForm {
         'open' => FALSE,
         'fields' => ['notes'],
       ],
+      'photos_section' => [
+        'title' => $this->t('Photos'),
+        'weight' => 8,
+        'open' => FALSE,
+        'fields' => ['images'],
+      ],
     ];
 
     foreach ($sections as $section_key => $section) {

--- a/tests/src/Kernel/ApiaryTest.php
+++ b/tests/src/Kernel/ApiaryTest.php
@@ -26,6 +26,8 @@ class ApiaryTest extends KernelTestBase {
     'field',
     'datetime',
     'options',
+    'file',
+    'image',
     'geofield',
     'hivelog',
   ];
@@ -43,9 +45,11 @@ class ApiaryTest extends KernelTestBase {
   protected function setUp(): void {
     parent::setUp();
     $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
     $this->installEntitySchema('apiary');
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
+    $this->installSchema('file', ['file_usage']);
 
     $this->user = User::create([
       'name' => 'testuser',

--- a/tests/src/Kernel/HiveInspectionTest.php
+++ b/tests/src/Kernel/HiveInspectionTest.php
@@ -30,6 +30,8 @@ class HiveInspectionTest extends KernelTestBase {
     'field',
     'datetime',
     'options',
+    'file',
+    'image',
     'geofield',
     'hivelog',
   ];
@@ -62,9 +64,11 @@ class HiveInspectionTest extends KernelTestBase {
     parent::setUp();
     $this->installConfig(['system']);
     $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
     $this->installEntitySchema('apiary');
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
+    $this->installSchema('file', ['file_usage']);
 
     $this->user = User::create([
       'name' => 'inspector',
@@ -315,6 +319,7 @@ class HiveInspectionTest extends KernelTestBase {
     $this->assertArrayHasKey('health', $form);
     $this->assertArrayHasKey('management', $form);
     $this->assertArrayHasKey('notes_section', $form);
+    $this->assertArrayHasKey('photos_section', $form);
 
     $this->assertEquals('overview', $form['hive']['#group']);
     $this->assertEquals('overview', $form['inspection_date']['#group']);
@@ -326,6 +331,7 @@ class HiveInspectionTest extends KernelTestBase {
     $this->assertEquals('management', $form['weight']['#group']);
     $this->assertEquals('management', $form['action_taken']['#group']);
     $this->assertEquals('notes_section', $form['notes']['#group']);
+    $this->assertEquals('photos_section', $form['images']['#group']);
   }
 
   /**
@@ -428,6 +434,71 @@ class HiveInspectionTest extends KernelTestBase {
     $this->assertStringContainsString('Edit', $html);
     $this->assertStringContainsString('Delete', $html);
     $this->assertStringContainsString('hivelog-inspection-actions', $html);
+  }
+
+  /**
+   * Tests that inspection photos are rendered as a grid linking to the file.
+   */
+  public function testInspectionViewRendersPhotosGrid(): void {
+    $directory = 'public://hivelog-test-inspection';
+    \Drupal::service('file_system')->prepareDirectory($directory, \Drupal\Core\File\FileSystemInterface::CREATE_DIRECTORY);
+    $png = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGD4DwABBAEAfbLI3wAAAABJRU5ErkJggg==');
+
+    $files = [];
+    foreach (['photo-1.png', 'photo-2.png'] as $filename) {
+      $uri = $directory . '/' . $filename;
+      file_put_contents($uri, $png);
+      $file = \Drupal\file\Entity\File::create([
+        'uri' => $uri,
+        'filename' => $filename,
+        'status' => 1,
+      ]);
+      $file->save();
+      $files[] = $file;
+    }
+
+    $inspection = HiveInspection::create([
+      'hive' => $this->hive->id(),
+      'inspection_date' => '2024-06-15',
+      'uid' => $this->user->id(),
+      'images' => [
+        ['target_id' => $files[0]->id(), 'alt' => 'Photo one'],
+        ['target_id' => $files[1]->id(), 'alt' => 'Photo two'],
+      ],
+    ]);
+    $inspection->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveInspectionController::class);
+    $build = $controller->view($inspection);
+
+    $this->assertArrayHasKey('photos', $build);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('hivelog-inspection-photos__grid', $html);
+    $this->assertStringContainsString('hivelog-inspection-photos__item', $html);
+    $this->assertStringContainsString('photo-1.png', $html);
+    $this->assertStringContainsString('photo-2.png', $html);
+    $this->assertStringContainsString('alt="Photo one"', $html);
+    $this->assertStringContainsString('alt="Photo two"', $html);
+    // Photos section heading should appear.
+    $this->assertStringContainsString('>Photos<', $html);
+  }
+
+  /**
+   * Tests that the Photos section is absent when no images are attached.
+   */
+  public function testInspectionViewOmitsPhotosSectionWhenEmpty(): void {
+    $inspection = HiveInspection::create([
+      'hive' => $this->hive->id(),
+      'inspection_date' => '2024-06-15',
+    ]);
+    $inspection->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveInspectionController::class);
+    $build = $controller->view($inspection);
+
+    $this->assertArrayNotHasKey('photos', $build);
   }
 
   /**

--- a/tests/src/Kernel/HiveTest.php
+++ b/tests/src/Kernel/HiveTest.php
@@ -29,6 +29,8 @@ class HiveTest extends KernelTestBase {
     'field',
     'datetime',
     'options',
+    'file',
+    'image',
     'geofield',
     'hivelog',
   ];
@@ -46,12 +48,33 @@ class HiveTest extends KernelTestBase {
   protected function setUp(): void {
     parent::setUp();
     $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
     $this->installEntitySchema('apiary');
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
+    $this->installSchema('file', ['file_usage']);
 
     $this->apiary = Apiary::create(['name' => 'Test Apiary']);
     $this->apiary->save();
+  }
+
+  /**
+   * Creates and saves a managed image file for tests.
+   */
+  protected function createTestImageFile(string $filename): \Drupal\file\FileInterface {
+    $directory = 'public://hivelog-test';
+    \Drupal::service('file_system')->prepareDirectory($directory, \Drupal\Core\File\FileSystemInterface::CREATE_DIRECTORY);
+    $uri = $directory . '/' . $filename;
+    // A tiny valid 1x1 PNG.
+    $png = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGD4DwABBAEAfbLI3wAAAABJRU5ErkJggg==');
+    file_put_contents($uri, $png);
+    $file = \Drupal\file\Entity\File::create([
+      'uri' => $uri,
+      'filename' => $filename,
+      'status' => 1,
+    ]);
+    $file->save();
+    return $file;
   }
 
   /**
@@ -356,6 +379,68 @@ class HiveTest extends KernelTestBase {
     $this->assertNotFalse($histogram_pos);
     $this->assertNotFalse($table_pos);
     $this->assertLessThan($table_pos, $histogram_pos, 'Histogram should appear before the inspections table.');
+  }
+
+  /**
+   * Tests that the hive view renders a letterbox hero image when present.
+   */
+  public function testHiveViewLetterboxHero(): void {
+    $this->installConfig(['system']);
+
+    $user = User::create([
+      'name' => 'hero-tester',
+      'mail' => 'hero-tester@example.com',
+    ]);
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    $file = $this->createTestImageFile('hive-hero.png');
+
+    $hive = Hive::create([
+      'name' => 'Hero Hive',
+      'apiary' => $this->apiary->id(),
+      'status' => 'active',
+      'images' => [['target_id' => $file->id(), 'alt' => 'Hero alt']],
+    ]);
+    $hive->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+
+    $this->assertArrayHasKey('hero', $build);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('hivelog-hive-hero--letterboxed', $html);
+    $this->assertStringContainsString('hivelog-hive-hero__frame', $html);
+    $this->assertStringContainsString('background-image: url(', $html);
+    $this->assertStringContainsString('hive-hero.png', $html);
+  }
+
+  /**
+   * Tests that no hero is rendered when the hive has no images.
+   */
+  public function testHiveViewLetterboxHeroAbsentWhenNoImage(): void {
+    $this->installConfig(['system']);
+
+    $user = User::create([
+      'name' => 'no-hero-tester',
+      'mail' => 'no-hero-tester@example.com',
+    ]);
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    $hive = Hive::create([
+      'name' => 'No Hero Hive',
+      'apiary' => $this->apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+
+    $this->assertArrayNotHasKey('hero', $build);
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds an `images` base field (unlimited cardinality) on both the Hive and HiveInspection entities and renders them appropriately on the canonical view pages.

Closes #22
Closes #23

## Changes

### Hive (#23)
- new `images` field with a form-only display
- `HiveController::view()` renders the first image as a **letterbox hero** above the hive details via an `inline_template` with a `background-image` CSS property
- `hivelog_update_10005` installs the new field storage

### HiveInspection (#22)
- new `images` field with both form and default view display
- `HiveInspectionForm` exposes it in a new **Photos** vertical tab
- `HiveInspectionController::view()` renders a responsive thumbnail grid in a **Photos** section; each thumbnail is wrapped in an `<a target="_blank">` pointing at the full image so users can click through to view it
- `hivelog_update_10006` installs the new field storage

### Supporting changes
- `drupal:image` added to `hivelog.info.yml` dependencies
- new `hivelog/images` library (`css/hivelog.images.css`) provides letterbox hero and photo grid styling
- `ApiaryTest`, `HiveTest`, `HiveInspectionTest` now load the `file` and `image` modules and install the `file_managed` / `file_usage` schemas
- new kernel tests:
  - `testHiveViewLetterboxHero` / `testHiveViewLetterboxHeroAbsentWhenNoImage`
  - `testInspectionViewRendersPhotosGrid` / `testInspectionViewOmitsPhotosSectionWhenEmpty`
  - updated form-grouping test to cover `photos_section`

## Testing

All 64 tests pass (587 assertions, 0 failures).

After merging, run `ddev drush updb -y && ddev drush cr` to install the new field storage on existing sites.

---
[Warp conversation](https://app.warp.dev/conversation/2251d63b-aa49-4405-bfe3-b113d8d86e29)

Co-Authored-By: Oz <oz-agent@warp.dev>