### PR TITLE
Add filtering and pagination to embedded child tables (#30)

### DIFF
--- a/css/hivelog.filter-form.css
+++ b/css/hivelog.filter-form.css
@@ -1,0 +1,29 @@
+/**
+ * @file
+ * Styling for the embedded child table filter forms.
+ */
+
+.hivelog-filter-form {
+  margin: 0.5rem 0 1rem;
+  padding: 0.75rem 1rem;
+  background: #fafafa;
+  border: 1px solid #e5e5e5;
+  border-radius: 4px;
+}
+
+.hivelog-filter-form__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  align-items: flex-end;
+}
+
+.hivelog-filter-form__filters .form-item {
+  margin: 0;
+}
+
+.hivelog-filter-form__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}

--- a/hivelog.libraries.yml
+++ b/hivelog.libraries.yml
@@ -9,3 +9,9 @@ images:
   css:
     component:
       css/hivelog.images.css: {}
+
+filter_form:
+  version: 1.x
+  css:
+    component:
+      css/hivelog.filter-form.css: {}

--- a/src/Controller/ApiaryController.php
+++ b/src/Controller/ApiaryController.php
@@ -3,13 +3,43 @@
 namespace Drupal\hivelog\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Url;
 use Drupal\hivelog\Entity\Apiary;
+use Drupal\hivelog\Form\HivelogHiveFilterForm;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Controller for Apiary pages.
  */
 class ApiaryController extends ControllerBase {
+
+  /**
+   * Default number of hives shown per page in the embedded list.
+   */
+  public const HIVES_PER_PAGE = 20;
+
+  /**
+   * Pager element id for the embedded hive table.
+   */
+  protected const HIVES_PAGER_ELEMENT = 0;
+
+  /**
+   * The request stack.
+   */
+  protected RequestStack $requestStack;
+
+  public function __construct(RequestStack $request_stack) {
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static($container->get('request_stack'));
+  }
 
   /**
    * Displays an apiary with its hives.
@@ -37,17 +67,25 @@ class ApiaryController extends ControllerBase {
       '#weight' => 11,
     ];
 
-    // Load hives for this apiary and enforce per-entity access checks.
-    $hive_ids = $this->entityTypeManager()
+    // Filter form.
+    $build['hives_filter'] = $this->formBuilder()->getForm(HivelogHiveFilterForm::class, $apiary);
+    $build['hives_filter']['#weight'] = 11.5;
+
+    // Build the query with filters and pagination applied.
+    $filters = $this->extractHiveFilters();
+    $query = $this->entityTypeManager()
       ->getStorage('hive')
       ->getQuery()
       ->accessCheck(TRUE)
       ->condition('apiary', $apiary->id())
       ->sort('name', 'ASC')
-      ->execute();
-    $hives = $this->entityTypeManager()
-      ->getStorage('hive')
-      ->loadMultiple($hive_ids);
+      ->pager(static::HIVES_PER_PAGE, static::HIVES_PAGER_ELEMENT);
+    $this->applyHiveFilters($query, $filters);
+    $hive_ids = $query->execute();
+
+    $hives = $hive_ids
+      ? $this->entityTypeManager()->getStorage('hive')->loadMultiple($hive_ids)
+      : [];
     $account = $this->currentUser();
     $hives = array_filter(
       $hives,
@@ -91,9 +129,21 @@ class ApiaryController extends ControllerBase {
       '#type' => 'table',
       '#header' => $header,
       '#rows' => $rows,
-      '#empty' => $this->t('No hives have been added to this apiary yet.'),
+      '#empty' => !empty($filters)
+        ? $this->t('No hives match the current filters.')
+        : $this->t('No hives have been added to this apiary yet.'),
       '#weight' => 12,
     ];
+
+    $build['hives_pager'] = [
+      '#type' => 'pager',
+      '#element' => static::HIVES_PAGER_ELEMENT,
+      '#weight' => 13,
+    ];
+
+    // Cache this render array per URL query string so pager + filter state
+    // produce distinct cache entries.
+    $build['#cache']['contexts'][] = 'url.query_args';
 
     return $build;
   }
@@ -103,6 +153,53 @@ class ApiaryController extends ControllerBase {
    */
   public function title(Apiary $apiary) {
     return $apiary->label();
+  }
+
+  /**
+   * Extracts hive filter values from the current request.
+   *
+   * @return array<string, string>
+   *   Associative array keyed by filter name. Only non-empty values are
+   *   included.
+   */
+  protected function extractHiveFilters(): array {
+    $request = $this->requestStack->getCurrentRequest();
+    if (!$request) {
+      return [];
+    }
+    $filters = [];
+    foreach (['status', 'bee_breed', 'temperament', 'name'] as $key) {
+      $value = trim((string) $request->query->get($key, ''));
+      if ($value !== '') {
+        $filters[$key] = $value;
+      }
+    }
+    return $filters;
+  }
+
+  /**
+   * Applies hive filters to an entity query.
+   */
+  protected function applyHiveFilters(QueryInterface $query, array $filters): void {
+    if (isset($filters['status'])) {
+      $query->condition('status', $filters['status']);
+    }
+    if (isset($filters['bee_breed'])) {
+      $query->condition('bee_breed', $filters['bee_breed']);
+    }
+    if (isset($filters['temperament'])) {
+      $query->condition('temperament', $filters['temperament']);
+    }
+    if (isset($filters['name'])) {
+      $query->condition('name', '%' . $this->escapeLike($filters['name']) . '%', 'LIKE');
+    }
+  }
+
+  /**
+   * Escapes LIKE wildcard characters for safe use inside a LIKE condition.
+   */
+  protected function escapeLike(string $value): string {
+    return addcslashes($value, '\\%_');
   }
 
 }

