### PR TITLE
Refactor controllers to explicit DI and explicit cache metadata (#33)

### DIFF
--- a/src/Controller/ApiaryController.php
+++ b/src/Controller/ApiaryController.php
@@ -2,8 +2,12 @@
 
 namespace Drupal\hivelog\Controller;
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\hivelog\Entity\Apiary;
 use Drupal\hivelog\Form\HivelogHiveFilterForm;
@@ -30,7 +34,17 @@ class ApiaryController extends ControllerBase {
    */
   protected RequestStack $requestStack;
 
-  public function __construct(RequestStack $request_stack) {
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    FormBuilderInterface $form_builder,
+    AccountInterface $current_user,
+    RequestStack $request_stack,
+  ) {
+    // $entityTypeManager / $formBuilder / $currentUser are untyped properties
+    // inherited from ControllerBase; assign rather than redeclare them.
+    $this->entityTypeManager = $entity_type_manager;
+    $this->formBuilder = $form_builder;
+    $this->currentUser = $current_user;
     $this->requestStack = $request_stack;
   }
 
@@ -38,7 +52,12 @@ class ApiaryController extends ControllerBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
-    return new static($container->get('request_stack'));
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('form_builder'),
+      $container->get('current_user'),
+      $container->get('request_stack'),
+    );
   }
 
   /**
@@ -48,7 +67,7 @@ class ApiaryController extends ControllerBase {
     $build = [];
 
     // Render the apiary entity fields.
-    $view_builder = $this->entityTypeManager()->getViewBuilder('apiary');
+    $view_builder = $this->entityTypeManager->getViewBuilder('apiary');
     $build['apiary'] = $view_builder->view($apiary);
 
     // Add hive heading and action link.
@@ -68,12 +87,12 @@ class ApiaryController extends ControllerBase {
     ];
 
     // Filter form.
-    $build['hives_filter'] = $this->formBuilder()->getForm(HivelogHiveFilterForm::class, $apiary);
+    $build['hives_filter'] = $this->formBuilder->getForm(HivelogHiveFilterForm::class, $apiary);
     $build['hives_filter']['#weight'] = 11.5;
 
     // Build the query with filters and pagination applied.
     $filters = $this->extractHiveFilters();
-    $query = $this->entityTypeManager()
+    $query = $this->entityTypeManager
       ->getStorage('hive')
       ->getQuery()
       ->accessCheck(TRUE)
@@ -84,12 +103,11 @@ class ApiaryController extends ControllerBase {
     $hive_ids = $query->execute();
 
     $hives = $hive_ids
-      ? $this->entityTypeManager()->getStorage('hive')->loadMultiple($hive_ids)
+      ? $this->entityTypeManager->getStorage('hive')->loadMultiple($hive_ids)
       : [];
-    $account = $this->currentUser();
     $hives = array_filter(
       $hives,
-      static fn($hive) => $hive->access('view', $account)
+      fn($hive) => $hive->access('view', $this->currentUser)
     );
 
     $header = [
@@ -141,9 +159,21 @@ class ApiaryController extends ControllerBase {
       '#weight' => 13,
     ];
 
-    // Cache this render array per URL query string so pager + filter state
-    // produce distinct cache entries.
-    $build['#cache']['contexts'][] = 'url.query_args';
+    // Explicit cache metadata.
+    // - url.query_args: pager + filter state travels in the query string.
+    // - user.permissions: hive rows are post-filtered by per-entity access,
+    //   so two users with different permissions must not share a cache entry.
+    // - Apiary entity tags: invalidate on apiary update/delete.
+    // - Hive list cache tag + each rendered hive's own tags: invalidate on
+    //   any hive change so the embedded table is never stale.
+    $cache = CacheableMetadata::createFromRenderArray($build)
+      ->addCacheContexts(['url.query_args', 'user.permissions'])
+      ->addCacheableDependency($apiary)
+      ->addCacheTags($this->entityTypeManager->getDefinition('hive')->getListCacheTags());
+    foreach ($hives as $hive) {
+      $cache->addCacheableDependency($hive);
+    }
+    $cache->applyTo($build);
 
     return $build;
   }

--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -2,8 +2,13 @@
 
 namespace Drupal\hivelog\Controller;
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityFormBuilderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Url;
 use Drupal\hivelog\Entity\Apiary;
 use Drupal\hivelog\Entity\Hive;
@@ -31,7 +36,25 @@ class HiveController extends ControllerBase {
    */
   protected RequestStack $requestStack;
 
