### PR TITLE
Retire the dormant queen_brood field on hive inspections (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ After installation, navigate to **Administration → Structure → HiveLog**
    - **External check (before opening)** — Flight activity, dead bees, signs of
      robbing, wasps, hive weight (hefting)
    - **Queen status** — Queen seen, queen cells present, eggs seen
-   - **Brood** — Brood pattern quality, capped queen brood
-   - **Stores** — Honey stores level, pollen stores level
+   - **Brood, honey and pollen** — Brood pattern quality, honey stores,
+     pollen stores
    - **Colony condition** — Temperament, population strength
    - **Health** — Varroa check performed, mite count, disease signs
    - **Management** — Colony fed, feed type, number of supers, actions taken
@@ -215,6 +215,12 @@ drush cr
    - `10001` — Migrate apiary lat/lng fields to geolocation field.
    - `10002` — Migrate geolocation field from geolocation module to geofield.
    - `10003` — Add `external_check` field to hive inspections.
+   - `10004` — Add `weight` field to hive inspections.
+   - `10005` — Add `images` field to hives.
+   - `10006` — Add `images` field to hive inspections.
+   - `10007` — Retire the dormant `queen_brood` field on hive inspections
+     (data in the removed column is dropped; the swarming / supersedure
+     signal is already captured by `queen_cells`).
 3. `drush cr` — Rebuilds caches so Drupal picks up any changes to entity
    definitions, routing, or services.
 

--- a/hivelog.install
+++ b/hivelog.install
@@ -233,3 +233,23 @@ function hivelog_update_10006(&$sandbox) {
 
   return t('Added images field to hive inspections.');
 }
+
+/**
+ * Retire the dormant queen_brood field on hive inspections.
+ *
+ * The queen_brood boolean was never exposed on the inspection form or the
+ * canonical view and the existing `queen_cells` field already captures the
+ * swarming / supersedure signal, so the data model is simplified by removing
+ * it. Any previously stored value is dropped along with the column.
+ */
+function hivelog_update_10007(&$sandbox) {
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+
+  $queen_brood_definition = $entity_definition_update_manager
+    ->getFieldStorageDefinition('queen_brood', 'hive_inspection');
+  if ($queen_brood_definition) {
+    $entity_definition_update_manager->uninstallFieldStorageDefinition($queen_brood_definition);
+  }
+
+  return t('Retired dormant queen_brood field on hive inspections.');
+}

--- a/src/Entity/HiveInspection.php
+++ b/src/Entity/HiveInspection.php
@@ -210,25 +210,6 @@ class HiveInspection extends ContentEntityBase implements EntityChangedInterface
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
-    $fields['queen_brood'] = BaseFieldDefinition::create('boolean')
-      ->setLabel(t('Queen Brood'))
-      ->setDescription(t('Is capped queen brood present?'))
-      ->setDefaultValue(FALSE)
-      ->setDisplayOptions('form', [
-        'type' => 'boolean_checkbox',
-        'weight' => 7,
-      ])
-      ->setDisplayOptions('view', [
-        'label' => 'inline',
-        'type' => 'boolean',
-        'weight' => 7,
-        'settings' => [
-          'format' => 'yes-no',
-        ],
-      ])
-      ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
-
     // Stores fields.
     $fields['honey_stores'] = BaseFieldDefinition::create('list_string')
       ->setLabel(t('Honey Stores'))

--- a/src/Form/HiveInspectionForm.php
+++ b/src/Form/HiveInspectionForm.php
@@ -101,12 +101,6 @@ class HiveInspectionForm extends ContentEntityForm {
       }
     }
 
-    // Keep the field storage for backward compatibility, but do not expose the
-    // duplicate queen_brood input on the form.
-    if (isset($form['queen_brood'])) {
-      $form['queen_brood']['#access'] = FALSE;
-    }
-
     // Hide dependent fields when their controlling boolean is unchecked so
     // users are not asked for information that is not applicable. With JS
     // disabled these fields stay visible (non-JS safe) and the server

