### PR TITLE
Use thumbnail image style for hive/inspection photo grids

### DIFF
--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -146,6 +146,10 @@ class HiveController extends ControllerBase {
     }
 
     $file_url_generator = \Drupal::service('file_url_generator');
+    $image_style = \Drupal::entityTypeManager()
+      ->getStorage('image_style')
+      ->load('thumbnail');
+
     $items = [];
     foreach ($hive->get('images') as $delta => $item) {
       /** @var \Drupal\file\FileInterface|null $file */
@@ -153,11 +157,14 @@ class HiveController extends ControllerBase {
       if (!$file) {
         continue;
       }
+
       $full_url = $file_url_generator->generateAbsoluteString($file->getFileUri());
+      $thumb_url = $image_style ? $image_style->buildUrl($file->getFileUri()) : $full_url;
       $alt = (string) ($item->alt ?? '');
+
       $items[] = [
         'full_url' => $full_url,
-        'thumb_url' => $full_url,
+        'thumb_url' => $thumb_url,
         'alt' => $alt,
       ];
     }

--- a/src/Controller/HiveInspectionController.php
+++ b/src/Controller/HiveInspectionController.php
@@ -88,6 +88,10 @@ class HiveInspectionController extends ControllerBase {
     }
 
     $file_url_generator = \Drupal::service('file_url_generator');
+    $image_style = \Drupal::entityTypeManager()
+      ->getStorage('image_style')
+      ->load('thumbnail');
+
     $items = [];
     foreach ($hive_inspection->get('images') as $delta => $item) {
       /** @var \Drupal\file\FileInterface|null $file */
@@ -95,11 +99,14 @@ class HiveInspectionController extends ControllerBase {
       if (!$file) {
         continue;
       }
+
       $full_url = $file_url_generator->generateAbsoluteString($file->getFileUri());
+      $thumb_url = $image_style ? $image_style->buildUrl($file->getFileUri()) : $full_url;
       $alt = (string) ($item->alt ?? '');
+
       $items[] = [
         'full_url' => $full_url,
-        'thumb_url' => $full_url,
+        'thumb_url' => $thumb_url,
         'alt' => $alt,
       ];
     }


### PR DESCRIPTION
## Summary

Fixes inspection photos (and hive pictures) appearing full-size by using Drupal's built-in thumbnail image style for the image URLs used in the photo grids, while still linking to the original file when clicked.

## Changes

- HiveInspectionController: photo grid now uses the thumbnail image style URL for thumb_url
- HiveController: hive pictures grid now uses the thumbnail image style URL for thumb_url

If the thumbnail image style is not present for any reason, the code falls back to the original file URL.

## Testing

hivelog PHPUnit suite passes.

---
Warp conversation: https://app.warp.dev/conversation/2251d63b-aa49-4405-bfe3-b113d8d86e29

Co-Authored-By: Oz <oz-agent@warp.dev>