### PR TITLE
Render filters inline with the list action button on one row (#44)

### DIFF
--- a/css/hivelog.filter-form.css
+++ b/css/hivelog.filter-form.css
@@ -1,7 +1,30 @@
 /**
  * @file
- * Styling for the embedded child table filter forms.
+ * Styling for the embedded child table filter forms and the toolbar that
+ * places them inline with the list-level action button.
  */
+
+/* Toolbar row that holds the filter form (left) and the action button
+   (right). Used on the apiary and hive view pages. */
+.hivelog-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 0.75rem 1rem;
+  margin: 0.5rem 0 1rem;
+}
+
+.hivelog-toolbar > .hivelog-filter-form {
+  flex: 1 1 auto;
+  margin: 0;
+}
+
+.hivelog-toolbar__action {
+  align-self: flex-end;
+  margin: 0;
+  white-space: nowrap;
+}
 
 .hivelog-filter-form {
   display: flex;

--- a/src/Controller/ApiaryController.php
+++ b/src/Controller/ApiaryController.php
@@ -78,17 +78,21 @@ class ApiaryController extends ControllerBase {
       '#weight' => 10,
     ];
 
-    $build['add_hive'] = [
-      '#type' => 'link',
-      '#title' => $this->t('Add Hive'),
-      '#url' => Url::fromRoute('hivelog.hive.add', ['apiary' => $apiary->id()]),
-      '#attributes' => ['class' => ['button', 'button--primary']],
+    // Toolbar: filter form on the left, Add Hive action on the right.
+    $build['hives_toolbar'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['hivelog-toolbar']],
       '#weight' => 11,
+      'filter' => $this->formBuilder->getForm(HivelogHiveFilterForm::class, $apiary),
+      'add' => [
+        '#type' => 'link',
+        '#title' => $this->t('Add Hive'),
+        '#url' => Url::fromRoute('hivelog.hive.add', ['apiary' => $apiary->id()]),
+        '#attributes' => [
+          'class' => ['button', 'button--primary', 'hivelog-toolbar__action'],
+        ],
+      ],
     ];
-
-    // Filter form.
-    $build['hives_filter'] = $this->formBuilder->getForm(HivelogHiveFilterForm::class, $apiary);
-    $build['hives_filter']['#weight'] = 11.5;
 
     // Build the query with filters and pagination applied.
     $filters = $this->extractHiveFilters();

--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -111,17 +111,21 @@ class HiveController extends ControllerBase {
       '#weight' => 10,
     ];
 
-    $build['add_inspection'] = [
-      '#type' => 'link',
-      '#title' => $this->t('Add Inspection'),
-      '#url' => Url::fromRoute('hivelog.inspection.add', ['hive' => $hive->id()]),
-      '#attributes' => ['class' => ['button', 'button--primary']],
+    // Toolbar: filter form on the left, Add Inspection action on the right.
+    $build['inspections_toolbar'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['hivelog-toolbar']],
       '#weight' => 11,
+      'filter' => $this->formBuilder->getForm(HivelogInspectionFilterForm::class, $hive),
+      'add' => [
+        '#type' => 'link',
+        '#title' => $this->t('Add Inspection'),
+        '#url' => Url::fromRoute('hivelog.inspection.add', ['hive' => $hive->id()]),
+        '#attributes' => [
+          'class' => ['button', 'button--primary', 'hivelog-toolbar__action'],
+        ],
+      ],
     ];
-
-    // Filter form.
-    $build['inspections_filter'] = $this->formBuilder->getForm(HivelogInspectionFilterForm::class, $hive);
-    $build['inspections_filter']['#weight'] = 11.5;
 
     // Build the paginated + filtered inspection query.
     $filters = $this->extractInspectionFilters();

--- a/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
+++ b/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
@@ -394,10 +394,22 @@ class EmbeddedTableFilterPaginationTest extends KernelTestBase {
       ->getInstanceFromDefinition(ApiaryController::class);
     $build = $controller->view($apiary);
 
-    $filter = $build['hives_filter'];
+    $filter = $build['hives_toolbar']['filter'];
     $this->assertEquals('get', $filter['#method']);
     $this->assertEquals('active', $filter['filters']['status']['#default_value']);
     $this->assertEquals('Hive', $filter['filters']['name']['#default_value']);
+
+    // Toolbar wraps the filter form and the Add Hive action link in one
+    // container so they can be rendered on the same row.
+    $this->assertArrayHasKey('add', $build['hives_toolbar']);
+    $this->assertContains(
+      'hivelog-toolbar__action',
+      $build['hives_toolbar']['add']['#attributes']['class']
+    );
+    $this->assertContains(
+      'hivelog-toolbar',
+      $build['hives_toolbar']['#attributes']['class']
+    );
   }
 
 }


### PR DESCRIPTION
Closes #44

## Summary
On the apiary and hive view pages the child-list filter form now shares a single toolbar row with the list-level action button. The filter form is left-aligned and the `Add Hive` / `Add Inspection` button sits right-aligned on the same line, exactly as the issue requested.

## Changes
- `ApiaryController::view` now wraps the filter form and the `Add Hive` link inside a `hives_toolbar` container instead of rendering them as top-level siblings.
- `HiveController::view` does the same with an `inspections_toolbar` container holding the inspection filter and the `Add Inspection` link.
- New `hivelog-toolbar` CSS class (flex, justify-content: space-between, align-items: flex-end, flex-wrap: wrap). Inside the toolbar the filter form drops its outer margin and grows to fill space (`flex: 1 1 auto`), while the action gets a `hivelog-toolbar__action` class (`white-space: nowrap`) so it stays on one line and aligned to the end of the row. On narrow viewports the row wraps gracefully.

## Tests
`EmbeddedTableFilterPaginationTest::testFilterFormIsGetAndPreservesDefaults` now reads the filter from `$build['hives_toolbar']['filter']` and additionally asserts that the toolbar container carries the `hivelog-toolbar` class, that the Add link is nested under it as `add`, and that it carries the `hivelog-toolbar__action` class.

Full suite (kernel + unit + functional): `98 tests, 1050 assertions, 0 failures/errors`.

## Oz
Conversation: https://app.warp.dev/conversation/9e6cc51b-334f-4483-b7b2-aeafce94fc65

Co-Authored-By: Oz <oz-agent@warp.dev>