### PR TITLE
Add conditional field visibility and sensible defaults to inspection form (#31)

### DIFF
--- a/src/Form/HiveInspectionForm.php
+++ b/src/Form/HiveInspectionForm.php
@@ -14,6 +14,12 @@ class HiveInspectionForm extends ContentEntityForm {
    * {@inheritdoc}
    */
   public function form(array $form, FormStateInterface $form_state) {
+    // Apply sensible defaults for new inspections before building widgets so
+    // the defaults flow through the standard entity field widgets.
+    if ($this->entity->isNew()) {
+      $this->applyNewEntityDefaults();
+    }
+
     $form = parent::form($form, $form_state);
 
     $form['inspection_sections'] = [
@@ -101,15 +107,64 @@ class HiveInspectionForm extends ContentEntityForm {
       $form['queen_brood']['#access'] = FALSE;
     }
 
+    // Hide dependent fields when their controlling boolean is unchecked so
+    // users are not asked for information that is not applicable. With JS
+    // disabled these fields stay visible (non-JS safe) and the server
+    // normalises irrelevant values on submit.
+    if (isset($form['feed_type'])) {
+      $form['feed_type']['#states'] = [
+        'visible' => [
+          ':input[name="fed[value]"]' => ['checked' => TRUE],
+        ],
+      ];
+    }
+    if (isset($form['varroa_count'])) {
+      $form['varroa_count']['#states'] = [
+        'visible' => [
+          ':input[name="varroa_check[value]"]' => ['checked' => TRUE],
+        ],
+      ];
+    }
+
     return $form;
+  }
+
+  /**
+   * Applies sensible defaults on a fresh inspection entity.
+   */
+  protected function applyNewEntityDefaults(): void {
+    $entity = $this->entity;
+    if ($entity->get('inspection_date')->isEmpty()) {
+      $entity->set('inspection_date', date('Y-m-d'));
+    }
+    if ($entity->get('disease_signs')->isEmpty()) {
+      $entity->set('disease_signs', 'none');
+    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
+    // Normalise values of hidden dependent fields before the rest of the
+    // validation runs, so a user who typed a value and then unchecked the
+    // controlling field isn't punished for something the UI hides anyway.
+    $this->normaliseDependentFields($form_state);
+
     parent::validateForm($form, $form_state);
     $this->validateDependentFields($form_state);
+  }
+
+  /**
+   * Clears dependent field values when their controlling field is unchecked.
+   */
+  protected function normaliseDependentFields(FormStateInterface $form_state): void {
+    if (!$this->getBooleanFieldValue($form_state, 'fed')) {
+      $this->clearScalarFieldValue($form_state, 'feed_type', '');
+    }
+    if (!$this->getBooleanFieldValue($form_state, 'varroa_check')) {
+      $this->clearScalarFieldValue($form_state, 'varroa_count', NULL);
+    }
   }
 
   /**
@@ -124,12 +179,6 @@ class HiveInspectionForm extends ContentEntityForm {
         $this->t('Feed type is required when the colony was fed.')
       );
     }
-    if (!$fed && $feed_type !== '') {
-      $form_state->setErrorByName(
-        'feed_type',
-        $this->t('Feed type must be empty unless the colony was fed.')
-      );
-    }
 
     $varroa_check = $this->getBooleanFieldValue($form_state, 'varroa_check');
     $varroa_count = $this->getNullableFieldValue($form_state, 'varroa_count');
@@ -137,12 +186,6 @@ class HiveInspectionForm extends ContentEntityForm {
       $form_state->setErrorByName(
         'varroa_count',
         $this->t('Varroa count is required when a varroa check was performed.')
-      );
-    }
-    if (!$varroa_check && $varroa_count !== NULL) {
-      $form_state->setErrorByName(
-        'varroa_count',
-        $this->t('Varroa count must be empty unless a varroa check was performed.')
       );
     }
   }
@@ -181,6 +224,28 @@ class HiveInspectionForm extends ContentEntityForm {
       return NULL;
     }
     return $value;
+  }
+
+  /**
+   * Replaces a scalar field value, preserving the original shape.
+   */
+  protected function clearScalarFieldValue(FormStateInterface $form_state, string $field_name, mixed $cleared): void {
+    $current = $form_state->getValue($field_name);
+    if (is_array($current)) {
+      if (isset($current[0]) && is_array($current[0]) && array_key_exists('value', $current[0])) {
+        $current[0]['value'] = $cleared;
+      }
+      elseif (array_key_exists('value', $current)) {
+        $current['value'] = $cleared;
+      }
+      else {
+        $current = [['value' => $cleared]];
+      }
+      $form_state->setValue($field_name, $current);
+    }
+    else {
+      $form_state->setValue($field_name, $cleared);
+    }
   }
 
   /**

--- a/tests/src/Kernel/HiveInspectionTest.php
+++ b/tests/src/Kernel/HiveInspectionTest.php
@@ -84,6 +84,35 @@ class HiveInspectionTest extends KernelTestBase {
   }
 
   /**
+   * Runs the full normalise-then-validate sequence the form uses on submit.
+   */
+  protected function normaliseThenValidateDependentInspectionFields(array $values): FormState {
+    $defaults = [
+      'fed' => [['value' => 0]],
+      'feed_type' => [['value' => '']],
+      'varroa_check' => [['value' => 0]],
+      'varroa_count' => [['value' => '']],
+    ];
+
+    $form_state = new FormState();
+    $form_state->setValues(array_replace($defaults, $values));
+
+    /** @var \Drupal\hivelog\Form\HiveInspectionForm $form_object */
+    $form_object = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveInspectionForm::class);
+
+    $normalise = new \ReflectionMethod(HiveInspectionForm::class, 'normaliseDependentFields');
+    $normalise->setAccessible(TRUE);
+    $normalise->invoke($form_object, $form_state);
+
+    $validate = new \ReflectionMethod(HiveInspectionForm::class, 'validateDependentFields');
+    $validate->setAccessible(TRUE);
+    $validate->invoke($form_object, $form_state);
+
+    return $form_state;
+  }
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -567,16 +596,17 @@ class HiveInspectionTest extends KernelTestBase {
   }
 
   /**
-   * Tests feed type must be empty when fed is not checked.
+   * Tests feed type is silently cleared when fed is not checked.
    */
-  public function testValidationRejectsFeedTypeWhenNotFed(): void {
-    $form_state = $this->validateDependentInspectionFields([
+  public function testValidationClearsFeedTypeWhenNotFed(): void {
+    $form_state = $this->normaliseThenValidateDependentInspectionFields([
       'fed' => [['value' => 0]],
       'feed_type' => [['value' => 'Fondant']],
     ]);
 
-    $this->assertTrue($form_state->hasAnyErrors());
-    $this->assertArrayHasKey('feed_type', $form_state->getErrors());
+    $this->assertFalse($form_state->hasAnyErrors());
+    $feed_type = $form_state->getValue('feed_type');
+    $this->assertSame('', $feed_type[0]['value'] ?? NULL);
   }
 
   /**
@@ -593,16 +623,17 @@ class HiveInspectionTest extends KernelTestBase {
   }
 
   /**
-   * Tests varroa count must be empty when no varroa check is performed.
+   * Tests varroa count is silently cleared when varroa check is not performed.
    */
-  public function testValidationRejectsVarroaCountWhenNotChecked(): void {
-    $form_state = $this->validateDependentInspectionFields([
+  public function testValidationClearsVarroaCountWhenNotChecked(): void {
+    $form_state = $this->normaliseThenValidateDependentInspectionFields([
       'varroa_check' => [['value' => 0]],
       'varroa_count' => [['value' => 3]],
     ]);
 
-    $this->assertTrue($form_state->hasAnyErrors());
-    $this->assertArrayHasKey('varroa_count', $form_state->getErrors());
+    $this->assertFalse($form_state->hasAnyErrors());
+    $varroa_count = $form_state->getValue('varroa_count');
+    $this->assertNull($varroa_count[0]['value'] ?? NULL);
   }
 
   /**
@@ -617,6 +648,85 @@ class HiveInspectionTest extends KernelTestBase {
     ]);
 
     $this->assertFalse($form_state->hasAnyErrors());
+  }
+
+  /**
+   * Tests that dependent fields declare #states visibility tied to their
+   * controlling boolean.
+   */
+  public function testInspectionFormHasConditionalStatesOnDependentFields(): void {
+    $inspection = HiveInspection::create([
+      'hive' => $this->hive->id(),
+    ]);
+
+    $form = \Drupal::service('entity.form_builder')->getForm($inspection, 'add');
+
+    $this->assertArrayHasKey('feed_type', $form);
+    $this->assertArrayHasKey('#states', $form['feed_type']);
+    $this->assertEquals(
+      [['checked' => TRUE]],
+      array_values($form['feed_type']['#states']['visible'] ?? [])
+    );
+    $this->assertArrayHasKey(':input[name="fed[value]"]', $form['feed_type']['#states']['visible']);
+
+    $this->assertArrayHasKey('varroa_count', $form);
+    $this->assertArrayHasKey('#states', $form['varroa_count']);
+    $this->assertArrayHasKey(
+      ':input[name="varroa_check[value]"]',
+      $form['varroa_count']['#states']['visible']
+    );
+    $this->assertEquals(
+      ['checked' => TRUE],
+      $form['varroa_count']['#states']['visible'][':input[name="varroa_check[value]"]']
+    );
+  }
+
+  /**
+   * Tests that a new inspection form defaults inspection_date to today.
+   */
+  public function testInspectionFormDefaultsInspectionDateToToday(): void {
+    $inspection = HiveInspection::create([
+      'hive' => $this->hive->id(),
+    ]);
+
+    $form = \Drupal::service('entity.form_builder')->getForm($inspection, 'add');
+
+    $today = date('Y-m-d');
+    $default = $form['inspection_date']['widget'][0]['value']['#default_value'] ?? NULL;
+    $this->assertNotNull($default, 'inspection_date should have a default date set on a new form.');
+    $this->assertEquals($today, $default->format('Y-m-d'));
+  }
+
+  /**
+   * Tests that a new inspection form defaults disease_signs to "none".
+   */
+  public function testInspectionFormDefaultsDiseaseSignsToNone(): void {
+    $inspection = HiveInspection::create([
+      'hive' => $this->hive->id(),
+    ]);
+
+    $form = \Drupal::service('entity.form_builder')->getForm($inspection, 'add');
+
+    $this->assertEquals('none', $form['disease_signs']['widget']['#default_value'][0] ?? NULL);
+  }
+
+  /**
+   * Tests that editing an existing inspection does NOT override saved values.
+   */
+  public function testInspectionFormDoesNotOverrideExistingDefaults(): void {
+    $inspection = HiveInspection::create([
+      'hive' => $this->hive->id(),
+      'inspection_date' => '2023-05-15',
+      'disease_signs' => 'chalkbrood',
+    ]);
+    $inspection->save();
+
+    $form = \Drupal::service('entity.form_builder')->getForm($inspection, 'edit');
+
+    $default_date = $form['inspection_date']['widget'][0]['value']['#default_value'] ?? NULL;
+    $this->assertNotNull($default_date);
+    $this->assertEquals('2023-05-15', $default_date->format('Y-m-d'));
+    $this->assertEquals('chalkbrood', $form['disease_signs']['widget']['#default_value'][0] ?? NULL);
   }
 
 }


### PR DESCRIPTION
Closes #31

## Summary
Reduces cognitive load on the inspection form by hiding dependent fields that only become relevant when a controlling option is selected, and pre-filling the two fields that are the same for almost every inspection.

## Changes
- **Conditional visibility**
  - `feed_type` is hidden unless `fed` is checked.
  - `varroa_count` is hidden unless `varroa_check` is checked.
  - Implemented with Drupal `#states` so it is pure progressive enhancement: with JS disabled the fields stay visible and the form remains fully usable and accessible.
- **Silent normalisation**
  - On submit, if the controlling boolean is unchecked the dependent field value is cleared server-side. This removes the previous "must be empty" validation error that could fire when a user typed a value and then unchecked the controller.
- **Improved defaults (new entities only)**
  - `inspection_date` defaults to today.
  - `disease_signs` defaults to `none`.
  - Editing an existing inspection never overrides saved values.

## Accessibility / Non-JS safety
- `#states` only toggles DOM visibility for JS clients; fields remain in the DOM and in tab order. Without JS every field is shown and the existing required-when validation still protects data integrity.
- Labels, descriptions and required attributes are unchanged.

## Tests
- Updated the two existing "rejects when not checked" tests to assert silent normalisation (`testValidationClearsFeedTypeWhenNotFed`, `testValidationClearsVarroaCountWhenNotChecked`).
- New tests:
  - `testInspectionFormHasConditionalStatesOnDependentFields` — asserts correct `#states` selectors on `feed_type` / `varroa_count`.
  - `testInspectionFormDefaultsInspectionDateToToday` — new form pre-fills today's date.
  - `testInspectionFormDefaultsDiseaseSignsToNone` — new form pre-selects "None".
  - `testInspectionFormDoesNotOverrideExistingDefaults` — editing keeps saved values.

Full suite run: `84 tests, 841 assertions, 0 failures/errors`.

## Oz
Conversation: https://app.warp.dev/conversation/9e6cc51b-334f-4483-b7b2-aeafce94fc65

Co-Authored-By: Oz <oz-agent@warp.dev>