### PR TITLE
Add global collection pages for hives and inspections (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Users with "Administer HiveLog" bypass all individual permission checks.
 | Path                                          | Description            |
 |-----------------------------------------------|------------------------|
 | `/admin/hivelog`                              | Apiary list            |
+| `/admin/hivelog/hives`                        | Hive list              |
+| `/admin/hivelog/inspections`                  | Inspection list        |
 | `/admin/hivelog/apiary/add`                   | Add apiary             |
 | `/admin/hivelog/apiary/{id}`                  | View apiary            |
 | `/admin/hivelog/apiary/{id}/edit`             | Edit apiary            |

--- a/hivelog.links.menu.yml
+++ b/hivelog.links.menu.yml
@@ -4,3 +4,17 @@ hivelog.admin:
   route_name: entity.apiary.collection
   parent: system.admin_structure
   weight: 10
+
+hivelog.hives:
+  title: 'Hives'
+  description: 'View all hives.'
+  route_name: entity.hive.collection
+  parent: hivelog.admin
+  weight: 1
+
+hivelog.inspections:
+  title: 'Inspections'
+  description: 'View all inspections.'
+  route_name: entity.hive_inspection.collection
+  parent: hivelog.admin
+  weight: 2

--- a/hivelog.routing.yml
+++ b/hivelog.routing.yml
@@ -52,6 +52,14 @@ entity.apiary.delete_form:
         type: entity:apiary
 
 # Hive routes.
+entity.hive.collection:
+  path: '/admin/hivelog/hives'
+  defaults:
+    _entity_list: 'hive'
+    _title: 'HiveLog - Hives'
+  requirements:
+    _permission: 'view hive+administer hivelog'
+
 hivelog.hive.add:
   path: '/admin/hivelog/apiary/{apiary}/hive/add'
   defaults:
@@ -101,6 +109,14 @@ entity.hive.delete_form:
         type: entity:hive
 
 # Inspection routes.
+entity.hive_inspection.collection:
+  path: '/admin/hivelog/inspections'
+  defaults:
+    _entity_list: 'hive_inspection'
+    _title: 'HiveLog - Inspections'
+  requirements:
+    _permission: 'view hive inspection+administer hivelog'
+
 hivelog.inspection.add:
   path: '/admin/hivelog/hive/{hive}/inspection/add'
   defaults:

--- a/tests/src/Kernel/ApiaryTest.php
+++ b/tests/src/Kernel/ApiaryTest.php
@@ -219,4 +219,25 @@ class ApiaryTest extends KernelTestBase {
     );
   }
 
+  /**
+   * Tests global hive and inspection collection routes are registered.
+   */
+  public function testGlobalCollectionRoutesAndMenuLinksExist(): void {
+    $route_provider = \Drupal::service('router.route_provider');
+    $hive_route = $route_provider->getRouteByName('entity.hive.collection');
+    $inspection_route = $route_provider->getRouteByName('entity.hive_inspection.collection');
+
+    $this->assertEquals('/admin/hivelog/hives', $hive_route->getPath());
+    $this->assertEquals('/admin/hivelog/inspections', $inspection_route->getPath());
+    $this->assertEquals('view hive+administer hivelog', $hive_route->getRequirement('_permission'));
+    $this->assertEquals('view hive inspection+administer hivelog', $inspection_route->getRequirement('_permission'));
+
+    $menu_links = \Drupal::service('plugin.manager.menu.link')->getDefinitions();
+    $this->assertArrayHasKey('hivelog.hives', $menu_links);
+    $this->assertArrayHasKey('hivelog.inspections', $menu_links);
+    $this->assertEquals('entity.hive.collection', $menu_links['hivelog.hives']['route_name']);
+    $this->assertEquals('entity.hive_inspection.collection', $menu_links['hivelog.inspections']['route_name']);
+    $this->assertEquals('hivelog.admin', $menu_links['hivelog.hives']['parent']);
+    $this->assertEquals('hivelog.admin', $menu_links['hivelog.inspections']['parent']);
+  }
 }


### PR DESCRIPTION
## Summary
- add admin collection routes for hive and hive inspection entities
- expose global hives and inspections links under the HiveLog admin menu
- document new list endpoints in README
- add kernel test coverage for route and menu link registration

## Test plan
- [x] `ddev exec \"SIMPLETEST_DB=mysql://db:db@db:3306/db SIMPLETEST_BASE_URL=http://web php /var/www/html/vendor/bin/phpunit -c /var/www/html/web/core /var/www/html/web/modules/hivelog/tests/src/Kernel/ApiaryTest.php --filter testGlobalCollectionRoutesAndMenuLinksExist\"`
- [x] `ddev exec \"SIMPLETEST_DB=mysql://db:db@db:3306/db SIMPLETEST_BASE_URL=http://web php /var/www/html/vendor/bin/phpunit -c /var/www/html/web/core /var/www/html/web/modules/hivelog/tests/src/Kernel/ApiaryTest.php\"`

Closes #29