### PR TITLE
Move Add action to heading and keep filter actions out of the top bar

### DIFF
--- a/css/hivelog.filter-form.css
+++ b/css/hivelog.filter-form.css
@@ -1,27 +1,24 @@
 /**
  * @file
- * Styling for the embedded child table filter forms and the toolbar that
- * places them inline with the list-level action button.
+ * Styling for the embedded child-list heading row (title + Add action)
+ * and the filter form that sits on its own row below it.
  */
 
-/* Toolbar row that holds the filter form (left) and the action button
-   (right). Used on the apiary and hive view pages. */
-.hivelog-toolbar {
+/* Heading row: list title on the left, Add action button on the right. */
+.hivelog-list-heading {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  align-items: flex-end;
-  gap: 0.75rem 1rem;
-  margin: 0.5rem 0 1rem;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  margin: 1rem 0 0.5rem;
 }
 
-.hivelog-toolbar > .hivelog-filter-form {
-  flex: 1 1 auto;
+.hivelog-list-heading__title {
   margin: 0;
 }
 
-.hivelog-toolbar__action {
-  align-self: flex-end;
+.hivelog-list-heading__action {
   margin: 0;
   white-space: nowrap;
 }
@@ -54,11 +51,13 @@
   margin-bottom: 0.15rem;
 }
 
+/* Push the Filter / Reset actions to the right end of the filter row so
+   they sit on the right-hand side of the filter inputs. */
 .hivelog-filter-form__actions {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin: 0;
+  margin: 0 0 0 auto;
   padding: 0;
 }
 

--- a/src/Controller/ApiaryController.php
+++ b/src/Controller/ApiaryController.php
@@ -70,29 +70,35 @@ class ApiaryController extends ControllerBase {
     $view_builder = $this->entityTypeManager->getViewBuilder('apiary');
     $build['apiary'] = $view_builder->view($apiary);
 
-    // Add hive heading and action link.
+    // Heading row: the "Hives" title on the left, the Add Hive action on
+    // the right. Placing the action here (rather than inline with the
+    // filter form below) keeps it at the top-right of the list section
+    // where it logically belongs.
     $build['hives_heading'] = [
-      '#type' => 'html_tag',
-      '#tag' => 'h3',
-      '#value' => $this->t('Hives'),
-      '#weight' => 10,
-    ];
-
-    // Toolbar: filter form on the left, Add Hive action on the right.
-    $build['hives_toolbar'] = [
       '#type' => 'container',
-      '#attributes' => ['class' => ['hivelog-toolbar']],
-      '#weight' => 11,
-      'filter' => $this->formBuilder->getForm(HivelogHiveFilterForm::class, $apiary),
+      '#attributes' => ['class' => ['hivelog-list-heading']],
+      '#weight' => 10,
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Hives'),
+        '#attributes' => ['class' => ['hivelog-list-heading__title']],
+      ],
       'add' => [
         '#type' => 'link',
         '#title' => $this->t('Add Hive'),
         '#url' => Url::fromRoute('hivelog.hive.add', ['apiary' => $apiary->id()]),
         '#attributes' => [
-          'class' => ['button', 'button--primary', 'hivelog-toolbar__action'],
+          'class' => ['button', 'button--primary', 'hivelog-list-heading__action'],
         ],
       ],
     ];
+
+    // Filter form sits on its own row below the heading. The form's own
+    // CSS pushes the Filter / Reset buttons to the right-hand side of the
+    // filter row.
+    $build['hives_filter'] = $this->formBuilder->getForm(HivelogHiveFilterForm::class, $apiary);
+    $build['hives_filter']['#weight'] = 11;
 
     // Build the query with filters and pagination applied.
     $filters = $this->extractHiveFilters();

--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -103,29 +103,35 @@ class HiveController extends ControllerBase {
       $build['weight_histogram'] = $histogram + ['#weight' => 7];
     }
 
-    // Add inspections heading and action link.
+    // Heading row: the "Inspections" title on the left, the Add Inspection
+    // action on the right. Placing the action here (rather than inline
+    // with the filter form below) keeps it at the top-right of the list
+    // section where it logically belongs.
     $build['inspections_heading'] = [
-      '#type' => 'html_tag',
-      '#tag' => 'h3',
-      '#value' => $this->t('Inspections'),
-      '#weight' => 10,
-    ];
-
-    // Toolbar: filter form on the left, Add Inspection action on the right.
-    $build['inspections_toolbar'] = [
       '#type' => 'container',
-      '#attributes' => ['class' => ['hivelog-toolbar']],
-      '#weight' => 11,
-      'filter' => $this->formBuilder->getForm(HivelogInspectionFilterForm::class, $hive),
+      '#attributes' => ['class' => ['hivelog-list-heading']],
+      '#weight' => 10,
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Inspections'),
+        '#attributes' => ['class' => ['hivelog-list-heading__title']],
+      ],
       'add' => [
         '#type' => 'link',
         '#title' => $this->t('Add Inspection'),
         '#url' => Url::fromRoute('hivelog.inspection.add', ['hive' => $hive->id()]),
         '#attributes' => [
-          'class' => ['button', 'button--primary', 'hivelog-toolbar__action'],
+          'class' => ['button', 'button--primary', 'hivelog-list-heading__action'],
         ],
       ],
     ];
+
+    // Filter form sits on its own row below the heading. The form's own
+    // CSS pushes the Filter / Reset buttons to the right-hand side of the
+    // filter row.
+    $build['inspections_filter'] = $this->formBuilder->getForm(HivelogInspectionFilterForm::class, $hive);
+    $build['inspections_filter']['#weight'] = 11;
 
     // Build the paginated + filtered inspection query.
     $filters = $this->extractInspectionFilters();

--- a/src/Form/HivelogHiveFilterForm.php
+++ b/src/Form/HivelogHiveFilterForm.php
@@ -94,18 +94,25 @@ class HivelogHiveFilterForm extends FormBase {
       '#default_value' => $query ? (string) $query->get('name', '') : '',
     ];
 
-    $form['actions'] = [
-      '#type' => 'actions',
+    // Deliberately named 'filter_actions' (not 'actions') and typed as a
+    // plain container so admin themes such as Gin do not treat these as
+    // form-level actions and relocate them into their sticky top bar
+    // (top-bar__actions). Gin's form alter keys off $form['actions'] to
+    // decide whether to hoist buttons; using a different key keeps the
+    // Filter and Reset controls inline with the filter fields.
+    // @see \Drupal\gin\GinContentFormHelper::formAlter()
+    $form['filter_actions'] = [
+      '#type' => 'container',
       '#attributes' => ['class' => ['hivelog-filter-form__actions']],
     ];
-    $form['actions']['submit'] = [
+    $form['filter_actions']['submit'] = [
       '#type' => 'submit',
       '#value' => $this->t('Filter'),
       '#button_type' => 'primary',
       '#attributes' => ['class' => ['hivelog-filter-form__submit']],
     ];
     if ($apiary) {
-      $form['actions']['reset'] = [
+      $form['filter_actions']['reset'] = [
         '#type' => 'link',
         '#title' => $this->t('Reset'),
         '#url' => Url::fromRoute('entity.apiary.canonical', ['apiary' => $apiary->id()]),

--- a/src/Form/HivelogInspectionFilterForm.php
+++ b/src/Form/HivelogInspectionFilterForm.php
@@ -96,18 +96,25 @@ class HivelogInspectionFilterForm extends FormBase {
       '#default_value' => $query ? (string) $query->get('brood_pattern', '') : '',
     ];
 
-    $form['actions'] = [
-      '#type' => 'actions',
+    // Deliberately named 'filter_actions' (not 'actions') and typed as a
+    // plain container so admin themes such as Gin do not treat these as
+    // form-level actions and relocate them into their sticky top bar
+    // (top-bar__actions). Gin's form alter keys off $form['actions'] to
+    // decide whether to hoist buttons; using a different key keeps the
+    // Filter and Reset controls inline with the filter fields.
+    // @see \Drupal\gin\GinContentFormHelper::formAlter()
+    $form['filter_actions'] = [
+      '#type' => 'container',
       '#attributes' => ['class' => ['hivelog-filter-form__actions']],
     ];
-    $form['actions']['submit'] = [
+    $form['filter_actions']['submit'] = [
       '#type' => 'submit',
       '#value' => $this->t('Filter'),
       '#button_type' => 'primary',
       '#attributes' => ['class' => ['hivelog-filter-form__submit']],
     ];
     if ($hive) {
-      $form['actions']['reset'] = [
+      $form['filter_actions']['reset'] = [
         '#type' => 'link',
         '#title' => $this->t('Reset'),
         '#url' => Url::fromRoute('entity.hive.canonical', ['hive' => $hive->id()]),

--- a/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
+++ b/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
@@ -394,22 +394,23 @@ class EmbeddedTableFilterPaginationTest extends KernelTestBase {
       ->getInstanceFromDefinition(ApiaryController::class);
     $build = $controller->view($apiary);
 
-    $filter = $build['hives_toolbar']['filter'];
+    $filter = $build['hives_filter'];
     $this->assertEquals('get', $filter['#method']);
     $this->assertEquals('active', $filter['filters']['status']['#default_value']);
     $this->assertEquals('Hive', $filter['filters']['name']['#default_value']);
 
-    // Toolbar wraps the filter form and the Add Hive action link in one
-    // container so they can be rendered on the same row.
-    $this->assertArrayHasKey('add', $build['hives_toolbar']);
+    // The Add Hive action lives in the heading row (top-right of the list
+    // section), not inline with the filter form.
+    $this->assertArrayHasKey('add', $build['hives_heading']);
     $this->assertContains(
-      'hivelog-toolbar__action',
-      $build['hives_toolbar']['add']['#attributes']['class']
+      'hivelog-list-heading__action',
+      $build['hives_heading']['add']['#attributes']['class']
     );
     $this->assertContains(
-      'hivelog-toolbar',
-      $build['hives_toolbar']['#attributes']['class']
+      'hivelog-list-heading',
+      $build['hives_heading']['#attributes']['class']
     );
+    $this->assertArrayNotHasKey('hives_toolbar', $build);
   }
 
 }


### PR DESCRIPTION
## Problem
On the apiary and hive view pages:
- The child-list filter toolbar bundled the *Add Hive* / *Add Inspection* link on the same flex row as the filter form, mixing an unrelated action into the filter controls.
- The filter form's **Filter** and **Reset** buttons were being hoisted out of the filter row into the Drupal navigation top bar (`.top-bar__actions`) by Gin's sticky form-actions mechanism, so they no longer sat next to the filters they operate on.

## Fix
### Controllers
`ApiaryController::view` and `HiveController::view` now emit two sibling render elements in place of the old combined `*_toolbar` container:

1. **`*_heading`** — a flex row (`justify-content: space-between`) with the `h3` title on the left and the *Add* action on the right.
2. **`*_filter`** — the filter form, rendered on its own row below the heading.

### CSS
`css/hivelog.filter-form.css`:
- Replaces the `.hivelog-toolbar*` rules with `.hivelog-list-heading*` rules for the heading row.
- Adds `margin-left: auto` to `.hivelog-filter-form__actions` so the **Filter** / **Reset** buttons are pushed to the right-hand side of the filter row.

### Filter forms
`HivelogHiveFilterForm` and `HivelogInspectionFilterForm` now place their Filter/Reset buttons inside a **`filter_actions`** container (not `actions`) of `#type => 'container'`. Gin's `GinContentFormHelper::formAlter()` keys off `isset($form['actions'])` to decide whether to attach its `formAfterBuild` callback that hoists buttons into the top bar's `gin_sticky_actions` region — using a different key sidesteps the hoisting entirely and keeps the filter actions inline with the filter fields.

## Tests
`EmbeddedTableFilterPaginationTest::testFilterFormIsGetAndPreservesDefaults` now asserts:
- The filter form lives at `$build['hives_filter']`.
- The *Add Hive* action is nested under `$build['hives_heading']['add']` with class `hivelog-list-heading__action`.
- The heading container carries class `hivelog-list-heading`.
- The old `hives_toolbar` key is gone.

Full kernel suite (`--group hivelog`) passes: 98 tests, 1051 assertions.

---
[Conversation](https://app.warp.dev/conversation/dfef5c25-714a-4638-9059-2b0eb7ddaca7)

Co-Authored-By: Oz <oz-agent@warp.dev>