### PR TITLE
fix(css): reduce weight histogram container padding from 1rem to 1px

### DIFF
--- a/css/hivelog.weight-histogram.css
+++ b/css/hivelog.weight-histogram.css
@@ -20,7 +20,7 @@
   aspect-ratio: 8 / 3;
   background: #111;
   border-radius: 4px;
-  padding: 1rem;
+  padding: 1px;
   box-sizing: border-box;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Reduces the padding on the weight histogram chart container from `1rem` to `1px`. The excessive padding was consuming a significant portion of the chart area, causing the SVG histogram to render smaller than intended.

## Changes

- `css/hivelog.weight-histogram.css`: `padding: 1rem` → `padding: 1px`

## Testing

- Cache rebuilt (`drush cr`) and verified visually across multiple breakpoints (375, 768, 1024, 1440 px).
- All manual layout checks passed.

---
*Generated with [Warp](https://app.warp.dev/conversation/2a1635e1-839a-4445-9b56-39605dcfa098)*

Co-Authored-By: Oz <oz-agent@warp.dev>