-  public function __construct(RequestStack $request_stack) {
+  /**
+   * The file URL generator.
+   */
+  protected FileUrlGeneratorInterface $fileUrlGenerator;
+
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityFormBuilderInterface $entity_form_builder,
+    FormBuilderInterface $form_builder,
+    FileUrlGeneratorInterface $file_url_generator,
+    RequestStack $request_stack,
+  ) {
+    // $entityTypeManager / $entityFormBuilder / $formBuilder are untyped
+    // properties inherited from ControllerBase; assign them rather than
+    // redeclaring with types.
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityFormBuilder = $entity_form_builder;
+    $this->formBuilder = $form_builder;
+    $this->fileUrlGenerator = $file_url_generator;
     $this->requestStack = $request_stack;
   }
 
@@ -39,17 +62,23 @@ class HiveController extends ControllerBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
-    return new static($container->get('request_stack'));
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('entity.form_builder'),
+      $container->get('form_builder'),
+      $container->get('file_url_generator'),
+      $container->get('request_stack'),
+    );
   }
 
   /**
    * Provides the add form for a hive within an apiary context.
    */
   public function addForm(Apiary $apiary) {
-    $hive = $this->entityTypeManager()->getStorage('hive')->create([
+    $hive = $this->entityTypeManager->getStorage('hive')->create([
       'apiary' => $apiary->id(),
     ]);
-    return $this->entityFormBuilder()->getForm($hive, 'add');
+    return $this->entityFormBuilder->getForm($hive, 'add');
   }
 
   /**
@@ -59,7 +88,7 @@ class HiveController extends ControllerBase {
     $build = [];
 
     // Render the hive entity fields.
-    $view_builder = $this->entityTypeManager()->getViewBuilder('hive');
+    $view_builder = $this->entityTypeManager->getViewBuilder('hive');
     $build['hive'] = $view_builder->view($hive);
     $build['hive']['#weight'] = 5;
 
@@ -68,7 +97,7 @@ class HiveController extends ControllerBase {
     // so the summary chart is not affected by active filters or paging.
     // Placed above the Inspections heading/Add Inspection action so it
     // reads as a summary of the whole inspection history.
-    $histogram_points = $this->collectHistogramPoints($hive);
+    [$histogram_points, $histogram_inspections] = $this->collectHistogramPoints($hive);
     $histogram = $this->buildWeightHistogram($histogram_points);
     if (!empty($histogram)) {
       $build['weight_histogram'] = $histogram + ['#weight' => 7];
@@ -91,12 +120,12 @@ class HiveController extends ControllerBase {
     ];
 
     // Filter form.
-    $build['inspections_filter'] = $this->formBuilder()->getForm(HivelogInspectionFilterForm::class, $hive);
+    $build['inspections_filter'] = $this->formBuilder->getForm(HivelogInspectionFilterForm::class, $hive);
     $build['inspections_filter']['#weight'] = 11.5;
 
     // Build the paginated + filtered inspection query.
     $filters = $this->extractInspectionFilters();
-    $query = $this->entityTypeManager()
+    $query = $this->entityTypeManager
       ->getStorage('hive_inspection')
       ->getQuery()
       ->accessCheck(TRUE)
@@ -107,7 +136,7 @@ class HiveController extends ControllerBase {
     $inspection_ids = $query->execute();
 
     $inspections = $inspection_ids
-      ? $this->entityTypeManager()->getStorage('hive_inspection')->loadMultiple($inspection_ids)
+      ? $this->entityTypeManager->getStorage('hive_inspection')->loadMultiple($inspection_ids)
       : [];
 
     $header = [
@@ -176,9 +205,26 @@ class HiveController extends ControllerBase {
       $build['images'] = $images + ['#weight' => 20];
     }
 
-    // Cache per URL query string so pager + filter state produce distinct
-    // cache entries.
-    $build['#cache']['contexts'][] = 'url.query_args';
+    // Explicit cache metadata.
+    // - url.query_args: filter + pager state is encoded in the query string.
+    // - user.permissions: the inspection list respects per-entity access
+    //   checks, so cache entries must vary by effective permissions.
+    // - Hive entity tags: invalidate on hive update/delete.
+    // - Inspection list cache tag + every rendered inspection's tags:
+    //   invalidate on any inspection change.
+    $cache = CacheableMetadata::createFromRenderArray($build)
+      ->addCacheContexts(['url.query_args', 'user.permissions'])
+      ->addCacheableDependency($hive)
+      ->addCacheTags($this->entityTypeManager->getDefinition('hive_inspection')->getListCacheTags());
+    foreach ($inspections as $inspection) {
+      $cache->addCacheableDependency($inspection);
+    }
+    // The histogram is derived from a separate unfiltered query, so include
+    // those inspections' cache tags too.
+    foreach ($histogram_inspections as $inspection) {
+      $cache->addCacheableDependency($inspection);
+    }
+    $cache->applyTo($build);
 
     return $build;
   }
@@ -236,10 +282,11 @@ class HiveController extends ControllerBase {
    * The histogram summarises the year of the most recent inspection and is
    * deliberately not restricted by filters or pagination.
    *
-   * @return array<int, array{date:string, mmdd:string, weight:float}>
+   * @return array{0: array<int, array{date:string, mmdd:string, weight:float, year:string}>, 1: \Drupal\hivelog\Entity\HiveInspection[]}
+   *   Tuple of [histogram data points, inspections loaded for the histogram].
    */
   protected function collectHistogramPoints(Hive $hive): array {
-    $inspection_ids = $this->entityTypeManager()
+    $inspection_ids = $this->entityTypeManager
       ->getStorage('hive_inspection')
       ->getQuery()
       ->accessCheck(TRUE)
@@ -248,9 +295,9 @@ class HiveController extends ControllerBase {
       ->execute();
 
     if (!$inspection_ids) {
-      return [];
+      return [[], []];
     }
-    $inspections = $this->entityTypeManager()
+    $inspections = $this->entityTypeManager
       ->getStorage('hive_inspection')
       ->loadMultiple($inspection_ids);
 
@@ -263,7 +310,7 @@ class HiveController extends ControllerBase {
       }
     }
     if (!$most_recent) {
-      return [];
+      return [[], $inspections];
     }
     $year = substr($most_recent, 0, 4);
 
@@ -287,7 +334,7 @@ class HiveController extends ControllerBase {
 
     usort($points, fn($a, $b) => strcmp($a['date'], $b['date']));
 
-    return $points;
+    return [$points, $inspections];
   }
 
   /**
@@ -298,8 +345,7 @@ class HiveController extends ControllerBase {
       return [];
     }
 
-    $file_url_generator = \Drupal::service('file_url_generator');
-    $image_style = \Drupal::entityTypeManager()
+    $image_style = $this->entityTypeManager
       ->getStorage('image_style')
       ->load('thumbnail');
 
@@ -311,7 +357,7 @@ class HiveController extends ControllerBase {
         continue;
       }
 
-      $full_url = $file_url_generator->generateAbsoluteString($file->getFileUri());
+      $full_url = $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri());
       $thumb_url = $image_style ? $image_style->buildUrl($file->getFileUri()) : $full_url;
       $alt = (string) ($item->alt ?? '');
 

--- a/src/Controller/HiveInspectionController.php
+++ b/src/Controller/HiveInspectionController.php
@@ -3,9 +3,15 @@
 namespace Drupal\hivelog\Controller;
 
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityFormBuilderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\hivelog\Entity\Hive;
 use Drupal\hivelog\Entity\HiveInspection;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Controller for Hive Inspection pages.
@@ -13,13 +19,50 @@ use Drupal\hivelog\Entity\HiveInspection;
 class HiveInspectionController extends ControllerBase {
 
   /**
+   * The file URL generator.
+   */
+  protected FileUrlGeneratorInterface $fileUrlGenerator;
+
+  /**
+   * The date formatter.
+   */
+  protected DateFormatterInterface $dateFormatter;
+
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityFormBuilderInterface $entity_form_builder,
+    FileUrlGeneratorInterface $file_url_generator,
+    DateFormatterInterface $date_formatter,
+  ) {
+    // $entityTypeManager and $entityFormBuilder are untyped properties
+    // inherited from ControllerBase; assign them rather than redeclaring
+    // them with types.
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityFormBuilder = $entity_form_builder;
+    $this->fileUrlGenerator = $file_url_generator;
+    $this->dateFormatter = $date_formatter;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('entity.form_builder'),
+      $container->get('file_url_generator'),
+      $container->get('date.formatter'),
+    );
+  }
+
+  /**
    * Provides the add form for an inspection within a hive context.
    */
   public function addForm(Hive $hive) {
-    $inspection = $this->entityTypeManager()->getStorage('hive_inspection')->create([
+    $inspection = $this->entityTypeManager->getStorage('hive_inspection')->create([
       'hive' => $hive->id(),
     ]);
-    return $this->entityFormBuilder()->getForm($inspection, 'add');
+    return $this->entityFormBuilder->getForm($inspection, 'add');
   }
 
   /**
@@ -76,6 +119,15 @@ class HiveInspectionController extends ControllerBase {
       $build['photos'] = $photos;
     }
 
+    // Explicit cache metadata.
+    // - user.permissions: the action buttons depend on the current user's
+    //   update/delete access on the inspection.
+    // - Inspection's own cache tags: invalidate on any update/delete.
+    $cache = CacheableMetadata::createFromRenderArray($build)
+      ->addCacheContexts(['user.permissions'])
+      ->addCacheableDependency($hive_inspection);
+    $cache->applyTo($build);
+
     return $build;
   }
 
@@ -87,8 +139,7 @@ class HiveInspectionController extends ControllerBase {
       return [];
     }
 
-    $file_url_generator = \Drupal::service('file_url_generator');
-    $image_style = \Drupal::entityTypeManager()
+    $image_style = $this->entityTypeManager
       ->getStorage('image_style')
       ->load('thumbnail');
 
@@ -100,7 +151,7 @@ class HiveInspectionController extends ControllerBase {
         continue;
       }
 
-      $full_url = $file_url_generator->generateAbsoluteString($file->getFileUri());
+      $full_url = $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri());
       $thumb_url = $image_style ? $image_style->buildUrl($file->getFileUri()) : $full_url;
       $alt = (string) ($item->alt ?? '');
 
@@ -252,7 +303,9 @@ class HiveInspectionController extends ControllerBase {
       case 'inspection_date':
         $timestamp = strtotime($field->value . ' 00:00:00 UTC');
         return [
-          '#plain_text' => $timestamp !== FALSE ? \Drupal::service('date.formatter')->format($timestamp, 'custom', 'Y-m-d') : (string) $field->value,
+          '#plain_text' => $timestamp !== FALSE
+            ? $this->dateFormatter->format($timestamp, 'custom', 'Y-m-d')
+            : (string) $field->value,
         ];
 
       case 'weight':

--- a/tests/src/Kernel/ControllerCacheMetadataTest.php
+++ b/tests/src/Kernel/ControllerCacheMetadataTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\hivelog\Kernel;
+
+use Drupal\hivelog\Controller\ApiaryController;
+use Drupal\hivelog\Controller\HiveController;
+use Drupal\hivelog\Controller\HiveInspectionController;
+use Drupal\hivelog\Entity\Apiary;
+use Drupal\hivelog\Entity\Hive;
+use Drupal\hivelog\Entity\HiveInspection;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+/**
+ * Tests explicit cache metadata on HiveLog controller views.
+ */
+#[Group('hivelog')]
+#[RunTestsInSeparateProcesses]
+class ControllerCacheMetadataTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'datetime',
+    'options',
+    'file',
+    'image',
+    'geofield',
+    'hivelog',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['system']);
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('apiary');
+    $this->installEntitySchema('hive');
+    $this->installEntitySchema('hive_inspection');
+    $this->installSchema('file', ['file_usage']);
+
+    $user = User::create([
+      'name' => 'tester',
+      'mail' => 'tester@example.com',
+    ]);
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    // FormBuilder requires a session on the current request; ensure one is
+    // present since the controllers build forms.
+    $request = Request::create('/admin/hivelog/apiary/1', 'GET');
+    $request->setSession(new Session(new MockArraySessionStorage()));
+    \Drupal::service('request_stack')->push($request);
+  }
+
+  /**
+   * Tests that the apiary view declares expected cache contexts and tags.
+   */
+  public function testApiaryViewCacheMetadata(): void {
+    $apiary = Apiary::create(['name' => 'Cache Apiary']);
+    $apiary->save();
+
+    $hive = Hive::create([
+      'name' => 'Cache Hive',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ApiaryController::class);
+    $build = $controller->view($apiary);
+
+    $this->assertContains('url.query_args', $build['#cache']['contexts']);
+    $this->assertContains('user.permissions', $build['#cache']['contexts']);
+
+    $hive_list_tags = \Drupal::entityTypeManager()
+      ->getDefinition('hive')
+      ->getListCacheTags();
+    foreach ($hive_list_tags as $tag) {
+      $this->assertContains($tag, $build['#cache']['tags']);
+    }
+
+    foreach ($apiary->getCacheTags() as $tag) {
+      $this->assertContains($tag, $build['#cache']['tags']);
+    }
+    foreach ($hive->getCacheTags() as $tag) {
+      $this->assertContains($tag, $build['#cache']['tags']);
+    }
+  }
+
+  /**
+   * Tests that the hive view declares expected cache contexts and tags.
+   */
+  public function testHiveViewCacheMetadata(): void {
+    $apiary = Apiary::create(['name' => 'Cache Apiary']);
+    $apiary->save();
+
+    $hive = Hive::create([
+      'name' => 'Cache Hive',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    $inspection = HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2024-06-15',
+    ]);
+    $inspection->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+
+    $this->assertContains('url.query_args', $build['#cache']['contexts']);
+    $this->assertContains('user.permissions', $build['#cache']['contexts']);
+
+    $inspection_list_tags = \Drupal::entityTypeManager()
+      ->getDefinition('hive_inspection')
+      ->getListCacheTags();
+    foreach ($inspection_list_tags as $tag) {
+      $this->assertContains($tag, $build['#cache']['tags']);
+    }
+
+    foreach ($hive->getCacheTags() as $tag) {
+      $this->assertContains($tag, $build['#cache']['tags']);
+    }
+    foreach ($inspection->getCacheTags() as $tag) {
+      $this->assertContains($tag, $build['#cache']['tags']);
+    }
+  }
+
+  /**
+   * Tests that the hive inspection view declares expected cache metadata.
+   */
+  public function testHiveInspectionViewCacheMetadata(): void {
+    $apiary = Apiary::create(['name' => 'Cache Apiary']);
+    $apiary->save();
+
+    $hive = Hive::create([
+      'name' => 'Cache Hive',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    $inspection = HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2024-06-15',
+    ]);
+    $inspection->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveInspectionController::class);
+    $build = $controller->view($inspection);
+
+    $this->assertContains('user.permissions', $build['#cache']['contexts']);
+
+    foreach ($inspection->getCacheTags() as $tag) {
+      $this->assertContains($tag, $build['#cache']['tags']);
+    }
+  }
+
+  /**
+   * Tests that each controller can be instantiated from the class resolver,
+   * which exercises the full service-container dependency injection path.
+   */
+  public function testControllersUseDependencyInjection(): void {
+    $class_resolver = \Drupal::service('class_resolver');
+
+    $apiary_controller = $class_resolver->getInstanceFromDefinition(ApiaryController::class);
+    $this->assertInstanceOf(ApiaryController::class, $apiary_controller);
+
+    $hive_controller = $class_resolver->getInstanceFromDefinition(HiveController::class);
+    $this->assertInstanceOf(HiveController::class, $hive_controller);
+
+    $inspection_controller = $class_resolver->getInstanceFromDefinition(HiveInspectionController::class);
+    $this->assertInstanceOf(HiveInspectionController::class, $inspection_controller);
+  }
+
+}