--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -3,14 +3,44 @@
 namespace Drupal\hivelog\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Url;
 use Drupal\hivelog\Entity\Apiary;
 use Drupal\hivelog\Entity\Hive;
+use Drupal\hivelog\Form\HivelogInspectionFilterForm;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Controller for Hive pages.
  */
 class HiveController extends ControllerBase {
+
+  /**
+   * Default number of inspections shown per page in the embedded list.
+   */
+  public const INSPECTIONS_PER_PAGE = 20;
+
+  /**
+   * Pager element id for the embedded inspection table.
+   */
+  protected const INSPECTIONS_PAGER_ELEMENT = 0;
+
+  /**
+   * The request stack.
+   */
+  protected RequestStack $requestStack;
+
+  public function __construct(RequestStack $request_stack) {
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static($container->get('request_stack'));
+  }
 
   /**
    * Provides the add form for a hive within an apiary context.
@@ -49,25 +79,34 @@ class HiveController extends ControllerBase {
       '#weight' => 11,
     ];
 
-    // Load inspections for this hive, ordered by date descending.
-    $inspection_ids = $this->entityTypeManager()
+    // Render a letterboxed weight histogram for the year of the most recent
+    // inspection, based on the full (unpaginated, unfiltered) inspection set
+    // so the summary chart is not affected by active filters or paging.
+    $histogram_points = $this->collectHistogramPoints($hive);
+    $histogram = $this->buildWeightHistogram($histogram_points);
+    if (!empty($histogram)) {
+      $build['weight_histogram'] = $histogram + ['#weight' => 11.2];
+    }
+
+    // Filter form.
+    $build['inspections_filter'] = $this->formBuilder()->getForm(HivelogInspectionFilterForm::class, $hive);
+    $build['inspections_filter']['#weight'] = 11.5;
+
+    // Build the paginated + filtered inspection query.
+    $filters = $this->extractInspectionFilters();
+    $query = $this->entityTypeManager()
       ->getStorage('hive_inspection')
       ->getQuery()
       ->accessCheck(TRUE)
       ->condition('hive', $hive->id())
       ->sort('inspection_date', 'DESC')
-      ->execute();
+      ->pager(static::INSPECTIONS_PER_PAGE, static::INSPECTIONS_PAGER_ELEMENT);
+    $this->applyInspectionFilters($query, $filters);
+    $inspection_ids = $query->execute();
 
-    $inspections = $this->entityTypeManager()
-      ->getStorage('hive_inspection')
-      ->loadMultiple($inspection_ids);
-
-    // Render a letterboxed weight histogram for the year of the most recent
-    // inspection (placed above the inspection list).
-    $histogram = $this->buildWeightHistogram($inspections);
-    if (!empty($histogram)) {
-      $build['weight_histogram'] = $histogram + ['#weight' => 11.5];
-    }
+    $inspections = $inspection_ids
+      ? $this->entityTypeManager()->getStorage('hive_inspection')->loadMultiple($inspection_ids)
+      : [];
 
     $header = [
       $this->t('Date'),
@@ -117,8 +156,16 @@ class HiveController extends ControllerBase {
       '#type' => 'table',
       '#header' => $header,
       '#rows' => $rows,
-      '#empty' => $this->t('No inspections have been recorded for this hive yet.'),
+      '#empty' => !empty($filters)
+        ? $this->t('No inspections match the current filters.')
+        : $this->t('No inspections have been recorded for this hive yet.'),
       '#weight' => 12,
+    ];
+
+    $build['inspections_pager'] = [
+      '#type' => 'pager',
+      '#element' => static::INSPECTIONS_PAGER_ELEMENT,
+      '#weight' => 13,
     ];
 
     // Attached pictures, rendered in a grid below the inspection list.
@@ -126,6 +173,10 @@ class HiveController extends ControllerBase {
     if (!empty($images)) {
       $build['images'] = $images + ['#weight' => 20];
     }
+
+    // Cache per URL query string so pager + filter state produce distinct
+    // cache entries.
+    $build['#cache']['contexts'][] = 'url.query_args';
 
     return $build;
   }
@@ -135,6 +186,106 @@ class HiveController extends ControllerBase {
    */
   public function title(Hive $hive) {
     return $hive->label();
+  }
+
+  /**
+   * Extracts inspection filter values from the current request.
+   *
+   * @return array<string, string>
+   *   Associative array keyed by filter name. Only non-empty values are
+   *   included.
+   */
+  protected function extractInspectionFilters(): array {
+    $request = $this->requestStack->getCurrentRequest();
+    if (!$request) {
+      return [];
+    }
+    $filters = [];
+    foreach (['date_from', 'date_to', 'queen_seen', 'brood_pattern'] as $key) {
+      $value = trim((string) $request->query->get($key, ''));
+      if ($value !== '') {
+        $filters[$key] = $value;
+      }
+    }
+    return $filters;
+  }
+
+  /**
+   * Applies inspection filters to an entity query.
+   */
+  protected function applyInspectionFilters(QueryInterface $query, array $filters): void {
+    if (isset($filters['date_from'])) {
+      $query->condition('inspection_date', $filters['date_from'], '>=');
+    }
+    if (isset($filters['date_to'])) {
+      $query->condition('inspection_date', $filters['date_to'], '<=');
+    }
+    if (isset($filters['queen_seen']) && in_array($filters['queen_seen'], ['0', '1'], TRUE)) {
+      $query->condition('queen_seen', (int) $filters['queen_seen']);
+    }
+    if (isset($filters['brood_pattern'])) {
+      $query->condition('brood_pattern', $filters['brood_pattern']);
+    }
+  }
+
+  /**
+   * Collects histogram data points from the full inspection set for a hive.
+   *
+   * The histogram summarises the year of the most recent inspection and is
+   * deliberately not restricted by filters or pagination.
+   *
+   * @return array<int, array{date:string, mmdd:string, weight:float}>
+   */
+  protected function collectHistogramPoints(Hive $hive): array {
+    $inspection_ids = $this->entityTypeManager()
+      ->getStorage('hive_inspection')
+      ->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('hive', $hive->id())
+      ->sort('inspection_date', 'DESC')
+      ->execute();
+
+    if (!$inspection_ids) {
+      return [];
+    }
+    $inspections = $this->entityTypeManager()
+      ->getStorage('hive_inspection')
+      ->loadMultiple($inspection_ids);
+
+    // Identify the most recent inspection date to determine the target year.
+    $most_recent = NULL;
+    foreach ($inspections as $inspection) {
+      $date = $inspection->get('inspection_date')->value;
+      if ($date && (!$most_recent || $date > $most_recent)) {
+        $most_recent = $date;
+      }
+    }
+    if (!$most_recent) {
+      return [];
+    }
+    $year = substr($most_recent, 0, 4);
+
+    $points = [];
+    foreach ($inspections as $inspection) {
+      $date = $inspection->get('inspection_date')->value;
+      $weight = $inspection->get('weight')->value;
+      if (!$date || $weight === NULL || $weight === '') {
+        continue;
+      }
+      if (substr($date, 0, 4) !== $year) {
+        continue;
+      }
+      $points[] = [
+        'date' => $date,
+        'mmdd' => substr($date, 5, 2) . '/' . substr($date, 8, 2),
+        'weight' => (float) $weight,
+        'year' => $year,
+      ];
+    }
+
+    usort($points, fn($a, $b) => strcmp($a['date'], $b['date']));
+
+    return $points;
   }
 
   /**
@@ -199,52 +350,19 @@ class HiveController extends ControllerBase {
   /**
    * Builds a letterboxed vertical histogram of inspection weights.
    *
-   * Restricted to the year of the most recent inspection that has data.
-   *
-   * @param \Drupal\hivelog\Entity\HiveInspection[] $inspections
-   *   Inspections belonging to the current hive.
+   * @param array<int, array{date:string, mmdd:string, weight:float, year?:string}> $points
+   *   Pre-collected data points for the target year.
    *
    * @return array
    *   A render array for the histogram, or an empty array if there is nothing
    *   to display.
    */
-  protected function buildWeightHistogram(array $inspections): array {
-    // Identify the most recent inspection date to determine the target year.
-    $most_recent = NULL;
-    foreach ($inspections as $inspection) {
-      $date = $inspection->get('inspection_date')->value;
-      if ($date && (!$most_recent || $date > $most_recent)) {
-        $most_recent = $date;
-      }
-    }
-    if (!$most_recent) {
-      return [];
-    }
-    $year = substr($most_recent, 0, 4);
-
-    // Collect data points for that year.
-    $points = [];
-    foreach ($inspections as $inspection) {
-      $date = $inspection->get('inspection_date')->value;
-      $weight = $inspection->get('weight')->value;
-      if (!$date || $weight === NULL || $weight === '') {
-        continue;
-      }
-      if (substr($date, 0, 4) !== $year) {
-        continue;
-      }
-      $points[] = [
-        'date' => $date,
-        'mmdd' => substr($date, 5, 2) . '/' . substr($date, 8, 2),
-        'weight' => (float) $weight,
-      ];
-    }
+  protected function buildWeightHistogram(array $points): array {
     if (empty($points)) {
       return [];
     }
 
-    // Sort chronologically so bars read left to right.
-    usort($points, fn($a, $b) => strcmp($a['date'], $b['date']));
+    $year = $points[0]['year'] ?? substr($points[0]['date'], 0, 4);
 
     // SVG layout constants.
     $svg_width = 800;

--- a/src/Form/HivelogHiveFilterForm.php
+++ b/src/Form/HivelogHiveFilterForm.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\hivelog\Form;
+
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\hivelog\Entity\Apiary;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Filter form for the hive child table on the apiary view page.
+ *
+ * Submits via GET so filter state is reflected in the URL query string and
+ * plays nicely with Drupal's pager.
+ */
+class HivelogHiveFilterForm extends FormBase {
+
+  /**
+   * The entity field manager.
+   */
+  protected EntityFieldManagerInterface $entityFieldManager;
+
+  public function __construct(RequestStack $request_stack, EntityFieldManagerInterface $entity_field_manager) {
+    $this->requestStack = $request_stack;
+    $this->entityFieldManager = $entity_field_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('request_stack'),
+      $container->get('entity_field.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'hivelog_hive_filter_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?Apiary $apiary = NULL): array {
+    $request = $this->requestStack->getCurrentRequest();
+    $query = $request ? $request->query : NULL;
+
+    $form['#method'] = 'get';
+    $form['#attributes']['class'][] = 'hivelog-filter-form';
+    $form['#attached']['library'][] = 'hivelog/filter_form';
+    $form['#cache']['contexts'][] = 'url.query_args';
+
+    $hive_fields = $this->entityFieldManager->getBaseFieldDefinitions('hive');
+
+    $form['filters'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['hivelog-filter-form__filters']],
+    ];
+
+    $form['filters']['status'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Status'),
+      '#options' => ['' => $this->t('- Any -')] + $hive_fields['status']->getSetting('allowed_values'),
+      '#default_value' => $query ? (string) $query->get('status', '') : '',
+    ];
+
+    $form['filters']['bee_breed'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Breed'),
+      '#options' => ['' => $this->t('- Any -')] + $hive_fields['bee_breed']->getSetting('allowed_values'),
+      '#default_value' => $query ? (string) $query->get('bee_breed', '') : '',
+    ];
+
+    $form['filters']['temperament'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Temperament'),
+      '#options' => ['' => $this->t('- Any -')] + $hive_fields['temperament']->getSetting('allowed_values'),
+      '#default_value' => $query ? (string) $query->get('temperament', '') : '',
+    ];
+
+    $form['filters']['name'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Name contains'),
+      '#size' => 20,
+      '#default_value' => $query ? (string) $query->get('name', '') : '',
+    ];
+
+    $form['actions'] = [
+      '#type' => 'actions',
+      '#attributes' => ['class' => ['hivelog-filter-form__actions']],
+    ];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Filter'),
+    ];
+    if ($apiary) {
+      $form['actions']['reset'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Reset'),
+        '#url' => Url::fromRoute('entity.apiary.canonical', ['apiary' => $apiary->id()]),
+        '#attributes' => ['class' => ['button']],
+      ];
+    }
+
+    // GET forms don't need CSRF / build id tokens; hide them so they don't
+    // end up as query string noise.
+    foreach (['form_build_id', 'form_token', 'form_id'] as $element) {
+      if (isset($form[$element])) {
+        $form[$element]['#access'] = FALSE;
+      }
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    // Intentionally empty: the form uses GET, so submission simply reloads
+    // the current URL with the filter values as query string parameters.
+  }
+
+}

--- a/src/Form/HivelogInspectionFilterForm.php
+++ b/src/Form/HivelogInspectionFilterForm.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\hivelog\Form;
+
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\hivelog\Entity\Hive;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Filter form for the inspection child table on the hive view page.
+ *
+ * Submits via GET so filter state is reflected in the URL query string and
+ * plays nicely with Drupal's pager.
+ */
+class HivelogInspectionFilterForm extends FormBase {
+
+  /**
+   * The entity field manager.
+   */
+  protected EntityFieldManagerInterface $entityFieldManager;
+
+  public function __construct(RequestStack $request_stack, EntityFieldManagerInterface $entity_field_manager) {
+    $this->requestStack = $request_stack;
+    $this->entityFieldManager = $entity_field_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('request_stack'),
+      $container->get('entity_field.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'hivelog_inspection_filter_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?Hive $hive = NULL): array {
+    $request = $this->requestStack->getCurrentRequest();
+    $query = $request ? $request->query : NULL;
+
+    $form['#method'] = 'get';
+    $form['#attributes']['class'][] = 'hivelog-filter-form';
+    $form['#attached']['library'][] = 'hivelog/filter_form';
+    $form['#cache']['contexts'][] = 'url.query_args';
+
+    $inspection_fields = $this->entityFieldManager->getBaseFieldDefinitions('hive_inspection');
+
+    $form['filters'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['hivelog-filter-form__filters']],
+    ];
+
+    $form['filters']['date_from'] = [
+      '#type' => 'date',
+      '#title' => $this->t('From'),
+      '#default_value' => $query ? (string) $query->get('date_from', '') : '',
+    ];
+
+    $form['filters']['date_to'] = [
+      '#type' => 'date',
+      '#title' => $this->t('To'),
+      '#default_value' => $query ? (string) $query->get('date_to', '') : '',
+    ];
+
+    $form['filters']['queen_seen'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Queen seen'),
+      '#options' => [
+        '' => $this->t('- Any -'),
+        '1' => $this->t('Yes'),
+        '0' => $this->t('No'),
+      ],
+      '#default_value' => $query ? (string) $query->get('queen_seen', '') : '',
+    ];
+
+    $form['filters']['brood_pattern'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Brood pattern'),
+      '#options' => ['' => $this->t('- Any -')] + $inspection_fields['brood_pattern']->getSetting('allowed_values'),
+      '#default_value' => $query ? (string) $query->get('brood_pattern', '') : '',
+    ];
+
+    $form['actions'] = [
+      '#type' => 'actions',
+      '#attributes' => ['class' => ['hivelog-filter-form__actions']],
+    ];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Filter'),
+    ];
+    if ($hive) {
+      $form['actions']['reset'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Reset'),
+        '#url' => Url::fromRoute('entity.hive.canonical', ['hive' => $hive->id()]),
+        '#attributes' => ['class' => ['button']],
+      ];
+    }
+
+    foreach (['form_build_id', 'form_token', 'form_id'] as $element) {
+      if (isset($form[$element])) {
+        $form[$element]['#access'] = FALSE;
+      }
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    // Intentionally empty: the form uses GET, so submission simply reloads
+    // the current URL with the filter values as query string parameters.
+  }
+
+}

--- a/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
+++ b/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
@@ -1,0 +1,403 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\hivelog\Kernel;
+
+use Drupal\hivelog\Controller\ApiaryController;
+use Drupal\hivelog\Controller\HiveController;
+use Drupal\hivelog\Entity\Apiary;
+use Drupal\hivelog\Entity\Hive;
+use Drupal\hivelog\Entity\HiveInspection;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+/**
+ * Tests that embedded child tables support pagination and filtering.
+ */
+#[Group('hivelog')]
+#[RunTestsInSeparateProcesses]
+class EmbeddedTableFilterPaginationTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'datetime',
+    'options',
+    'file',
+    'image',
+    'geofield',
+    'hivelog',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['system']);
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('apiary');
+    $this->installEntitySchema('hive');
+    $this->installEntitySchema('hive_inspection');
+    $this->installSchema('file', ['file_usage']);
+
+    $user = User::create([
+      'name' => 'tester',
+      'mail' => 'tester@example.com',
+    ]);
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+  }
+
+  /**
+   * Pushes a request with the given query parameters onto the request stack.
+   */
+  protected function pushRequestWithQuery(array $query): void {
+    $request = Request::create('/admin/hivelog/apiary/1', 'GET', $query);
+    // FormBuilder requires a session on the current request.
+    $request->setSession(new Session(new MockArraySessionStorage()));
+    \Drupal::service('request_stack')->push($request);
+  }
+
+  /**
+   * Tests pagination limits the number of hives rendered on the apiary page.
+   */
+  public function testApiaryHiveTablePaginates(): void {
+    $apiary = Apiary::create(['name' => 'Big Apiary']);
+    $apiary->save();
+
+    // Seed more hives than the per-page threshold.
+    $total = ApiaryController::HIVES_PER_PAGE + 5;
+    for ($i = 1; $i <= $total; $i++) {
+      Hive::create([
+        'name' => sprintf('Hive %03d', $i),
+        'apiary' => $apiary->id(),
+        'status' => 'active',
+      ])->save();
+    }
+
+    $this->pushRequestWithQuery([]);
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ApiaryController::class);
+    $build = $controller->view($apiary);
+
+    $this->assertArrayHasKey('hives_table', $build);
+    $this->assertArrayHasKey('hives_pager', $build);
+    $this->assertEquals('pager', $build['hives_pager']['#type']);
+    $this->assertCount(
+      ApiaryController::HIVES_PER_PAGE,
+      $build['hives_table']['#rows'],
+      'First page should contain exactly HIVES_PER_PAGE rows.'
+    );
+
+    // Request the second page and verify we see the remainder.
+    $this->pushRequestWithQuery(['page' => '1']);
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ApiaryController::class);
+    $build = $controller->view($apiary);
+    $this->assertCount(5, $build['hives_table']['#rows'], 'Second page should contain the remaining rows.');
+  }
+
+  /**
+   * Tests the hive status filter on the apiary page.
+   */
+  public function testApiaryHiveTableStatusFilter(): void {
+    $apiary = Apiary::create(['name' => 'Filter Apiary']);
+    $apiary->save();
+
+    Hive::create([
+      'name' => 'Alpha Active',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ])->save();
+    Hive::create([
+      'name' => 'Beta Inactive',
+      'apiary' => $apiary->id(),
+      'status' => 'inactive',
+    ])->save();
+    Hive::create([
+      'name' => 'Gamma Dead',
+      'apiary' => $apiary->id(),
+      'status' => 'dead',
+    ])->save();
+
+    $this->pushRequestWithQuery(['status' => 'inactive']);
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ApiaryController::class);
+    $build = $controller->view($apiary);
+
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('Beta Inactive', $html);
+    $this->assertStringNotContainsString('Alpha Active', $html);
+    $this->assertStringNotContainsString('Gamma Dead', $html);
+  }
+
+  /**
+   * Tests the hive name substring filter on the apiary page.
+   */
+  public function testApiaryHiveTableNameFilter(): void {
+    $apiary = Apiary::create(['name' => 'Name Filter Apiary']);
+    $apiary->save();
+
+    Hive::create([
+      'name' => 'Willow Queen',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ])->save();
+    Hive::create([
+      'name' => 'Oak Queen',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ])->save();
+    Hive::create([
+      'name' => 'Ash Worker',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ])->save();
+
+    $this->pushRequestWithQuery(['name' => 'Queen']);
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ApiaryController::class);
+    $build = $controller->view($apiary);
+
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('Willow Queen', $html);
+    $this->assertStringContainsString('Oak Queen', $html);
+    $this->assertStringNotContainsString('Ash Worker', $html);
+  }
+
+  /**
+   * Tests the empty-filters message on the apiary page.
+   */
+  public function testApiaryHiveTableFilteredEmptyMessage(): void {
+    $apiary = Apiary::create(['name' => 'Empty Filters Apiary']);
+    $apiary->save();
+
+    Hive::create([
+      'name' => 'Sole Hive',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ])->save();
+
+    $this->pushRequestWithQuery(['status' => 'dead']);
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ApiaryController::class);
+    $build = $controller->view($apiary);
+
+    $this->assertEquals(
+      'No hives match the current filters.',
+      (string) $build['hives_table']['#empty']
+    );
+  }
+
+  /**
+   * Tests pagination on the inspections table on the hive page.
+   */
+  public function testHiveInspectionTablePaginates(): void {
+    $apiary = Apiary::create(['name' => 'Pager Apiary']);
+    $apiary->save();
+    $hive = Hive::create([
+      'name' => 'Pager Hive',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    $total = HiveController::INSPECTIONS_PER_PAGE + 3;
+    for ($i = 1; $i <= $total; $i++) {
+      HiveInspection::create([
+        'hive' => $hive->id(),
+        // Distinct dates so ordering is deterministic.
+        'inspection_date' => sprintf('2024-01-%02d', $i),
+      ])->save();
+    }
+
+    $this->pushRequestWithQuery([]);
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+
+    $this->assertArrayHasKey('inspections_table', $build);
+    $this->assertArrayHasKey('inspections_pager', $build);
+    $this->assertCount(
+      HiveController::INSPECTIONS_PER_PAGE,
+      $build['inspections_table']['#rows'],
+      'First page should contain exactly INSPECTIONS_PER_PAGE rows.'
+    );
+
+    $this->pushRequestWithQuery(['page' => '1']);
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+    $this->assertCount(3, $build['inspections_table']['#rows']);
+  }
+
+  /**
+   * Tests date range filtering on the inspections table.
+   */
+  public function testHiveInspectionTableDateFilter(): void {
+    $apiary = Apiary::create(['name' => 'Date Apiary']);
+    $apiary->save();
+    $hive = Hive::create([
+      'name' => 'Date Hive',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2024-03-01',
+      'notes' => 'March inspection',
+    ])->save();
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2024-06-01',
+      'notes' => 'June inspection',
+    ])->save();
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2024-09-01',
+      'notes' => 'September inspection',
+    ])->save();
+
+    $this->pushRequestWithQuery([
+      'date_from' => '2024-05-01',
+      'date_to' => '2024-08-01',
+    ]);
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+
+    $this->assertCount(1, $build['inspections_table']['#rows']);
+    $this->assertEquals('2024-06-01', (string) $build['inspections_table']['#rows'][0][0]);
+  }
+
+  /**
+   * Tests queen seen filter on the inspections table.
+   */
+  public function testHiveInspectionTableQueenSeenFilter(): void {
+    $apiary = Apiary::create(['name' => 'Queen Apiary']);
+    $apiary->save();
+    $hive = Hive::create([
+      'name' => 'Queen Hive',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2024-05-01',
+      'queen_seen' => TRUE,
+    ])->save();
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2024-05-02',
+      'queen_seen' => FALSE,
+    ])->save();
+
+    $this->pushRequestWithQuery(['queen_seen' => '1']);
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+    $this->assertCount(1, $build['inspections_table']['#rows']);
+    $this->assertEquals('2024-05-01', (string) $build['inspections_table']['#rows'][0][0]);
+
+    $this->pushRequestWithQuery(['queen_seen' => '0']);
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+    $this->assertCount(1, $build['inspections_table']['#rows']);
+    $this->assertEquals('2024-05-02', (string) $build['inspections_table']['#rows'][0][0]);
+  }
+
+  /**
+   * Tests that the weight histogram is unaffected by filters/pagination.
+   */
+  public function testWeightHistogramIsNotFiltered(): void {
+    $apiary = Apiary::create(['name' => 'Histogram Apiary']);
+    $apiary->save();
+    $hive = Hive::create([
+      'name' => 'Histogram Hive',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    // Two 2025 inspections, with weights; one 2024 inspection, with weight.
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2025-05-03',
+      'weight' => 28.5,
+    ])->save();
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2025-07-12',
+      'weight' => 35.25,
+    ])->save();
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2024-06-01',
+      'weight' => 22.0,
+    ])->save();
+
+    // Restrict the table to a window that excludes the 2025 data.
+    $this->pushRequestWithQuery([
+      'date_from' => '2024-01-01',
+      'date_to' => '2024-12-31',
+    ]);
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+
+    // Table should reflect the filter (only 2024 row).
+    $this->assertCount(1, $build['inspections_table']['#rows']);
+
+    // Histogram should still summarise the most recent year (2025).
+    $this->assertArrayHasKey('weight_histogram', $build);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('Inspection weights for 2025', $html);
+    $this->assertStringContainsString('28.5 kg', $html);
+    $this->assertStringContainsString('35.25 kg', $html);
+  }
+
+  /**
+   * Tests that the filter form is rendered with a GET method and preserves
+   * submitted values as defaults.
+   */
+  public function testFilterFormIsGetAndPreservesDefaults(): void {
+    $apiary = Apiary::create(['name' => 'Form Apiary']);
+    $apiary->save();
+    Hive::create([
+      'name' => 'A Hive',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ])->save();
+
+    $this->pushRequestWithQuery([
+      'status' => 'active',
+      'name' => 'Hive',
+    ]);
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ApiaryController::class);
+    $build = $controller->view($apiary);
+
+    $filter = $build['hives_filter'];
+    $this->assertEquals('get', $filter['#method']);
+    $this->assertEquals('active', $filter['filters']['status']['#default_value']);
+    $this->assertEquals('Hive', $filter['filters']['name']['#default_value']);
+  }
+
+}


