### PR TITLE
Add functional tests for permissions, tab visibility and CRUD journeys (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,11 @@ ddev exec "SIMPLETEST_DB=mysql://db:db@db:3306/db \
   --group hivelog"
 ```
 
-The suite includes 53 tests covering entity CRUD, relationships, queen colour
-auto-calculation, field option validation, inspection logging, and breadcrumb
-building.
+The suite includes kernel, unit, and functional tests covering entity CRUD,
+relationships, queen colour auto-calculation, field option validation,
+inspection logging, breadcrumb building, controller cache metadata,
+permission-matrix route access, tab visibility, and full add/edit/delete
+browser journeys for every entity type.
 
 ## Deployment
 

--- a/hivelog.info.yml
+++ b/hivelog.info.yml
@@ -4,7 +4,11 @@ description: 'Beekeeping activity logger for managing apiaries, hives, and inspe
 core_version_requirement: ^11
 package: Custom
 dependencies:
+  - drupal:datetime
+  - drupal:file
   - drupal:image
+  - drupal:options
+  - drupal:user
   - geofield:geofield
   - geocoder:geocoder
   - leaflet:leaflet

--- a/tests/src/Functional/EntityCrudJourneyTest.php
+++ b/tests/src/Functional/EntityCrudJourneyTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\hivelog\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\hivelog\Entity\Apiary;
+use Drupal\hivelog\Entity\Hive;
+use Drupal\hivelog\Entity\HiveInspection;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Functional coverage for add/edit/delete happy paths for each entity type.
+ */
+#[Group('hivelog')]
+#[RunTestsInSeparateProcesses]
+class EntityCrudJourneyTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['hivelog'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $admin = $this->drupalCreateUser(['administer hivelog']);
+    $this->drupalLogin($admin);
+  }
+
+  /**
+   * Tests adding, editing and deleting an apiary through the UI.
+   */
+  public function testApiaryCrudJourney(): void {
+    // Create.
+    $this->drupalGet('/admin/hivelog/apiary/add');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->submitForm([
+      'name[0][value]' => 'Home Apiary',
+      'location[0][value]' => 'Back garden',
+      'notes[0][value]' => 'Sheltered spot.',
+    ], 'Save');
+    $this->assertSession()->pageTextContains('Home Apiary');
+
+    $apiaries = \Drupal::entityTypeManager()
+      ->getStorage('apiary')
+      ->loadByProperties(['name' => 'Home Apiary']);
+    $this->assertCount(1, $apiaries);
+    /** @var \Drupal\hivelog\Entity\Apiary $apiary */
+    $apiary = reset($apiaries);
+
+    // Edit.
+    $this->drupalGet('/admin/hivelog/apiary/' . $apiary->id() . '/edit');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->submitForm([
+      'name[0][value]' => 'Home Apiary Renamed',
+    ], 'Save');
+    $reloaded = Apiary::load($apiary->id());
+    $this->assertEquals('Home Apiary Renamed', $reloaded->label());
+
+    // Delete.
+    $this->drupalGet('/admin/hivelog/apiary/' . $apiary->id() . '/delete');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->submitForm([], 'Delete');
+    $this->assertNull(Apiary::load($apiary->id()));
+  }
+
+  /**
+   * Tests adding, editing and deleting a hive through the scoped add route.
+   */
+  public function testHiveCrudJourney(): void {
+    $apiary = Apiary::create(['name' => 'CRUD Apiary']);
+    $apiary->save();
+
+    // Create via the scoped /apiary/{apiary}/hive/add route so the parent
+    // reference is pre-populated by HiveController::addForm().
+    $this->drupalGet('/admin/hivelog/apiary/' . $apiary->id() . '/hive/add');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->submitForm([
+      'name[0][value]' => 'CRUD Hive',
+      'status' => 'active',
+    ], 'Save');
+
+    $hives = \Drupal::entityTypeManager()
+      ->getStorage('hive')
+      ->loadByProperties(['name' => 'CRUD Hive']);
+    $this->assertCount(1, $hives);
+    /** @var \Drupal\hivelog\Entity\Hive $hive */
+    $hive = reset($hives);
+    $this->assertEquals($apiary->id(), $hive->get('apiary')->target_id);
+
+    // Edit.
+    $this->drupalGet('/admin/hivelog/hive/' . $hive->id() . '/edit');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->submitForm([
+      'name[0][value]' => 'CRUD Hive Renamed',
+      'status' => 'inactive',
+    ], 'Save');
+    $reloaded = Hive::load($hive->id());
+    $this->assertEquals('CRUD Hive Renamed', $reloaded->label());
+    $this->assertEquals('inactive', $reloaded->get('status')->value);
+
+    // Delete.
+    $this->drupalGet('/admin/hivelog/hive/' . $hive->id() . '/delete');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->submitForm([], 'Delete');
+    $this->assertNull(Hive::load($hive->id()));
+  }
+
+  /**
+   * Tests adding, editing and deleting an inspection through the scoped add
+   * route.
+   */
+  public function testInspectionCrudJourney(): void {
+    $apiary = Apiary::create(['name' => 'CRUD Apiary']);
+    $apiary->save();
+    $hive = Hive::create([
+      'name' => 'CRUD Hive',
+      'apiary' => $apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    // Create via /hive/{hive}/inspection/add.
+    $this->drupalGet('/admin/hivelog/hive/' . $hive->id() . '/inspection/add');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->submitForm([
+      'inspection_date[0][value][date]' => '2024-06-15',
+      'notes[0][value]' => 'Routine inspection.',
+    ], 'Save');
+
+    $inspections = \Drupal::entityTypeManager()
+      ->getStorage('hive_inspection')
+      ->loadByProperties(['hive' => $hive->id()]);
+    $this->assertCount(1, $inspections);
+    /** @var \Drupal\hivelog\Entity\HiveInspection $inspection */
+    $inspection = reset($inspections);
+    $this->assertEquals('2024-06-15', $inspection->get('inspection_date')->value);
+
+    // Edit.
+    $this->drupalGet('/admin/hivelog/inspection/' . $inspection->id() . '/edit');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->submitForm([
+      'notes[0][value]' => 'Updated notes.',
+    ], 'Save');
+    $reloaded = HiveInspection::load($inspection->id());
+    $this->assertEquals('Updated notes.', $reloaded->get('notes')->value);
+
+    // Delete.
+    $this->drupalGet('/admin/hivelog/inspection/' . $inspection->id() . '/delete');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->submitForm([], 'Delete');
+    $this->assertNull(HiveInspection::load($inspection->id()));
+  }
+
+}

--- a/tests/src/Functional/PermissionMatrixTest.php
+++ b/tests/src/Functional/PermissionMatrixTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\hivelog\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\hivelog\Entity\Apiary;
+use Drupal\hivelog\Entity\Hive;
+use Drupal\hivelog\Entity\HiveInspection;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Functional coverage for the HiveLog permission matrix and tab visibility.
+ */
+#[Group('hivelog')]
+#[RunTestsInSeparateProcesses]
+class PermissionMatrixTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['block', 'hivelog'];
+
+  /**
+   * An apiary used as canonical route fixture.
+   */
+  protected Apiary $apiary;
+
+  /**
+   * A hive used as canonical route fixture.
+   */
+  protected Hive $hive;
+
+  /**
+   * An inspection used as canonical route fixture.
+   */
+  protected HiveInspection $inspection;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Render local task tabs so tab visibility can be asserted.
+    $this->drupalPlaceBlock('local_tasks_block');
+
+    $this->apiary = Apiary::create(['name' => 'Matrix Apiary']);
+    $this->apiary->save();
+
+    $this->hive = Hive::create([
+      'name' => 'Matrix Hive',
+      'apiary' => $this->apiary->id(),
+      'status' => 'active',
+    ]);
+    $this->hive->save();
+
+    $this->inspection = HiveInspection::create([
+      'hive' => $this->hive->id(),
+      'inspection_date' => '2024-06-15',
+    ]);
+    $this->inspection->save();
+  }
+
+  /**
+   * Tests that anonymous users are denied every HiveLog route.
+   */
+  public function testAnonymousHasNoAccess(): void {
+    $paths = [
+      '/admin/hivelog',
+      '/admin/hivelog/hives',
+      '/admin/hivelog/inspections',
+      '/admin/hivelog/apiary/add',
+      '/admin/hivelog/apiary/' . $this->apiary->id(),
+      '/admin/hivelog/apiary/' . $this->apiary->id() . '/edit',
+      '/admin/hivelog/apiary/' . $this->apiary->id() . '/delete',
+      '/admin/hivelog/apiary/' . $this->apiary->id() . '/hive/add',
+      '/admin/hivelog/hive/' . $this->hive->id(),
+      '/admin/hivelog/hive/' . $this->hive->id() . '/edit',
+      '/admin/hivelog/hive/' . $this->hive->id() . '/delete',
+      '/admin/hivelog/hive/' . $this->hive->id() . '/inspection/add',
+      '/admin/hivelog/inspection/' . $this->inspection->id(),
+      '/admin/hivelog/inspection/' . $this->inspection->id() . '/edit',
+      '/admin/hivelog/inspection/' . $this->inspection->id() . '/delete',
+    ];
+
+    foreach ($paths as $path) {
+      $this->drupalGet($path);
+      $this->assertSession()->statusCodeEquals(403);
+    }
+  }
+
+  /**
+   * Tests a view-only user can view but not add/edit/delete entities.
+   */
+  public function testViewOnlyPermissions(): void {
+    $viewer = $this->drupalCreateUser([
+      'view apiary',
+      'view hive',
+      'view hive inspection',
+    ]);
+    $this->drupalLogin($viewer);
+
+    // View is allowed on collections and canonicals.
+    $this->drupalGet('/admin/hivelog');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->drupalGet('/admin/hivelog/apiary/' . $this->apiary->id());
+    $this->assertSession()->statusCodeEquals(200);
+    $this->drupalGet('/admin/hivelog/hive/' . $this->hive->id());
+    $this->assertSession()->statusCodeEquals(200);
+    $this->drupalGet('/admin/hivelog/inspection/' . $this->inspection->id());
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Add/edit/delete routes are denied.
+    foreach ([
+      '/admin/hivelog/apiary/add',
+      '/admin/hivelog/apiary/' . $this->apiary->id() . '/edit',
+      '/admin/hivelog/apiary/' . $this->apiary->id() . '/delete',
+      '/admin/hivelog/apiary/' . $this->apiary->id() . '/hive/add',
+      '/admin/hivelog/hive/' . $this->hive->id() . '/edit',
+      '/admin/hivelog/hive/' . $this->hive->id() . '/delete',
+      '/admin/hivelog/hive/' . $this->hive->id() . '/inspection/add',
+      '/admin/hivelog/inspection/' . $this->inspection->id() . '/edit',
+      '/admin/hivelog/inspection/' . $this->inspection->id() . '/delete',
+    ] as $denied_path) {
+      $this->drupalGet($denied_path);
+      $this->assertSession()->statusCodeEquals(403);
+    }
+
+    // On canonical pages the Edit and Delete tabs must NOT be visible.
+    $this->drupalGet('/admin/hivelog/apiary/' . $this->apiary->id());
+    $this->assertSession()->linkByHrefNotExists('/admin/hivelog/apiary/' . $this->apiary->id() . '/edit');
+    $this->assertSession()->linkByHrefNotExists('/admin/hivelog/apiary/' . $this->apiary->id() . '/delete');
+  }
+
+  /**
+   * Tests that administer hivelog bypasses every per-operation permission.
+   */
+  public function testAdministerHivelogBypassesGranularChecks(): void {
+    $admin = $this->drupalCreateUser(['administer hivelog']);
+    $this->drupalLogin($admin);
+
+    $routes = [
+      '/admin/hivelog',
+      '/admin/hivelog/hives',
+      '/admin/hivelog/inspections',
+      '/admin/hivelog/apiary/add',
+      '/admin/hivelog/apiary/' . $this->apiary->id(),
+      '/admin/hivelog/apiary/' . $this->apiary->id() . '/edit',
+      '/admin/hivelog/apiary/' . $this->apiary->id() . '/delete',
+      '/admin/hivelog/apiary/' . $this->apiary->id() . '/hive/add',
+      '/admin/hivelog/hive/' . $this->hive->id(),
+      '/admin/hivelog/hive/' . $this->hive->id() . '/edit',
+      '/admin/hivelog/hive/' . $this->hive->id() . '/delete',
+      '/admin/hivelog/hive/' . $this->hive->id() . '/inspection/add',
+      '/admin/hivelog/inspection/' . $this->inspection->id(),
+      '/admin/hivelog/inspection/' . $this->inspection->id() . '/edit',
+      '/admin/hivelog/inspection/' . $this->inspection->id() . '/delete',
+    ];
+
+    foreach ($routes as $path) {
+      $this->drupalGet($path);
+      $this->assertSession()->statusCodeEquals(200);
+    }
+
+    // Canonical apiary page exposes Edit and Delete tabs for admins.
+    $this->drupalGet('/admin/hivelog/apiary/' . $this->apiary->id());
+    $this->assertSession()->linkByHrefExists('/admin/hivelog/apiary/' . $this->apiary->id() . '/edit');
+    $this->assertSession()->linkByHrefExists('/admin/hivelog/apiary/' . $this->apiary->id() . '/delete');
+  }
+
+  /**
+   * Tests that an editor can edit but not delete without delete permission.
+   */
+  public function testEditOnlyPermission(): void {
+    $editor = $this->drupalCreateUser([
+      'view hive',
+      'edit hive',
+    ]);
+    $this->drupalLogin($editor);
+
+    $this->drupalGet('/admin/hivelog/hive/' . $this->hive->id());
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Edit tab is visible; Delete tab is not.
+    $this->assertSession()->linkByHrefExists('/admin/hivelog/hive/' . $this->hive->id() . '/edit');
+    $this->assertSession()->linkByHrefNotExists('/admin/hivelog/hive/' . $this->hive->id() . '/delete');
+
+    $this->drupalGet('/admin/hivelog/hive/' . $this->hive->id() . '/edit');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $this->drupalGet('/admin/hivelog/hive/' . $this->hive->id() . '/delete');
+    $this->assertSession()->statusCodeEquals(403);
+  }
+
+}


### PR DESCRIPTION
Closes #34

## Summary
New `BrowserTestBase` coverage validates route access, tab visibility, and complete add/edit/delete journeys end-to-end for every HiveLog entity, complementing the existing kernel/unit tests.

## New tests
### `tests/src/Functional/PermissionMatrixTest.php`
- Anonymous users get `403` on every HiveLog route.
- View-only permissions allow collection + canonical pages but not add/edit/delete, and no Edit/Delete tabs render on canonical pages.
- `administer hivelog` bypasses every granular per-operation permission and surfaces the Edit/Delete tabs.
- Edit-only users see the Edit tab but not Delete, and are denied the delete route.
- The `local_tasks_block` is placed in `setUp()` so tab visibility is actually rendered under the `stark` test theme.

### `tests/src/Functional/EntityCrudJourneyTest.php`
- Apiary, Hive and HiveInspection each get a full **add → verify → edit → verify → delete → verify** browser journey as an `administer hivelog` user.
- Hive creation uses the scoped `/apiary/{apiary}/hive/add` route to confirm the parent reference is pre-populated by `HiveController::addForm()`.
- Inspection creation uses the scoped `/hive/{hive}/inspection/add` route for the same reason.

Both classes carry `@group hivelog` and `#[RunTestsInSeparateProcesses]` (required in Drupal 11.3+ for functional tests).

## Supporting fix
`hivelog.info.yml` now declares the core modules whose field types the entities already rely on (`drupal:datetime`, `drupal:file`, `drupal:options`, `drupal:user`). Without these, a fresh install via `BrowserTestBase` fails with "field_item:list_string plugin does not exist". Kernel tests pass either way because they enable these modules explicitly.

## Docs
README updated to describe the expanded suite (kernel, unit, functional).

## Tests
Full suite run: `96 tests, 1017 assertions, 0 failures/errors`.

## Oz
Conversation: https://app.warp.dev/conversation/9e6cc51b-334f-4483-b7b2-aeafce94fc65

Co-Authored-By: Oz <oz-agent@warp.dev>