### PR DESCRIPTION
Closes #33

## Summary
All three HiveLog controllers now use constructor / service-container dependency injection and declare explicit cacheability on their view render arrays, so cached responses invalidate on data changes and stay isolated per effective permission set and URL query state.

## Dependency injection
- **ApiaryController** injects `entity_type.manager`, `form_builder`, `current_user` and `request_stack`.
- **HiveController** injects `entity_type.manager`, `entity.form_builder`, `form_builder`, `file_url_generator` and `request_stack`; the `\\Drupal::service('file_url_generator')` call inside `buildImagesGrid()` is removed.
- **HiveInspectionController** injects `entity_type.manager`, `entity.form_builder`, `file_url_generator` and `date.formatter`; the static `\\Drupal::service('file_url_generator')` / `\\Drupal::entityTypeManager()` / `\\Drupal::service('date.formatter')` calls are removed.
- `ControllerBase` already declares untyped protected properties for `entityTypeManager`, `formBuilder`, `entityFormBuilder` and `currentUser`; the constructors assign to those inherited properties rather than redeclaring them with types (which would conflict).

## Cache metadata
- **Apiary view**: contexts `url.query_args` (filters + pager) and `user.permissions` (post-query access check on hives); tags include the apiary entity tags, the `hive` list cache tag and each rendered hive's own tags.
- **Hive view**: contexts `url.query_args` and `user.permissions`; tags include hive entity tags, the `hive_inspection` list cache tag, each rendered inspection's tags, and also the tags of the full inspection set that backs the weight histogram (so the chart invalidates on any inspection change).
- **Hive inspection view**: context `user.permissions` (Edit/Delete action visibility depends on access) and the inspection's own tags.

## Tests
New `ControllerCacheMetadataTest` kernel test asserts the expected contexts and tags on each view build, and that every controller can be instantiated through the `class_resolver` (exercising the full DI wiring).

Full suite run: `89 tests, 903 assertions, 0 failures/errors`.

## Oz
Conversation: https://app.warp.dev/conversation/9e6cc51b-334f-4483-b7b2-aeafce94fc65

Co-Authored-By: Oz <oz-agent@warp.dev>