### PR DESCRIPTION
Closes #30

## Summary
Adds configurable pagination and GET-based filter forms to the embedded child tables on the apiary and hive view pages so they remain usable as hive/inspection volume grows.

## Changes
- **Apiary page**: filter hives by status, breed, temperament, or name (substring), paginated at 20 hives/page.
- **Hive page**: filter inspections by date range, queen-seen, and brood pattern, paginated at 20 inspections/page.
  - The weight histogram still uses the full (unfiltered, unpaginated) inspection set so the yearly summary is not affected by current filter state.
- Filter forms submit via **GET**, so filter + pager state lives in the URL query string and is preserved across navigation. Pager links keep active filters via Drupal's default query-arg preservation; rendered output varies by `url.query_args` cache context.
- New CSS library (`hivelog/filter_form`) styles the inline filter bar.
- Page size is defined as a class constant on each controller (`ApiaryController::HIVES_PER_PAGE`, `HiveController::INSPECTIONS_PER_PAGE`) for easy future tuning / config.

## Tests
New kernel test `EmbeddedTableFilterPaginationTest` covers:
- Pagination correctly slices rows on both parent pages (page 1 vs. page 2).
- Each filter narrows results as expected (hive status, hive name substring, inspection date range, queen seen).
- Filtered empty state shows the filter-aware empty message.
- Weight histogram is not affected by active date filters.
- Filter form renders with `#method = get` and preserves submitted values as defaults.

Full suite run: `80 tests, 791 assertions, 0 failures/errors`.

## Oz
Conversation: https://app.warp.dev/conversation/9e6cc51b-334f-4483-b7b2-aeafce94fc65

Co-Authored-By: Oz <oz-agent@warp.dev>