### PR TITLE
Add cross-field validation for inspection integrity (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ After installation, navigate to **Administration → Structure → HiveLog**
    - **Management** — Colony fed, feed type, number of supers, actions taken
    - **Notes** — Free-text observations
 
+### Inspection Validation Rules
+
+To preserve data integrity, the inspection form enforces dependent-field rules:
+
+- If **Fed** is checked, **Feed Type** is required.
+- If **Fed** is not checked, **Feed Type** must be left empty.
+- If **Varroa Check** is checked, **Varroa Count** is required.
+- If **Varroa Check** is not checked, **Varroa Count** must be left empty.
+
 ### Queen Marking Colour
 
 When a queen year is entered on a hive, the international queen marking colour

--- a/src/Form/HiveInspectionForm.php
+++ b/src/Form/HiveInspectionForm.php
@@ -107,6 +107,85 @@ class HiveInspectionForm extends ContentEntityForm {
   /**
    * {@inheritdoc}
    */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+    $this->validateDependentFields($form_state);
+  }
+
+  /**
+   * Validates dependent inspection fields for consistent combinations.
+   */
+  protected function validateDependentFields(FormStateInterface $form_state): void {
+    $fed = $this->getBooleanFieldValue($form_state, 'fed');
+    $feed_type = trim($this->getStringFieldValue($form_state, 'feed_type'));
+    if ($fed && $feed_type === '') {
+      $form_state->setErrorByName(
+        'feed_type',
+        $this->t('Feed type is required when the colony was fed.')
+      );
+    }
+    if (!$fed && $feed_type !== '') {
+      $form_state->setErrorByName(
+        'feed_type',
+        $this->t('Feed type must be empty unless the colony was fed.')
+      );
+    }
+
+    $varroa_check = $this->getBooleanFieldValue($form_state, 'varroa_check');
+    $varroa_count = $this->getNullableFieldValue($form_state, 'varroa_count');
+    if ($varroa_check && $varroa_count === NULL) {
+      $form_state->setErrorByName(
+        'varroa_count',
+        $this->t('Varroa count is required when a varroa check was performed.')
+      );
+    }
+    if (!$varroa_check && $varroa_count !== NULL) {
+      $form_state->setErrorByName(
+        'varroa_count',
+        $this->t('Varroa count must be empty unless a varroa check was performed.')
+      );
+    }
+  }
+
+  /**
+   * Extracts a boolean value from an entity form field.
+   */
+  protected function getBooleanFieldValue(FormStateInterface $form_state, string $field_name): bool {
+    $value = $form_state->getValue($field_name);
+    if (is_array($value)) {
+      $value = $value[0]['value'] ?? $value['value'] ?? NULL;
+    }
+    return (bool) $value;
+  }
+
+  /**
+   * Extracts a string value from an entity form field.
+   */
+  protected function getStringFieldValue(FormStateInterface $form_state, string $field_name): string {
+    $value = $form_state->getValue($field_name);
+    if (is_array($value)) {
+      $value = $value[0]['value'] ?? $value['value'] ?? '';
+    }
+    return (string) ($value ?? '');
+  }
+
+  /**
+   * Extracts an optional scalar field value.
+   */
+  protected function getNullableFieldValue(FormStateInterface $form_state, string $field_name): mixed {
+    $value = $form_state->getValue($field_name);
+    if (is_array($value)) {
+      $value = $value[0]['value'] ?? $value['value'] ?? NULL;
+    }
+    if ($value === '' || $value === NULL) {
+      return NULL;
+    }
+    return $value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function save(array $form, FormStateInterface $form_state) {
     $entity = $this->entity;
     $status = $entity->save();

--- a/tests/src/Kernel/HiveInspectionTest.php
+++ b/tests/src/Kernel/HiveInspectionTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\hivelog\Kernel;
 
+use Drupal\Core\Form\FormState;
 use Drupal\hivelog\Controller\HiveInspectionController;
 use Drupal\hivelog\Entity\Apiary;
 use Drupal\hivelog\Entity\Hive;
 use Drupal\hivelog\Entity\HiveInspection;
+use Drupal\hivelog\Form\HiveInspectionForm;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
@@ -56,6 +58,30 @@ class HiveInspectionTest extends KernelTestBase {
    * @var \Drupal\user\Entity\User
    */
   protected User $user;
+
+  /**
+   * Validates dependent inspection fields using form-level rule logic.
+   */
+  protected function validateDependentInspectionFields(array $values): FormState {
+    $defaults = [
+      'fed' => [['value' => 0]],
+      'feed_type' => [['value' => '']],
+      'varroa_check' => [['value' => 0]],
+      'varroa_count' => [['value' => '']],
+    ];
+
+    $form_state = new FormState();
+    $form_state->setValues(array_replace($defaults, $values));
+
+    /** @var \Drupal\hivelog\Form\HiveInspectionForm $form_object */
+    $form_object = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveInspectionForm::class);
+    $method = new \ReflectionMethod(HiveInspectionForm::class, 'validateDependentFields');
+    $method->setAccessible(TRUE);
+    $method->invoke($form_object, $form_state);
+
+    return $form_state;
+  }
 
   /**
    * {@inheritdoc}
@@ -525,6 +551,72 @@ class HiveInspectionTest extends KernelTestBase {
 
     $loaded2 = HiveInspection::load($inspection2->id());
     $this->assertTrue($loaded2->get('weight')->isEmpty());
+  }
+
+  /**
+   * Tests feed type is required when fed is checked.
+   */
+  public function testValidationRequiresFeedTypeWhenFed(): void {
+    $form_state = $this->validateDependentInspectionFields([
+      'fed' => [['value' => 1]],
+      'feed_type' => [['value' => '']],
+    ]);
+
+    $this->assertTrue($form_state->hasAnyErrors());
+    $this->assertArrayHasKey('feed_type', $form_state->getErrors());
+  }
+
+  /**
+   * Tests feed type must be empty when fed is not checked.
+   */
+  public function testValidationRejectsFeedTypeWhenNotFed(): void {
+    $form_state = $this->validateDependentInspectionFields([
+      'fed' => [['value' => 0]],
+      'feed_type' => [['value' => 'Fondant']],
+    ]);
+
+    $this->assertTrue($form_state->hasAnyErrors());
+    $this->assertArrayHasKey('feed_type', $form_state->getErrors());
+  }
+
+  /**
+   * Tests varroa count is required when varroa check is performed.
+   */
+  public function testValidationRequiresVarroaCountWhenChecked(): void {
+    $form_state = $this->validateDependentInspectionFields([
+      'varroa_check' => [['value' => 1]],
+      'varroa_count' => [['value' => '']],
+    ]);
+
+    $this->assertTrue($form_state->hasAnyErrors());
+    $this->assertArrayHasKey('varroa_count', $form_state->getErrors());
+  }
+
+  /**
+   * Tests varroa count must be empty when no varroa check is performed.
+   */
+  public function testValidationRejectsVarroaCountWhenNotChecked(): void {
+    $form_state = $this->validateDependentInspectionFields([
+      'varroa_check' => [['value' => 0]],
+      'varroa_count' => [['value' => 3]],
+    ]);
+
+    $this->assertTrue($form_state->hasAnyErrors());
+    $this->assertArrayHasKey('varroa_count', $form_state->getErrors());
+  }
+
+  /**
+   * Tests consistent dependent field combinations pass validation.
+   */
+  public function testValidationAcceptsConsistentDependentFields(): void {
+    $form_state = $this->validateDependentInspectionFields([
+      'fed' => [['value' => 1]],
+      'feed_type' => [['value' => 'Sugar syrup 1:1']],
+      'varroa_check' => [['value' => 1]],
+      'varroa_count' => [['value' => 2]],
+    ]);
+
+    $this->assertFalse($form_state->hasAnyErrors());
   }
 
 }


### PR DESCRIPTION
## Summary
- add dependent-field validation rules for inspection forms (`fed`/`feed_type`, `varroa_check`/`varroa_count`)
- centralize rule checks in form validation helper methods with clear error messages
- extend kernel tests for invalid and valid dependent-field combinations
- document inspection validation expectations in README

## Test plan
- [x] `ddev exec \"SIMPLETEST_DB=mysql://db:db@db:3306/db SIMPLETEST_BASE_URL=http://web php /var/www/html/vendor/bin/phpunit -c /var/www/html/web/core /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php --filter 'testValidation'\"`
- [x] `ddev exec \"SIMPLETEST_DB=mysql://db:db@db:3306/db SIMPLETEST_BASE_URL=http://web php /var/www/html/vendor/bin/phpunit -c /var/www/html/web/core /var/www/html/web/modules/hivelog/tests/src/Kernel/HiveInspectionTest.php\"`

Closes #28

Made with [Cursor](https://cursor.com)