--- a/tests/src/Kernel/HiveInspectionTest.php
+++ b/tests/src/Kernel/HiveInspectionTest.php
@@ -153,7 +153,6 @@ class HiveInspectionTest extends KernelTestBase {
       'queen_cells' => FALSE,
       'eggs_seen' => TRUE,
       'brood_pattern' => 'good',
-      'queen_brood' => TRUE,
       'honey_stores' => 'abundant',
       'pollen_stores' => 'adequate',
       'temperament' => 'calm',
@@ -180,7 +179,6 @@ class HiveInspectionTest extends KernelTestBase {
     $this->assertEquals(FALSE, (bool) $loaded->get('queen_cells')->value);
     $this->assertEquals(TRUE, (bool) $loaded->get('eggs_seen')->value);
     $this->assertEquals('good', $loaded->get('brood_pattern')->value);
-    $this->assertEquals(TRUE, (bool) $loaded->get('queen_brood')->value);
     $this->assertEquals('abundant', $loaded->get('honey_stores')->value);
     $this->assertEquals('adequate', $loaded->get('pollen_stores')->value);
     $this->assertEquals('calm', $loaded->get('temperament')->value);
@@ -378,8 +376,8 @@ class HiveInspectionTest extends KernelTestBase {
 
     $this->assertEquals('overview', $form['hive']['#group']);
     $this->assertEquals('overview', $form['inspection_date']['#group']);
-    $this->assertArrayHasKey('queen_brood', $form);
-    $this->assertFalse($form['queen_brood']['#access']);
+    // queen_brood has been retired; ensure no residual form element remains.
+    $this->assertArrayNotHasKey('queen_brood', $form);
     $this->assertEquals('queen_status', $form['queen_seen']['#group']);
     $this->assertEquals('brood_and_stores', $form['honey_stores']['#group']);
     $this->assertEquals('health', $form['disease_signs']['#group']);
@@ -401,7 +399,6 @@ class HiveInspectionTest extends KernelTestBase {
       'queen_cells' => FALSE,
       'eggs_seen' => TRUE,
       'brood_pattern' => 'good',
-      'queen_brood' => FALSE,
       'honey_stores' => 'adequate',
       'pollen_stores' => 'abundant',
       'temperament' => 'calm',
@@ -708,6 +705,27 @@ class HiveInspectionTest extends KernelTestBase {
     $form = \Drupal::service('entity.form_builder')->getForm($inspection, 'add');
 
     $this->assertEquals('none', $form['disease_signs']['widget']['#default_value'][0] ?? NULL);
+  }
+
+  /**
+   * Tests that the dormant queen_brood field has been fully retired.
+   */
+  public function testQueenBroodFieldIsRetired(): void {
+    $base_fields = \Drupal::service('entity_field.manager')
+      ->getBaseFieldDefinitions('hive_inspection');
+    $this->assertArrayNotHasKey('queen_brood', $base_fields);
+
+    $table_mapping = \Drupal::entityTypeManager()
+      ->getStorage('hive_inspection')
+      ->getTableMapping();
+    $this->assertNotContains(
+      'queen_brood',
+      $table_mapping->getFieldNames('hivelog_hive_inspection')
+    );
+
+    $schema = \Drupal::database()->schema();
+    $this->assertFalse($schema->fieldExists('hivelog_hive_inspection', 'queen_brood'));
+    $this->assertFalse($schema->fieldExists('hivelog_hive_inspection', 'queen_brood__value'));
   }
 
   /**


### PR DESCRIPTION
Closes #32

## Decision
**Deprecate and remove.**

`queen_brood` was defined on `HiveInspection` but never rendered on the inspection form (the form explicitly set `#access = FALSE`) or on the canonical view. The `queen_cells` field already captures the swarming / supersedure signal beekeepers act on, so the dormant field added schema and test complexity without user value.

## Changes
- **Entity**: drop the `queen_brood` base field definition from `HiveInspection`.
- **Form**: drop the `#access = FALSE` opt-out block in `HiveInspectionForm` since there is no longer a field to hide.
- **Update path**: new `hivelog_update_10007()` uninstalls the field storage via `entityDefinitionUpdateManager`, dropping the database column and any persisted data. Sites with existing data run `drush updb` once after deploying.
- **Tests**:
  - Remove `queen_brood` setters and loaded-value assertions from existing inspection tests.
  - Replace the form 'present-but-hidden' assertion with an 'absent' assertion.
  - New `testQueenBroodFieldIsRetired` verifies the field is absent from base field definitions, the entity table mapping and the database schema.
- **Docs**: README inspection section drops the 'capped queen brood' bullet; deployment section documents `10007` (and the previously undocumented `10004`/`10005`/`10006` hooks).

## Tests
Full suite run: `85 tests, 852 assertions, 0 failures/errors`.

## Oz
Conversation: https://app.warp.dev/conversation/9e6cc51b-334f-4483-b7b2-aeafce94fc65

Co-Authored-By: Oz <oz-agent@warp.dev>