### PR TITLE
Replace PHPUnit doc-comment metadata with attributes

### DIFF
--- a/tests/src/Unit/Breadcrumb/HivelogBreadcrumbBuilderTest.php
+++ b/tests/src/Unit/Breadcrumb/HivelogBreadcrumbBuilderTest.php
@@ -9,6 +9,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\hivelog\Breadcrumb\HivelogBreadcrumbBuilder;
 use Drupal\Tests\UnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -53,9 +54,9 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   // -------------------------------------------------------------------------
 
   /**
-   * @covers ::applies
-   * @dataProvider apiaryRouteProvider
+   * Tests that applies() returns TRUE for apiary entity routes.
    */
+  #[DataProvider('apiaryRouteProvider')]
   public function testAppliesReturnsTrueForApiaryRoutes(string $route_name): void {
     $this->assertTrue($this->builder->applies($this->createRouteMatch($route_name)));
   }
@@ -74,9 +75,9 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::applies
-   * @dataProvider hiveRouteProvider
+   * Tests that applies() returns TRUE for hive entity routes.
    */
+  #[DataProvider('hiveRouteProvider')]
   public function testAppliesReturnsTrueForHiveRoutes(string $route_name): void {
     $this->assertTrue($this->builder->applies($this->createRouteMatch($route_name)));
   }
@@ -93,9 +94,9 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::applies
-   * @dataProvider hiveInspectionRouteProvider
+   * Tests that applies() returns TRUE for hive_inspection entity routes.
    */
+  #[DataProvider('hiveInspectionRouteProvider')]
   public function testAppliesReturnsTrueForHiveInspectionRoutes(string $route_name): void {
     $this->assertTrue($this->builder->applies($this->createRouteMatch($route_name)));
   }
@@ -112,9 +113,9 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::applies
-   * @dataProvider hivelogCustomRouteProvider
+   * Tests that applies() returns TRUE for hivelog.* custom routes.
    */
+  #[DataProvider('hivelogCustomRouteProvider')]
   public function testAppliesReturnsTrueForHivelogCustomRoutes(string $route_name): void {
     $this->assertTrue($this->builder->applies($this->createRouteMatch($route_name)));
   }
@@ -131,9 +132,9 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::applies
-   * @dataProvider unrelatedRouteProvider
+   * Tests that applies() returns FALSE for unrelated routes.
    */
+  #[DataProvider('unrelatedRouteProvider')]
   public function testAppliesReturnsFalseForUnrelatedRoutes(string $route_name): void {
     $this->assertFalse($this->builder->applies($this->createRouteMatch($route_name)));
   }
@@ -156,8 +157,6 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   // -------------------------------------------------------------------------
 
   /**
-   * @covers ::build
-   *
    * Apiary collection: no entity parameters → 3 base links only.
    */
   public function testBuildApiaryCollection(): void {
@@ -178,8 +177,6 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::build
-   *
    * Apiary canonical: apiary is the current page so it is NOT appended to the
    * trail, but its cache tags are still added.
    */
@@ -200,8 +197,6 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::build
-   *
    * Apiary edit: apiary is an ancestor, so its link IS added (4 links total).
    */
   public function testBuildApiaryEditForm(): void {
@@ -224,8 +219,6 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::build
-   *
    * Hive canonical: hive is the current page; apiary ancestor link is added,
    * hive link is NOT.
    */
@@ -250,8 +243,6 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::build
-   *
    * Hive edit: apiary and hive ancestor links are both added (5 links total).
    */
   public function testBuildHiveEditForm(): void {
@@ -275,8 +266,6 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::build
-   *
    * Inspection canonical: inspection is the current page; apiary and hive
    * ancestor links are added, inspection link is NOT.
    */
@@ -303,8 +292,6 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::build
-   *
    * Inspection edit: apiary, hive, and inspection ancestor links all added
    * (6 links total).
    */
@@ -331,8 +318,6 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::build
-   *
    * hivelog.hive.add carries an {apiary} route parameter; the apiary link
    * should be added as an ancestor (4 links total).
    */
@@ -354,8 +339,6 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::build
-   *
    * hivelog.inspection.add carries a {hive} route parameter; apiary and hive
    * ancestor links should both be added (5 links total).
    */


### PR DESCRIPTION
## Summary

Silences the 14 PHPUnit test-runner deprecations reported by the hivelog test suite by converting doc-comment metadata in `HivelogBreadcrumbBuilderTest` to PHP attributes. These warnings were for annotations that PHPUnit 12 will stop supporting.

## Changes

- Added `PHPUnit\Framework\Attributes\DataProvider` import.
- Replaced every `@dataProvider xxx` docblock tag on the parameterised `applies()` tests with `#[DataProvider('xxx')]` attributes.
- Removed the redundant `@covers ::applies` / `@covers ::build` tags; the class-level `#[CoversClass(HivelogBreadcrumbBuilder::class)]` already declares coverage for the whole class, and `#[CoversMethod]` cannot be used on methods.

## Test plan

Full module test suite (kernel + unit + functional, `hivelog` group):

```
ddev exec \"SIMPLETEST_DB=mysql://db:db@db:3306/db \\
  SIMPLETEST_BASE_URL=http://web \\
  php /var/www/html/vendor/bin/phpunit \\
  -c /var/www/html/web/core \\
  /var/www/html/web/modules/hivelog/tests/ \\
  --group hivelog\"
```

Result: **98 tests, 1050 assertions, 0 failures**.

- PHPUnit test-runner deprecations: **14 → 0**
- Runtime deprecations: 23 → 23 (all in contrib modules, out of scope for this module).

## Out of scope

The remaining 23 runtime deprecations originate from contrib modules (leaflet, metatag, webform, token, easy_breadcrumb, focal_point, autosave_form, field_group, klaro, scheduler, etc.) emitting Drupal 11.2 / 11.3 hook-attribute migration notices (`#[LegacyRequirementsHook]`, `#[LegacyModuleImplementsAlter]`) and interface return-type hints. They must be fixed upstream.

---

[View conversation](https://app.warp.dev/conversation/8110ffa2-ba81-4d80-974c-5a120dc4b87a)

Co-Authored-By: Oz <oz-agent@warp.dev>