### PR TITLE
Move hive pictures below inspections (remove letterbox hero)

### DIFF
--- a/css/hivelog.images.css
+++ b/css/hivelog.images.css
@@ -1,32 +1,22 @@
 /**
  * @file
- * Styles for the hive hero image and inspection photo grid.
+ * Shared photo grid styles used for hive and inspection pictures.
  */
 
-/* Hive hero: a letterboxed frame showing a section of the first picture. */
-.hivelog-hive-hero {
-  margin: 0 0 1.5rem;
+.hivelog-hive-photos,
+.hivelog-inspection-photos {
+  margin: 1rem 0;
 }
 
-.hivelog-hive-hero--letterboxed .hivelog-hive-hero__frame {
-  width: 100%;
-  aspect-ratio: 21 / 9;
-  background-color: #111;
-  background-position: center;
-  background-size: cover;
-  background-repeat: no-repeat;
-  border-radius: 4px;
-}
-
-/* Inspection photos: responsive grid of thumbnails linking to the original. */
-.hivelog-inspection-photos__grid {
+/* Responsive grid of thumbnails linking to the original image. */
+.hivelog-photos-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
   gap: 0.75rem;
   margin: 0.5rem 0 1.25rem;
 }
 
-.hivelog-inspection-photos__item {
+.hivelog-photos-grid__item {
   display: block;
   aspect-ratio: 1 / 1;
   overflow: hidden;
@@ -34,7 +24,7 @@
   background: #f3f3f3;
 }
 
-.hivelog-inspection-photos__item img {
+.hivelog-photos-grid__item img {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -42,7 +32,7 @@
   transition: transform 0.15s ease-in-out;
 }
 
-.hivelog-inspection-photos__item:hover img,
-.hivelog-inspection-photos__item:focus img {
+.hivelog-photos-grid__item:hover img,
+.hivelog-photos-grid__item:focus img {
   transform: scale(1.03);
 }

--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -28,13 +28,6 @@ class HiveController extends ControllerBase {
   public function view(Hive $hive) {
     $build = [];
 
-    // Letterbox hero image (first attached picture), rendered above the
-    // hive entity details when present.
-    $hero = $this->buildHero($hive);
-    if (!empty($hero)) {
-      $build['hero'] = $hero;
-    }
-
     // Render the hive entity fields.
     $view_builder = $this->entityTypeManager()->getViewBuilder('hive');
     $build['hive'] = $view_builder->view($hive);
@@ -128,6 +121,12 @@ class HiveController extends ControllerBase {
       '#weight' => 12,
     ];
 
+    // Attached pictures, rendered in a grid below the inspection list.
+    $images = $this->buildImagesGrid($hive);
+    if (!empty($images)) {
+      $build['images'] = $images + ['#weight' => 20];
+    }
+
     return $build;
   }
 
@@ -139,39 +138,52 @@ class HiveController extends ControllerBase {
   }
 
   /**
-   * Builds a letterboxed hero render array from the hive's first image.
+   * Builds a grid of hive pictures with links to the full-size image.
    */
-  protected function buildHero(Hive $hive): array {
+  protected function buildImagesGrid(Hive $hive): array {
     if ($hive->get('images')->isEmpty()) {
       return [];
     }
 
-    $file = $hive->get('images')->entity;
-    if (!$file) {
-      return [];
+    $file_url_generator = \Drupal::service('file_url_generator');
+    $items = [];
+    foreach ($hive->get('images') as $delta => $item) {
+      /** @var \Drupal\file\FileInterface|null $file */
+      $file = $item->entity;
+      if (!$file) {
+        continue;
+      }
+      $full_url = $file_url_generator->generateAbsoluteString($file->getFileUri());
+      $alt = (string) ($item->alt ?? '');
+      $items[] = [
+        'full_url' => $full_url,
+        'thumb_url' => $full_url,
+        'alt' => $alt,
+      ];
     }
 
-    $url = \Drupal::service('file_url_generator')->generateAbsoluteString($file->getFileUri());
-    $alt = (string) ($hive->get('images')->alt ?? $hive->label());
+    if (empty($items)) {
+      return [];
+    }
 
     return [
       '#type' => 'container',
       '#attributes' => [
-        'class' => [
-          'hivelog-hive-hero',
-          'hivelog-hive-hero--letterboxed',
-        ],
+        'class' => ['hivelog-hive-photos'],
       ],
-      '#weight' => -10,
       '#attached' => [
         'library' => ['hivelog/images'],
       ],
-      'frame' => [
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Pictures'),
+      ],
+      'grid' => [
         '#type' => 'inline_template',
-        '#template' => '<div class="hivelog-hive-hero__frame" style="background-image: url({{ url }});" role="img" aria-label="{{ alt }}"></div>',
+        '#template' => '<div class="hivelog-photos-grid">{% for item in items %}<a class="hivelog-photos-grid__item" href="{{ item.full_url }}" target="_blank" rel="noopener"><img src="{{ item.thumb_url }}" alt="{{ item.alt }}" loading="lazy" /></a>{% endfor %}</div>',
         '#context' => [
-          'url' => $url,
-          'alt' => $alt,
+          'items' => $items,
         ],
       ],
     ];

--- a/src/Controller/HiveInspectionController.php
+++ b/src/Controller/HiveInspectionController.php
@@ -123,7 +123,7 @@ class HiveInspectionController extends ControllerBase {
       ],
       'grid' => [
         '#type' => 'inline_template',
-        '#template' => '<div class="hivelog-inspection-photos__grid">{% for item in items %}<a class="hivelog-inspection-photos__item" href="{{ item.full_url }}" target="_blank" rel="noopener"><img src="{{ item.thumb_url }}" alt="{{ item.alt }}" loading="lazy" /></a>{% endfor %}</div>',
+        '#template' => '<div class="hivelog-photos-grid">{% for item in items %}<a class="hivelog-photos-grid__item" href="{{ item.full_url }}" target="_blank" rel="noopener"><img src="{{ item.thumb_url }}" alt="{{ item.alt }}" loading="lazy" /></a>{% endfor %}</div>',
         '#context' => [
           'items' => $items,
         ],

--- a/tests/src/Kernel/HiveInspectionTest.php
+++ b/tests/src/Kernel/HiveInspectionTest.php
@@ -474,8 +474,8 @@ class HiveInspectionTest extends KernelTestBase {
 
     $this->assertArrayHasKey('photos', $build);
     $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
-    $this->assertStringContainsString('hivelog-inspection-photos__grid', $html);
-    $this->assertStringContainsString('hivelog-inspection-photos__item', $html);
+    $this->assertStringContainsString('hivelog-photos-grid', $html);
+    $this->assertStringContainsString('hivelog-photos-grid__item', $html);
     $this->assertStringContainsString('photo-1.png', $html);
     $this->assertStringContainsString('photo-2.png', $html);
     $this->assertStringContainsString('alt="Photo one"', $html);

--- a/tests/src/Kernel/HiveTest.php
+++ b/tests/src/Kernel/HiveTest.php
@@ -382,25 +382,29 @@ class HiveTest extends KernelTestBase {
   }
 
   /**
-   * Tests that the hive view renders a letterbox hero image when present.
+   * Tests that attached hive pictures render in a grid below the inspections.
    */
-  public function testHiveViewLetterboxHero(): void {
+  public function testHiveViewImagesGridBelowInspections(): void {
     $this->installConfig(['system']);
 
     $user = User::create([
-      'name' => 'hero-tester',
-      'mail' => 'hero-tester@example.com',
+      'name' => 'images-tester',
+      'mail' => 'images-tester@example.com',
     ]);
     $user->save();
     \Drupal::currentUser()->setAccount($user);
 
-    $file = $this->createTestImageFile('hive-hero.png');
+    $file_a = $this->createTestImageFile('hive-photo-a.png');
+    $file_b = $this->createTestImageFile('hive-photo-b.png');
 
     $hive = Hive::create([
-      'name' => 'Hero Hive',
+      'name' => 'Pictured Hive',
       'apiary' => $this->apiary->id(),
       'status' => 'active',
-      'images' => [['target_id' => $file->id(), 'alt' => 'Hero alt']],
+      'images' => [
+        ['target_id' => $file_a->id(), 'alt' => 'Photo A'],
+        ['target_id' => $file_b->id(), 'alt' => 'Photo B'],
+      ],
     ]);
     $hive->save();
 
@@ -408,29 +412,53 @@ class HiveTest extends KernelTestBase {
       ->getInstanceFromDefinition(HiveController::class);
     $build = $controller->view($hive);
 
-    $this->assertArrayHasKey('hero', $build);
+    // No hero anymore.
+    $this->assertArrayNotHasKey('hero', $build);
+    $this->assertArrayHasKey('images', $build);
+    // Images block weight must be greater than inspections table weight so it
+    // sorts below the list of inspections.
+    $this->assertGreaterThan(
+      $build['inspections_table']['#weight'],
+      $build['images']['#weight'],
+      'Images grid should sort after the inspections table.'
+    );
+
     $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
-    $this->assertStringContainsString('hivelog-hive-hero--letterboxed', $html);
-    $this->assertStringContainsString('hivelog-hive-hero__frame', $html);
-    $this->assertStringContainsString('background-image: url(', $html);
-    $this->assertStringContainsString('hive-hero.png', $html);
+    $this->assertStringNotContainsString('hivelog-hive-hero', $html);
+    $this->assertStringContainsString('hivelog-photos-grid', $html);
+    $this->assertStringContainsString('hivelog-photos-grid__item', $html);
+    $this->assertStringContainsString('hive-photo-a.png', $html);
+    $this->assertStringContainsString('hive-photo-b.png', $html);
+    $this->assertStringContainsString('alt="Photo A"', $html);
+    $this->assertStringContainsString('alt="Photo B"', $html);
+
+    // Grid must appear after the inspections table in the final HTML.
+    $inspections_pos = strpos($html, '<table');
+    $grid_pos = strpos($html, 'hivelog-photos-grid');
+    $this->assertNotFalse($inspections_pos);
+    $this->assertNotFalse($grid_pos);
+    $this->assertGreaterThan(
+      $inspections_pos,
+      $grid_pos,
+      'Pictures grid should render below the inspections table in the final HTML.'
+    );
   }
 
   /**
-   * Tests that no hero is rendered when the hive has no images.
+   * Tests that no images grid is rendered when the hive has no images.
    */
-  public function testHiveViewLetterboxHeroAbsentWhenNoImage(): void {
+  public function testHiveViewImagesGridAbsentWhenNoImage(): void {
     $this->installConfig(['system']);
 
     $user = User::create([
-      'name' => 'no-hero-tester',
-      'mail' => 'no-hero-tester@example.com',
+      'name' => 'no-images-tester',
+      'mail' => 'no-images-tester@example.com',
     ]);
     $user->save();
     \Drupal::currentUser()->setAccount($user);
 
     $hive = Hive::create([
-      'name' => 'No Hero Hive',
+      'name' => 'No Pictures Hive',
       'apiary' => $this->apiary->id(),
       'status' => 'active',
     ]);
@@ -441,6 +469,7 @@ class HiveTest extends KernelTestBase {
     $build = $controller->view($hive);
 
     $this->assertArrayNotHasKey('hero', $build);
+    $this->assertArrayNotHasKey('images', $build);
   }
 
   /**


### PR DESCRIPTION
## Summary

Remove the letterbox hero image from the hive canonical page and render attached hive pictures in a thumbnail grid at the bottom of the page, below the list of inspections.

## Changes

- **HiveController** (`src/Controller/HiveController.php`): `view()` no longer calls `buildHero()`. New `buildImagesGrid()` method renders all attached images with `#weight => 20` (after the inspections table at weight 12).
- **Shared photo grid CSS**: `.hivelog-hive-hero*` rules removed; photo grid styles renamed to shared `.hivelog-photos-grid` / `.hivelog-photos-grid__item` selectors used by both Hive and HiveInspection controllers.
- **HiveInspectionController**: updated to emit the shared class names.
- **HiveTest**: replaced hero tests with `testHiveViewImagesGridBelowInspections` and `testHiveViewImagesGridAbsentWhenNoImage` (placement is verified via both render-array `#weight` and final HTML order).
- **HiveInspectionTest**: photo grid assertions updated for the new class names.

## Testing

All 64 tests pass (596 assertions, 0 failures).

No schema changes \u2014 a `drush cr` is sufficient after merge.

---
[Warp conversation](https://app.warp.dev/conversation/2251d63b-aa49-4405-bfe3-b113d8d86e29)

Co-Authored-By: Oz <oz-agent@warp.dev>