### PR TITLE
Remove unused geocoder dependency (#35)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,11 @@ three custom content entities with a strict parent–child hierarchy:
 Apiary → Hive → Hive Inspection
 ```
 
-Required contrib dependencies: `geofield`, `geocoder`, `leaflet` (see
-`hivelog.info.yml`).
+Required contrib dependencies: `geofield`, `leaflet` (see
+`hivelog.info.yml`). The geocoder module is intentionally NOT a dependency:
+the apiary map widget is `leaflet_widget_default`, not a geocoder-backed
+widget, and nothing else in the module talks to geocoder services. Do not
+reintroduce the dependency without adding and documenting a concrete use.
 
 ## Common Commands
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Apiary → Hive → Hive Inspection
 
 - Drupal 11
 - [Geofield](https://www.drupal.org/project/geofield) module — provides the geofield field type for storing geospatial data
-- [Geocoder](https://www.drupal.org/project/geocoder) module — provides geocoding services
 - [Leaflet](https://www.drupal.org/project/leaflet) module — provides Leaflet/OpenStreetMap map display and interactive map widget
 
 ## Installation
@@ -211,8 +210,8 @@ drush cr
 
 **Step summary:**
 
-1. `composer install` — Ensures all PHP dependencies (including geofield,
-   geocoder, leaflet) are present.
+1. `composer install` — Ensures all PHP dependencies (including geofield and
+   leaflet) are present.
 2. `drush updb` — Runs any pending database update hooks. Current hooks:
    - `10001` — Migrate apiary lat/lng fields to geolocation field.
    - `10002` — Migrate geolocation field from geolocation module to geofield.

--- a/hivelog.info.yml
+++ b/hivelog.info.yml
@@ -10,5 +10,4 @@ dependencies:
   - drupal:options
   - drupal:user
   - geofield:geofield
-  - geocoder:geocoder
   - leaflet:leaflet

--- a/tests/src/Kernel/ModuleDependencyAuditTest.php
+++ b/tests/src/Kernel/ModuleDependencyAuditTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\hivelog\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Guards the declared module dependency set.
+ *
+ * The geocoder module was removed after an audit confirmed nothing in the
+ * hivelog codebase consumes it: the apiary map widget is
+ * leaflet_widget_default, which does not require geocoder, and no
+ * geocoder service is invoked anywhere in the module. This test keeps that
+ * decision from silently regressing.
+ */
+#[Group('hivelog')]
+#[RunTestsInSeparateProcesses]
+class ModuleDependencyAuditTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'datetime',
+    'options',
+    'file',
+    'image',
+    'geofield',
+    'hivelog',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('apiary');
+    $this->installEntitySchema('hive');
+    $this->installEntitySchema('hive_inspection');
+    $this->installSchema('file', ['file_usage']);
+  }
+
+  /**
+   * Asserts hivelog.info.yml does not declare the geocoder dependency.
+   */
+  public function testGeocoderIsNotDeclaredAsDependency(): void {
+    $info = \Drupal::service('extension.list.module')->getExtensionInfo('hivelog');
+    $dependencies = $info['dependencies'] ?? [];
+    foreach ($dependencies as $dependency) {
+      $this->assertStringNotContainsString(
+        'geocoder',
+        $dependency,
+        'hivelog must not depend on geocoder unless a concrete use is added.'
+      );
+    }
+  }
+
+  /**
+   * Asserts the module keeps functioning with geocoder absent.
+   *
+   * The test explicitly does not list 'geocoder' in $modules, so installing
+   * hivelog and the entity schemas without it exercises the removed
+   * dependency. A failure here most likely means something reintroduced a
+   * geocoder service call or plugin expectation.
+   */
+  public function testInstallsWithoutGeocoder(): void {
+    $module_handler = \Drupal::moduleHandler();
+    $this->assertTrue($module_handler->moduleExists('hivelog'));
+    $this->assertFalse($module_handler->moduleExists('geocoder'));
+
+    $entity_type_manager = \Drupal::entityTypeManager();
+    $this->assertNotNull($entity_type_manager->getDefinition('apiary'));
+    $this->assertNotNull($entity_type_manager->getDefinition('hive'));
+    $this->assertNotNull($entity_type_manager->getDefinition('hive_inspection'));
+  }
+
+}


### PR DESCRIPTION
Closes #35

## Audit outcome
The geocoder module is **not used** anywhere in HiveLog:
- A repo-wide `grep` for `geocoder` only matches `hivelog.info.yml`, `README.md` and `AGENTS.md` — no PHP code references geocoder services, plugins, widgets or formatters.
- The apiary map widget is `leaflet_widget_default` (provided by the `leaflet` module). That widget lets the user click / drag a marker on a Leaflet map and writes the resulting WKT back to the `geofield`; it does **not** call geocoder or any address-to-coordinates service.
- There is no address field, no reverse-geocoding, and no Views plugin that pulls geocoder in via config.

Decision: **remove**.

## Changes
- `hivelog.info.yml`: drop `geocoder:geocoder` from the dependency list so the module no longer forces the geocoder module to be installed.
- `README.md`: "Requirements" no longer lists Geocoder; the "composer install" deployment note drops the geocoder mention.
- `AGENTS.md`: explicitly calls out that geocoder is intentionally not a dependency, so it can't silently creep back in without a concrete use.
- New `ModuleDependencyAuditTest` kernel test:
  - `testGeocoderIsNotDeclaredAsDependency` reads the module info via `extension.list.module` and asserts no dependency string contains `geocoder`.
  - `testInstallsWithoutGeocoder` installs hivelog and its entity schemas with geocoder explicitly absent from `$modules` and verifies the module and its entity types register cleanly.

## Tests
Full suite run (kernel + unit + functional): `98 tests, 1047 assertions, 0 failures/errors`.

## Oz
Conversation: https://app.warp.dev/conversation/9e6cc51b-334f-4483-b7b2-aeafce94fc65

Co-Authored-By: Oz <oz-agent@warp.dev>