### PR TITLE
Inline filter bar and reorder weight histogram above inspections

### DIFF
--- a/css/hivelog.filter-form.css
+++ b/css/hivelog.filter-form.css
@@ -4,6 +4,10 @@
  */
 
 .hivelog-filter-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem 1rem;
   margin: 0.5rem 0 1rem;
   padding: 0.75rem 1rem;
   background: #fafafa;
@@ -11,19 +15,30 @@
   border-radius: 4px;
 }
 
+/* Flatten the filters container so its children become direct flex items
+   of the outer form, keeping every filter + the action buttons on one row. */
 .hivelog-filter-form__filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem 1.25rem;
-  align-items: flex-end;
+  display: contents;
 }
 
-.hivelog-filter-form__filters .form-item {
+.hivelog-filter-form .form-item {
   margin: 0;
+}
+
+.hivelog-filter-form .form-item label {
+  display: block;
+  font-size: 0.85rem;
+  margin-bottom: 0.15rem;
 }
 
 .hivelog-filter-form__actions {
   display: flex;
+  align-items: center;
   gap: 0.5rem;
-  margin-top: 0.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.hivelog-filter-form__actions .button {
+  margin: 0;
 }

--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -63,6 +63,17 @@ class HiveController extends ControllerBase {
     $build['hive'] = $view_builder->view($hive);
     $build['hive']['#weight'] = 5;
 
+    // Render a letterboxed weight histogram for the year of the most recent
+    // inspection, based on the full (unpaginated, unfiltered) inspection set
+    // so the summary chart is not affected by active filters or paging.
+    // Placed above the Inspections heading/Add Inspection action so it
+    // reads as a summary of the whole inspection history.
+    $histogram_points = $this->collectHistogramPoints($hive);
+    $histogram = $this->buildWeightHistogram($histogram_points);
+    if (!empty($histogram)) {
+      $build['weight_histogram'] = $histogram + ['#weight' => 7];
+    }
+
     // Add inspections heading and action link.
     $build['inspections_heading'] = [
       '#type' => 'html_tag',
@@ -78,15 +89,6 @@ class HiveController extends ControllerBase {
       '#attributes' => ['class' => ['button', 'button--primary']],
       '#weight' => 11,
     ];
-
-    // Render a letterboxed weight histogram for the year of the most recent
-    // inspection, based on the full (unpaginated, unfiltered) inspection set
-    // so the summary chart is not affected by active filters or paging.
-    $histogram_points = $this->collectHistogramPoints($hive);
-    $histogram = $this->buildWeightHistogram($histogram_points);
-    if (!empty($histogram)) {
-      $build['weight_histogram'] = $histogram + ['#weight' => 11.2];
-    }
 
     // Filter form.
     $build['inspections_filter'] = $this->formBuilder()->getForm(HivelogInspectionFilterForm::class, $hive);

--- a/src/Form/HivelogHiveFilterForm.php
+++ b/src/Form/HivelogHiveFilterForm.php
@@ -101,6 +101,8 @@ class HivelogHiveFilterForm extends FormBase {
     $form['actions']['submit'] = [
       '#type' => 'submit',
       '#value' => $this->t('Filter'),
+      '#button_type' => 'primary',
+      '#attributes' => ['class' => ['hivelog-filter-form__submit']],
     ];
     if ($apiary) {
       $form['actions']['reset'] = [

--- a/src/Form/HivelogInspectionFilterForm.php
+++ b/src/Form/HivelogInspectionFilterForm.php
@@ -103,6 +103,8 @@ class HivelogInspectionFilterForm extends FormBase {
     $form['actions']['submit'] = [
       '#type' => 'submit',
       '#value' => $this->t('Filter'),
+      '#button_type' => 'primary',
+      '#attributes' => ['class' => ['hivelog-filter-form__submit']],
     ];
     if ($hive) {
       $form['actions']['reset'] = [


### PR DESCRIPTION
Follow-up UX polish on top of #39.

## Changes
- **Inline filter bar** on both the apiary and hive pages. The filter container is now flattened into the outer form using `display: contents` so every filter control and the action buttons share a single responsive flex row instead of stacking. Labels become compact captions above their controls.
- **Visible Filter button**: the submit button on both filter forms is now rendered as a primary button so it reads clearly next to the filters.
- **Hive page layout**: the weight histogram is now rendered above the Inspections heading and the Add Inspection action (weight 7), so it reads as a summary of the whole inspection history rather than a companion to the list below.

## Tests
Existing kernel tests still assert the histogram renders before the inspections table and that pagination/filter behaviour works unchanged. Full suite: 80 tests / 791 assertions passing.

## Oz
Conversation: https://app.warp.dev/conversation/9e6cc51b-334f-4483-b7b2-aeafce94fc65

Co-Authored-By: Oz <oz-agent@warp.dev>