### PR TITLE
Filter apiary hive listings by entity access (#27)

### DIFF
--- a/src/Controller/ApiaryController.php
+++ b/src/Controller/ApiaryController.php
@@ -37,10 +37,22 @@ class ApiaryController extends ControllerBase {
       '#weight' => 11,
     ];
 
-    // Load hives for this apiary.
+    // Load hives for this apiary and enforce per-entity access checks.
+    $hive_ids = $this->entityTypeManager()
+      ->getStorage('hive')
+      ->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('apiary', $apiary->id())
+      ->sort('name', 'ASC')
+      ->execute();
     $hives = $this->entityTypeManager()
       ->getStorage('hive')
-      ->loadByProperties(['apiary' => $apiary->id()]);
+      ->loadMultiple($hive_ids);
+    $account = $this->currentUser();
+    $hives = array_filter(
+      $hives,
+      static fn($hive) => $hive->access('view', $account)
+    );
 
     $header = [
       $this->t('Name'),

--- a/tests/src/Kernel/ApiaryTest.php
+++ b/tests/src/Kernel/ApiaryTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\hivelog\Kernel;
 
+use Drupal\hivelog\Controller\ApiaryController;
 use Drupal\hivelog\Entity\Apiary;
+use Drupal\hivelog\Entity\Hive;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
@@ -162,6 +165,58 @@ class ApiaryTest extends KernelTestBase {
     $apiary->delete();
 
     $this->assertNull(Apiary::load($id));
+  }
+
+  /**
+   * Tests apiary page child listing only includes accessible hives.
+   */
+  public function testApiaryViewFiltersInaccessibleHives(): void {
+    $apiary = Apiary::create([
+      'name' => 'Restricted View Apiary',
+    ]);
+    $apiary->save();
+
+    $hive = Hive::create([
+      'name' => 'Hidden Hive',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    $viewer = User::create([
+      'name' => 'apiary-viewer',
+      'mail' => 'apiary-viewer@example.com',
+    ]);
+    $viewer->save();
+
+    $role = Role::create([
+      'id' => 'apiary_view_only',
+      'label' => 'Apiary view only',
+    ]);
+    $role->grantPermission('view apiary');
+    $role->save();
+    $authenticated = Role::load('authenticated');
+    if ($authenticated) {
+      $authenticated->revokePermission('view hive');
+      $authenticated->revokePermission('edit hive');
+      $authenticated->revokePermission('delete hive');
+      $authenticated->save();
+    }
+    $viewer->addRole('apiary_view_only');
+    $viewer->save();
+
+    \Drupal::currentUser()->setAccount($viewer);
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ApiaryController::class);
+    $build = $controller->view($apiary);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+
+    $this->assertStringNotContainsString('Hidden Hive', $html);
+    $this->assertStringContainsString(
+      'No hives have been added to this apiary yet.',
+      $html
+    );
   }
 
 }


### PR DESCRIPTION
## Summary
- load apiary child hives with access-aware query logic
- enforce per-entity view access before rendering hive rows
- add kernel regression coverage for parent-page child listing access behavior

## Test plan
- [x] `ddev exec \"SIMPLETEST_DB=mysql://db:db@db:3306/db SIMPLETEST_BASE_URL=http://web php /var/www/html/vendor/bin/phpunit -c /var/www/html/web/core /var/www/html/web/modules/hivelog/tests/src/Kernel/ApiaryTest.php --filter testApiaryViewFiltersInaccessibleHives\"`
- [x] `ddev exec \"SIMPLETEST_DB=mysql://db:db@db:3306/db SIMPLETEST_BASE_URL=http://web php /var/www/html/vendor/bin/phpunit -c /var/www/html/web/core /var/www/html/web/modules/hivelog/tests/src/Kernel/ApiaryTest.php\"`

Closes #27

Made with [Cursor](https://cursor.com)