### PR TITLE
Split queen tracking into its own Queen entity (#51)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,14 @@ This file provides guidance to WARP (warp.dev) when working with code in this re
 
 HiveLog is a custom Drupal 11 module (located at `web/modules/hivelog` inside a
 larger CMS checkout) that provides a beekeeping activity logger. It defines
-three custom content entities with a strict parent–child hierarchy:
+four custom content entities. Apiaries, hives and inspections form a strict
+parent–child hierarchy; queens are tracked separately and linked to the
+hive they are currently installed in (hives outlive queens):
 
 ```
 Apiary → Hive → Hive Inspection
+              ↑
+            Queen (active ↔ inactive)
 ```
 
 Required contrib dependencies: `geofield`, `leaflet` (see
@@ -76,16 +80,25 @@ requires a corresponding update hook (see `hivelog.install`).
   (WKT POINT). Earlier schemas used separate lat/lng columns and the
   `geolocation` module; `hivelog_update_10001` and `_10002` migrate through
   those states.
-- `Hive` — references an `Apiary` via `apiary` entity_reference. On
-  `preSave()` it auto-derives `queen_colour` from `queen_year` using the
-  `QUEEN_COLOUR_MAP` constant (international queen marking convention).
+- `Hive` — references an `Apiary` via `apiary` entity_reference. Queen info
+  is NOT stored on the hive (see `Queen` below); `Hive::getActiveQueen()`
+  resolves the active queen via a reverse lookup on `queen.hive`.
 - `HiveInspection` — references a `Hive` and carries the full inspection
   payload (external check, queen, brood, stores, health, management, notes).
+- `Queen` — references a `Hive` via `hive` entity_reference (optional).
+  Stores identity/provenance (`name`, `origin`, `queen_year`, `queen_colour`,
+  `breed`, `temperament`, `purchase_cost`, `purchase_date`,
+  `introduction_date`, `status` [`active` | `inactive`]). `preSave()`
+  auto-derives `queen_colour` from `queen_year` via the `QUEEN_COLOUR_MAP`
+  constant (international queen marking convention) AND enforces the
+  "one active queen per hive" invariant by demoting any previously active
+  queen on the same hive to `inactive` and clearing its `hive` reference.
 
 Allowed-value lists for hive `type`, `material`, `breed`, `temperament`,
-`status`, and the various inspection enums are hard-coded in the respective
-`baseFieldDefinitions()`. Extending them requires editing the entity class
-**and** writing an update hook if existing data must be preserved.
+`status`, queen `breed` / `temperament` / `status`, and the various
+inspection enums are hard-coded in the respective `baseFieldDefinitions()`.
+Extending them requires editing the entity class **and** writing an update
+hook if existing data must be preserved.
 
 ### Routing, controllers and forms
 
@@ -95,12 +108,13 @@ Routes in `hivelog.routing.yml` follow two patterns:
   `.edit_form`, `.delete_form`) that use Drupal's `_entity_form` / list
   builder machinery.
 - Custom "scoped add" routes (`hivelog.hive.add`,
-  `hivelog.inspection.add`) whose path includes the parent entity
-  (`/apiary/{apiary}/hive/add`, `/hive/{hive}/inspection/add`). These are
+  `hivelog.inspection.add`, `hivelog.queen.add`) whose path includes the
+  parent entity (`/apiary/{apiary}/hive/add`,
+  `/hive/{hive}/inspection/add`, `/hive/{hive}/queen/add`). These are
   handled by `addForm()` methods on the child's controller, which
-  pre-populates the parent reference on a new child entity before handing it
-  to the entity form. Always use these routes when adding children so the
-  parent reference is set correctly.
+  pre-populates the parent reference on a new child entity before handing
+  it to the entity form. Always use these routes when adding children so
+  the parent reference is set correctly.
 
 Canonical view pages are rendered by custom controllers
 (`ApiaryController`, `HiveController`, `HiveInspectionController`) rather

--- a/README.md
+++ b/README.md
@@ -8,15 +8,22 @@ inspection activities.
 HiveLog provides a structured system for beekeepers to:
 
 - Track **apiary locations** (with optional GPS coordinates)
-- Manage individual **hives** and their characteristics (type, material, breed,
-  queen details)
+- Manage individual **hives** and their characteristics (type, material,
+  breed, temperament)
+- Track **queens** as first-class entities linked to a hive, with their own
+  identifier, provenance, and active/inactive lifecycle (hives outlive
+  queens, so queen info is not stored on the hive itself)
 - Record detailed **inspection logs** covering queen status, brood, stores,
   health, feeding, and management actions
 
-The module uses three custom content entities with parent–child relationships:
+The module uses four custom content entities. Apiaries, hives and
+inspections form a strict parent–child hierarchy; queens are tracked
+separately and linked to a hive:
 
 ```
 Apiary → Hive → Hive Inspection
+              ↑
+            Queen (active ↔ inactive)
 ```
 
 ## Requirements
@@ -50,12 +57,25 @@ After installation, navigate to **Administration → Structure → HiveLog**
    Each hive records:
    - Hive type (10x12, Norwegian, Langstroth, Trugstad, Normal)
    - Hive material (Wood, Styrofoam)
-   - Queen year and auto-calculated queen marking colour
    - Bee breed (Buckfast, Carniolan, Italian, Caucasian, Dark European/AMM, Other)
    - Temperament (Calm, Moderate, Aggressive)
    - Status (Active, Inactive, Dead, Sold, Merged)
 
-3. **Log inspections** — From the hive view page, click "Add Inspection". Each
+3. **Track queens** — Queens are separate from hives because a hive typically
+   outlives any single queen. From the hive view page, click "Add Queen" to
+   record a new queen and attach it to the hive. Each queen records:
+   - A human-readable ID (e.g. `Q-2026-001`)
+   - Origin (breeder, swarm, supplier, …)
+   - Queen year (international marking colour auto-calculated)
+   - Breed and temperament
+   - Purchase cost and purchase date
+   - Hive reference and introduction date
+   - Status: **Active** or **Inactive**
+   Only one queen may be active per hive at a time. Saving a new active
+   queen on a hive that already has one automatically marks the previous
+   queen inactive and detaches it from the hive.
+
+4. **Log inspections** — From the hive view page, click "Add Inspection". Each
    inspection captures:
    - **External check (before opening)** — Flight activity, dead bees, signs of
      robbing, wasps, hive weight (hefting)
@@ -78,8 +98,8 @@ To preserve data integrity, the inspection form enforces dependent-field rules:
 
 ### Queen Marking Colour
 
-When a queen year is entered on a hive, the international queen marking colour
-is calculated automatically on save:
+When a queen year is entered on the queen record, the international queen
+marking colour is calculated automatically on save:
 
 | Last digit of year | Colour |
 |--------------------|--------|
@@ -107,6 +127,7 @@ View, Edit, and Delete tabs are available on each entity page.
 | View/Add/Edit/Delete apiaries    | Per-operation access to apiaries |
 | View/Add/Edit/Delete hives       | Per-operation access to hives    |
 | View/Add/Edit/Delete hive inspections | Per-operation access to inspections |
+| View/Add/Edit/Delete queens      | Per-operation access to queens   |
 
 Users with "Administer HiveLog" bypass all individual permission checks.
 
@@ -129,6 +150,12 @@ Users with "Administer HiveLog" bypass all individual permission checks.
 | `/admin/hivelog/inspection/{id}`              | View inspection        |
 | `/admin/hivelog/inspection/{id}/edit`         | Edit inspection        |
 | `/admin/hivelog/inspection/{id}/delete`       | Delete inspection      |
+| `/admin/hivelog/queens`                       | Queen list             |
+| `/admin/hivelog/queen/add`                    | Add queen              |
+| `/admin/hivelog/hive/{id}/queen/add`          | Add queen to hive      |
+| `/admin/hivelog/queen/{id}`                   | View queen             |
+| `/admin/hivelog/queen/{id}/edit`              | Edit queen             |
+| `/admin/hivelog/queen/{id}/delete`            | Delete queen           |
 
 ## Module Structure
 
@@ -148,32 +175,39 @@ hivelog/
 │   ├── Entity/
 │   │   ├── Apiary.php            # Apiary content entity
 │   │   ├── Hive.php              # Hive content entity
-│   │   └── HiveInspection.php    # Inspection content entity
+│   │   ├── HiveInspection.php    # Inspection content entity
+│   │   └── Queen.php             # Queen content entity
 │   ├── Form/
 │   │   ├── ApiaryForm.php        # Apiary add/edit form
 │   │   ├── ApiaryDeleteForm.php
 │   │   ├── HiveForm.php          # Hive add/edit form
 │   │   ├── HiveDeleteForm.php
 │   │   ├── HiveInspectionForm.php    # Inspection add/edit form
-│   │   └── HiveInspectionDeleteForm.php
+│   │   ├── HiveInspectionDeleteForm.php
+│   │   ├── QueenForm.php         # Queen add/edit form
+│   │   └── QueenDeleteForm.php
 │   ├── Controller/
 │   │   ├── ApiaryController.php      # Apiary view (with hives table)
-│   │   ├── HiveController.php        # Hive view (with inspections table)
-│   │   └── HiveInspectionController.php  # Inspection view
+│   │   ├── HiveController.php        # Hive view (queen + histogram + inspections)
+│   │   ├── HiveInspectionController.php  # Inspection view
+│   │   └── QueenController.php       # Queen view + hive-scoped add
 │   ├── Breadcrumb/
 │   │   └── HivelogBreadcrumbBuilder.php  # Breadcrumb builder service
 │   ├── ApiaryListBuilder.php
 │   ├── HiveListBuilder.php
 │   ├── HiveInspectionListBuilder.php
+│   ├── QueenListBuilder.php
 │   ├── ApiaryAccessControlHandler.php
 │   ├── HiveAccessControlHandler.php
-│   └── HiveInspectionAccessControlHandler.php
+│   ├── HiveInspectionAccessControlHandler.php
+│   └── QueenAccessControlHandler.php
 └── tests/
     └── src/
         ├── Kernel/
         │   ├── ApiaryTest.php            # Apiary entity tests
-        │   ├── HiveTest.php              # Hive entity + queen colour tests
-        │   └── HiveInspectionTest.php    # Inspection entity tests
+        │   ├── HiveTest.php              # Hive entity + queen section tests
+        │   ├── HiveInspectionTest.php    # Inspection entity tests
+        │   └── QueenTest.php             # Queen CRUD + colour + invariant tests
         └── Unit/
             └── Breadcrumb/
                 └── HivelogBreadcrumbBuilderTest.php  # Breadcrumb unit tests
@@ -222,6 +256,8 @@ drush cr
    - `10007` — Retire the dormant `queen_brood` field on hive inspections
      (data in the removed column is dropped; the swarming / supersedure
      signal is already captured by `queen_cells`).
+   - `10008` — Install the `queen` entity type and drop the `queen_year` /
+     `queen_colour` columns from `hive`. No data migration.
 3. `drush cr` — Rebuilds caches so Drupal picks up any changes to entity
    definitions, routing, or services.
 

--- a/hivelog.install
+++ b/hivelog.install
@@ -253,3 +253,34 @@ function hivelog_update_10007(&$sandbox) {
 
   return t('Retired dormant queen_brood field on hive inspections.');
 }
+
+/**
+ * Split queen tracking into its own Queen entity.
+ *
+ * Issue #51: queen information lives on a long-lived Queen entity linked to
+ * a hive rather than inline columns on the hive itself. The module is not
+ * in production yet, so existing queen_year / queen_colour values on hives
+ * are dropped along with the column — there is no data migration.
+ */
+function hivelog_update_10008(&$sandbox) {
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+  $entity_type_manager = \Drupal::entityTypeManager();
+
+  // Install the new Queen entity type (schema + base fields) from its
+  // #[ContentEntityType] attribute definition.
+  if (!$entity_definition_update_manager->getEntityType('queen')) {
+    $queen_type = $entity_type_manager->getDefinition('queen');
+    $entity_definition_update_manager->installEntityType($queen_type);
+  }
+
+  // Drop the queen_year and queen_colour columns from the hive entity.
+  foreach (['queen_year', 'queen_colour'] as $field_name) {
+    $definition = $entity_definition_update_manager
+      ->getFieldStorageDefinition($field_name, 'hive');
+    if ($definition) {
+      $entity_definition_update_manager->uninstallFieldStorageDefinition($definition);
+    }
+  }
+
+  return t('Installed the Queen entity type and removed queen_year/queen_colour from hives.');
+}

--- a/hivelog.links.action.yml
+++ b/hivelog.links.action.yml
@@ -3,3 +3,9 @@ hivelog.apiary.add:
   title: 'Add Apiary'
   appears_on:
     - entity.apiary.collection
+
+hivelog.queen.add_action:
+  route_name: entity.queen.add_form
+  title: 'Add Queen'
+  appears_on:
+    - entity.queen.collection

--- a/hivelog.links.menu.yml
+++ b/hivelog.links.menu.yml
@@ -18,3 +18,10 @@ hivelog.inspections:
   route_name: entity.hive_inspection.collection
   parent: hivelog.admin
   weight: 2
+
+hivelog.queens:
+  title: 'Queens'
+  description: 'Manage queens across all hives.'
+  route_name: entity.queen.collection
+  parent: hivelog.admin
+  weight: 3

--- a/hivelog.links.task.yml
+++ b/hivelog.links.task.yml
@@ -48,3 +48,20 @@ hivelog.inspection.delete_tab:
   title: 'Delete'
   base_route: entity.hive_inspection.canonical
   weight: 10
+
+# Queen tabs.
+hivelog.queen.view_tab:
+  route_name: entity.queen.canonical
+  title: 'View'
+  base_route: entity.queen.canonical
+
+hivelog.queen.edit_tab:
+  route_name: entity.queen.edit_form
+  title: 'Edit'
+  base_route: entity.queen.canonical
+
+hivelog.queen.delete_tab:
+  route_name: entity.queen.delete_form
+  title: 'Delete'
+  base_route: entity.queen.canonical
+  weight: 10

--- a/hivelog.permissions.yml
+++ b/hivelog.permissions.yml
@@ -37,3 +37,15 @@ edit hive inspection:
 
 delete hive inspection:
   title: 'Delete hive inspections'
+
+view queen:
+  title: 'View queens'
+
+add queen:
+  title: 'Add queens'
+
+edit queen:
+  title: 'Edit queens'
+
+delete queen:
+  title: 'Delete queens'

--- a/hivelog.routing.yml
+++ b/hivelog.routing.yml
@@ -164,3 +164,68 @@ entity.hive_inspection.delete_form:
     parameters:
       hive_inspection:
         type: entity:hive_inspection
+
+# Queen routes.
+entity.queen.collection:
+  path: '/admin/hivelog/queens'
+  defaults:
+    _entity_list: 'queen'
+    _title: 'HiveLog - Queens'
+  requirements:
+    _permission: 'view queen+administer hivelog'
+
+entity.queen.add_form:
+  path: '/admin/hivelog/queen/add'
+  defaults:
+    _entity_form: 'queen.add'
+    _title: 'Add Queen'
+  requirements:
+    _permission: 'add queen+administer hivelog'
+
+hivelog.queen.add:
+  path: '/admin/hivelog/hive/{hive}/queen/add'
+  defaults:
+    _controller: '\Drupal\hivelog\Controller\QueenController::addForm'
+    _title: 'Add Queen'
+  requirements:
+    _permission: 'add queen+administer hivelog'
+  options:
+    parameters:
+      hive:
+        type: entity:hive
+
+entity.queen.canonical:
+  path: '/admin/hivelog/queen/{queen}'
+  defaults:
+    _controller: '\Drupal\hivelog\Controller\QueenController::view'
+    _title_callback: '\Drupal\hivelog\Controller\QueenController::title'
+  requirements:
+    _permission: 'view queen+administer hivelog'
+  options:
+    parameters:
+      queen:
+        type: entity:queen
+
+entity.queen.edit_form:
+  path: '/admin/hivelog/queen/{queen}/edit'
+  defaults:
+    _entity_form: 'queen.edit'
+    _title: 'Edit Queen'
+  requirements:
+    _permission: 'edit queen+administer hivelog'
+  options:
+    parameters:
+      queen:
+        type: entity:queen
+
+entity.queen.delete_form:
+  path: '/admin/hivelog/queen/{queen}/delete'
+  defaults:
+    _entity_form: 'queen.delete'
+    _title: 'Delete Queen'
+  requirements:
+    _permission: 'delete queen+administer hivelog'
+  options:
+    parameters:
+      queen:
+        type: entity:queen

--- a/src/Breadcrumb/HivelogBreadcrumbBuilder.php
+++ b/src/Breadcrumb/HivelogBreadcrumbBuilder.php
@@ -43,6 +43,7 @@ class HivelogBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     return str_starts_with($route_name, 'entity.apiary.')
       || str_starts_with($route_name, 'entity.hive.')
       || str_starts_with($route_name, 'entity.hive_inspection.')
+      || str_starts_with($route_name, 'entity.queen.')
       || str_starts_with($route_name, 'hivelog.');
   }
 
@@ -99,6 +100,27 @@ class HivelogBreadcrumbBuilder implements BreadcrumbBuilderInterface {
       }
       if ($route_name !== 'entity.hive_inspection.canonical') {
         $breadcrumb->addLink(Link::createFromRoute($inspection->label(), 'entity.hive_inspection.canonical', ['hive_inspection' => $inspection->id()]));
+      }
+    }
+
+    // Queen-level routes: when a queen has a hive, thread Apiary → Hive
+    // ancestry. Queens that are unassigned (archived with no hive) just
+    // render the base HiveLog breadcrumb with a trailing queen link.
+    $queen = $route_match->getParameter('queen');
+    if ($queen && is_object($queen)) {
+      $breadcrumb->addCacheableDependency($queen);
+      $queen_hive = $queen->get('hive')->entity;
+      if ($queen_hive) {
+        $breadcrumb->addCacheableDependency($queen_hive);
+        $queen_apiary = $queen_hive->get('apiary')->entity;
+        if ($queen_apiary) {
+          $breadcrumb->addCacheableDependency($queen_apiary);
+          $breadcrumb->addLink(Link::createFromRoute($queen_apiary->label(), 'entity.apiary.canonical', ['apiary' => $queen_apiary->id()]));
+        }
+        $breadcrumb->addLink(Link::createFromRoute($queen_hive->label(), 'entity.hive.canonical', ['hive' => $queen_hive->id()]));
+      }
+      if ($route_name !== 'entity.queen.canonical') {
+        $breadcrumb->addLink(Link::createFromRoute($queen->label(), 'entity.queen.canonical', ['queen' => $queen->id()]));
       }
     }
 

--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -103,6 +103,13 @@ class HiveController extends ControllerBase {
       $build['weight_histogram'] = $histogram + ['#weight' => 7];
     }
 
+    // Queen section — rendered after the histogram so the histogram stays
+    // visually on top of the page, but still above the inspection list so
+    // the current queen is the last thing the reader sees before the
+    // inspection history.
+    $active_queen = $hive->getActiveQueen();
+    $build['queen'] = $this->buildQueenSection($hive, $active_queen) + ['#weight' => 8];
+
     // Heading row: the "Inspections" title on the left, the Add Inspection
     // action on the right. Placing the action here (rather than inline
     // with the filter form below) keeps it at the top-right of the list
@@ -225,7 +232,11 @@ class HiveController extends ControllerBase {
     $cache = CacheableMetadata::createFromRenderArray($build)
       ->addCacheContexts(['url.query_args', 'user.permissions'])
       ->addCacheableDependency($hive)
-      ->addCacheTags($this->entityTypeManager->getDefinition('hive_inspection')->getListCacheTags());
+      ->addCacheTags($this->entityTypeManager->getDefinition('hive_inspection')->getListCacheTags())
+      ->addCacheTags($this->entityTypeManager->getDefinition('queen')->getListCacheTags());
+    if ($active_queen) {
+      $cache->addCacheableDependency($active_queen);
+    }
     foreach ($inspections as $inspection) {
       $cache->addCacheableDependency($inspection);
     }
@@ -244,6 +255,72 @@ class HiveController extends ControllerBase {
    */
   public function title(Hive $hive) {
     return $hive->label();
+  }
+
+  /**
+   * Builds the queen section shown on the hive view page.
+   *
+   * When an active queen is present, summarise its key attributes and
+   * expose View / Edit links. Otherwise, invite the user to add a queen
+   * via the hive-scoped add route.
+   *
+   * @param \Drupal\hivelog\Entity\Hive $hive
+   *   The hive being rendered.
+   * @param \Drupal\hivelog\Entity\Queen|null $queen
+   *   The hive's currently active queen, if any.
+   */
+  protected function buildQueenSection(Hive $hive, $queen): array {
+    $section = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['hivelog-list-heading']],
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Queen'),
+        '#attributes' => ['class' => ['hivelog-list-heading__title']],
+      ],
+    ];
+
+    if ($queen) {
+      $colour = $queen->get('queen_colour')->value;
+      $colour_label = $colour
+        ? ($queen->get('queen_colour')->getSetting('allowed_values')[$colour] ?? $colour)
+        : $this->t('Not set');
+
+      $section['details'] = [
+        '#type' => 'table',
+        '#header' => [$this->t('Field'), $this->t('Value')],
+        '#rows' => [
+          [$this->t('Queen ID'), $queen->toLink()->toString()],
+          [$this->t('Colour'), $colour_label],
+          [$this->t('Year'), $queen->get('queen_year')->value ?: $this->t('Not set')],
+          [$this->t('Introduced'), $queen->get('introduction_date')->value ?: $this->t('Not set')],
+        ],
+      ];
+      $section['edit'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Edit Queen'),
+        '#url' => $queen->toUrl('edit-form'),
+        '#attributes' => [
+          'class' => ['button', 'hivelog-list-heading__action'],
+        ],
+      ];
+    }
+    else {
+      $section['empty'] = [
+        '#markup' => '<p>' . $this->t('No active queen is recorded for this hive.') . '</p>',
+      ];
+      $section['add'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Add Queen'),
+        '#url' => Url::fromRoute('hivelog.queen.add', ['hive' => $hive->id()]),
+        '#attributes' => [
+          'class' => ['button', 'button--primary', 'hivelog-list-heading__action'],
+        ],
+      ];
+    }
+
+    return $section;
   }
 
   /**

--- a/src/Controller/QueenController.php
+++ b/src/Controller/QueenController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\hivelog\Controller;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityFormBuilderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\hivelog\Entity\Hive;
+use Drupal\hivelog\Entity\Queen;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Controller for Queen pages.
+ */
+class QueenController extends ControllerBase {
+
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityFormBuilderInterface $entity_form_builder,
+  ) {
+    // $entityTypeManager and $entityFormBuilder are untyped properties
+    // inherited from ControllerBase; assign them rather than redeclaring
+    // them with types.
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityFormBuilder = $entity_form_builder;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('entity.form_builder'),
+    );
+  }
+
+  /**
+   * Provides the add form for a queen within a hive context.
+   *
+   * Pre-populates the queen's `hive` reference so the user does not have to
+   * pick the hive manually when adding from the hive page.
+   */
+  public function addForm(Hive $hive) {
+    $queen = $this->entityTypeManager->getStorage('queen')->create([
+      'hive' => $hive->id(),
+      'status' => 'active',
+    ]);
+    return $this->entityFormBuilder->getForm($queen, 'add');
+  }
+
+  /**
+   * Displays a queen entity.
+   */
+  public function view(Queen $queen) {
+    $view_builder = $this->entityTypeManager->getViewBuilder('queen');
+    $build = [
+      'queen' => $view_builder->view($queen),
+    ];
+
+    $cache = CacheableMetadata::createFromRenderArray($build)
+      ->addCacheContexts(['user.permissions'])
+      ->addCacheableDependency($queen);
+    $cache->applyTo($build);
+
+    return $build;
+  }
+
+  /**
+   * Title callback for the queen view page.
+   */
+  public function title(Queen $queen) {
+    return $queen->label();
+  }
+
+}

--- a/src/Entity/Hive.php
+++ b/src/Entity/Hive.php
@@ -12,6 +12,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\hivelog\Entity\Queen;
 use Drupal\hivelog\Form\HiveDeleteForm;
 use Drupal\hivelog\Form\HiveForm;
 use Drupal\hivelog\HiveAccessControlHandler;
@@ -58,33 +59,32 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
   use EntityOwnerTrait;
 
   /**
-   * Maps the last digit of a year to the international queen marking colour.
+   * Returns the currently active queen for this hive, if any.
+   *
+   * Queens are tracked on the `queen` entity; only one may be active per
+   * hive at a time (enforced in Queen::preSave). This helper wraps the
+   * query used by the hive view page and by tests.
+   *
+   * @return \Drupal\hivelog\Entity\Queen|null
+   *   The active queen entity, or NULL if the hive has no active queen.
    */
-  const QUEEN_COLOUR_MAP = [
-    0 => 'blue',
-    1 => 'white',
-    2 => 'yellow',
-    3 => 'red',
-    4 => 'green',
-    5 => 'blue',
-    6 => 'white',
-    7 => 'yellow',
-    8 => 'red',
-    9 => 'green',
-  ];
-
-  /**
-   * {@inheritdoc}
-   */
-  public function preSave(\Drupal\Core\Entity\EntityStorageInterface $storage) {
-    parent::preSave($storage);
-
-    // Auto-calculate queen colour from queen year.
-    $queen_year = $this->get('queen_year')->value;
-    if ($queen_year) {
-      $last_digit = (int) $queen_year % 10;
-      $this->set('queen_colour', self::QUEEN_COLOUR_MAP[$last_digit]);
+  public function getActiveQueen(): ?Queen {
+    if ($this->isNew()) {
+      return NULL;
     }
+    $storage = $this->entityTypeManager()->getStorage('queen');
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('hive', $this->id())
+      ->condition('status', 'active')
+      ->range(0, 1)
+      ->execute();
+    if (!$ids) {
+      return NULL;
+    }
+    /** @var \Drupal\hivelog\Entity\Queen $queen */
+    $queen = $storage->load(reset($ids));
+    return $queen ?: NULL;
   }
 
   /**
@@ -141,34 +141,6 @@ class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOw
       ->setSetting('allowed_values', [
         'wood' => 'Wood',
         'styrofoam' => 'Styrofoam',
-      ])
-      ->setDisplayOptions('form', [
-        'type' => 'options_select',
-        'weight' => 3,
-      ])
-      ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
-
-    $fields['queen_year'] = BaseFieldDefinition::create('integer')
-      ->setLabel(t('Queen Year'))
-      ->setDescription(t('The year the queen was introduced. The queen colour is set automatically based on this value.'))
-      ->setSetting('min', 2000)
-      ->setDisplayOptions('form', [
-        'type' => 'number',
-        'weight' => 2,
-      ])
-      ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
-
-    $fields['queen_colour'] = BaseFieldDefinition::create('list_string')
-      ->setLabel(t('Queen Colour'))
-      ->setDescription(t('International queen marking colour. Auto-calculated from Queen Year: White (1,6), Yellow (2,7), Red (3,8), Green (4,9), Blue (0,5).'))
-      ->setSetting('allowed_values', [
-        'white' => 'White (years ending 1, 6)',
-        'yellow' => 'Yellow (years ending 2, 7)',
-        'red' => 'Red (years ending 3, 8)',
-        'green' => 'Green (years ending 4, 9)',
-        'blue' => 'Blue (years ending 0, 5)',
       ])
       ->setDisplayOptions('form', [
         'type' => 'options_select',

--- a/src/Entity/Queen.php
+++ b/src/Entity/Queen.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\hivelog\Entity;
+
+use Drupal\Core\Entity\Attribute\ContentEntityType;
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityChangedInterface;
+use Drupal\Core\Entity\EntityChangedTrait;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\hivelog\Form\QueenDeleteForm;
+use Drupal\hivelog\Form\QueenForm;
+use Drupal\hivelog\QueenAccessControlHandler;
+use Drupal\hivelog\QueenListBuilder;
+use Drupal\user\EntityOwnerInterface;
+use Drupal\user\EntityOwnerTrait;
+
+/**
+ * Defines the Queen entity.
+ *
+ * Queens are tracked separately from hives because hives outlive queens and
+ * a single hive may house different queens over its lifetime. A queen has
+ * its own identifier, provenance and lifecycle, and carries an optional
+ * reference to the hive it is currently installed in. When the queen is no
+ * longer in service (superseded, died, sold) the record is archived.
+ */
+#[ContentEntityType(
+  id: 'queen',
+  label: new TranslatableMarkup('Queen'),
+  label_collection: new TranslatableMarkup('Queens'),
+  label_singular: new TranslatableMarkup('queen'),
+  label_plural: new TranslatableMarkup('queens'),
+  handlers: [
+    'list_builder' => QueenListBuilder::class,
+    'form' => [
+      'default' => QueenForm::class,
+      'add' => QueenForm::class,
+      'edit' => QueenForm::class,
+      'delete' => QueenDeleteForm::class,
+    ],
+    'access' => QueenAccessControlHandler::class,
+  ],
+  base_table: 'hivelog_queen',
+  admin_permission: 'administer hivelog',
+  entity_keys: [
+    'id' => 'id',
+    'label' => 'name',
+    'uuid' => 'uuid',
+    'owner' => 'uid',
+  ],
+  links: [
+    'canonical' => '/admin/hivelog/queen/{queen}',
+    'add-form' => '/admin/hivelog/queen/add',
+    'edit-form' => '/admin/hivelog/queen/{queen}/edit',
+    'delete-form' => '/admin/hivelog/queen/{queen}/delete',
+    'collection' => '/admin/hivelog/queens',
+  ],
+)]
+class Queen extends ContentEntityBase implements EntityChangedInterface, EntityOwnerInterface {
+
+  use EntityChangedTrait;
+  use EntityOwnerTrait;
+
+  /**
+   * Maps the last digit of a year to the international queen marking colour.
+   */
+  const QUEEN_COLOUR_MAP = [
+    0 => 'blue',
+    1 => 'white',
+    2 => 'yellow',
+    3 => 'red',
+    4 => 'green',
+    5 => 'blue',
+    6 => 'white',
+    7 => 'yellow',
+    8 => 'red',
+    9 => 'green',
+  ];
+
+  /**
+   * {@inheritdoc}
+   *
+   * Derives the marking colour from the hatch year and enforces the
+   * "one active queen per hive" invariant by deactivating any previously
+   * active queen on the same hive when this one is saved as active.
+   */
+  public function preSave(EntityStorageInterface $storage) {
+    parent::preSave($storage);
+
+    // Auto-calculate queen colour from queen year.
+    $queen_year = $this->get('queen_year')->value;
+    if ($queen_year) {
+      $last_digit = (int) $queen_year % 10;
+      $this->set('queen_colour', self::QUEEN_COLOUR_MAP[$last_digit]);
+    }
+
+    // Enforce at most one active queen per hive: if this queen is being
+    // saved as active with a hive assigned, mark any other active queen
+    // currently attached to the same hive inactive and detach it.
+    $status = $this->get('status')->value;
+    $hive_id = $this->get('hive')->target_id;
+    if ($status === 'active' && $hive_id) {
+      $query = $storage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('hive', $hive_id)
+        ->condition('status', 'active');
+      if (!$this->isNew()) {
+        $query->condition('id', $this->id(), '<>');
+      }
+      $conflict_ids = $query->execute();
+      if ($conflict_ids) {
+        foreach ($storage->loadMultiple($conflict_ids) as $conflict) {
+          $conflict->set('status', 'inactive');
+          $conflict->set('hive', NULL);
+          $conflict->save();
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+    $fields = parent::baseFieldDefinitions($entity_type);
+    $fields += static::ownerBaseFieldDefinitions($entity_type);
+
+    $fields['name'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Queen ID'))
+      ->setDescription(t('A human readable identifier for this queen, e.g. Q-2026-001.'))
+      ->setRequired(TRUE)
+      ->setSetting('max_length', 255)
+      ->setDisplayOptions('form', [
+        'type' => 'string_textfield',
+        'weight' => 0,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'string',
+        'weight' => 0,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['origin'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Origin'))
+      ->setDescription(t('Where this queen came from (breeder, swarm, supplier, ...).'))
+      ->setSetting('max_length', 255)
+      ->setDisplayOptions('form', [
+        'type' => 'string_textfield',
+        'weight' => 1,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'string',
+        'weight' => 1,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['queen_year'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Queen Year'))
+      ->setDescription(t('The year the queen hatched. The queen colour is set automatically based on this value.'))
+      ->setSetting('min', 2000)
+      ->setDisplayOptions('form', [
+        'type' => 'number',
+        'weight' => 2,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'number_integer',
+        'weight' => 2,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['queen_colour'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(t('Queen Colour'))
+      ->setDescription(t('International queen marking colour. Auto-calculated from Queen Year: White (1,6), Yellow (2,7), Red (3,8), Green (4,9), Blue (0,5).'))
+      ->setSetting('allowed_values', [
+        'white' => 'White (years ending 1, 6)',
+        'yellow' => 'Yellow (years ending 2, 7)',
+        'red' => 'Red (years ending 3, 8)',
+        'green' => 'Green (years ending 4, 9)',
+        'blue' => 'Blue (years ending 0, 5)',
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'options_select',
+        'weight' => 3,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'list_default',
+        'weight' => 3,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['breed'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(t('Breed'))
+      ->setDescription(t('The breed of this queen.'))
+      ->setSetting('allowed_values', [
+        'buckfast' => 'Buckfast',
+        'carniolan' => 'Apis mellifera carnica (Carniolan)',
+        'italian' => 'Apis mellifera ligustica (Italian)',
+        'caucasian' => 'Apis mellifera caucasica (Caucasian)',
+        'amm' => 'Apis mellifera mellifera (Dark European)',
+        'other' => 'Other',
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'options_select',
+        'weight' => 4,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'list_default',
+        'weight' => 4,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['temperament'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(t('Temperament'))
+      ->setDescription(t('The general temperament associated with this queen.'))
+      ->setSetting('allowed_values', [
+        'calm' => 'Calm',
+        'moderate' => 'Moderate',
+        'aggressive' => 'Aggressive',
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'options_select',
+        'weight' => 5,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'list_default',
+        'weight' => 5,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['purchase_cost'] = BaseFieldDefinition::create('decimal')
+      ->setLabel(t('Purchase Cost'))
+      ->setDescription(t('What this queen cost, if purchased.'))
+      ->setSetting('precision', 10)
+      ->setSetting('scale', 2)
+      ->setSetting('min', 0)
+      ->setDisplayOptions('form', [
+        'type' => 'number',
+        'weight' => 6,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'number_decimal',
+        'weight' => 6,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['purchase_date'] = BaseFieldDefinition::create('datetime')
+      ->setLabel(t('Purchase Date'))
+      ->setDescription(t('The date this queen was purchased, if applicable.'))
+      ->setSetting('datetime_type', 'date')
+      ->setDisplayOptions('form', [
+        'type' => 'datetime_default',
+        'weight' => 7,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'datetime_default',
+        'weight' => 7,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['hive'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Hive'))
+      ->setDescription(t('The hive this queen is currently installed in, if any. Leave empty for queens that are not yet assigned or that are inactive.'))
+      ->setSetting('target_type', 'hive')
+      ->setDisplayOptions('form', [
+        'type' => 'entity_reference_autocomplete',
+        'weight' => 8,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'entity_reference_label',
+        'weight' => 8,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['introduction_date'] = BaseFieldDefinition::create('datetime')
+      ->setLabel(t('Introduction Date'))
+      ->setDescription(t('The date this queen was introduced to the hive.'))
+      ->setSetting('datetime_type', 'date')
+      ->setDisplayOptions('form', [
+        'type' => 'datetime_default',
+        'weight' => 9,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'datetime_default',
+        'weight' => 9,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['status'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(t('Status'))
+      ->setDescription(t('Whether this queen is currently in service (active) or retired from service (inactive).'))
+      ->setRequired(TRUE)
+      ->setDefaultValue('active')
+      ->setSetting('allowed_values', [
+        'active' => 'Active',
+        'inactive' => 'Inactive',
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'options_select',
+        'weight' => 10,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'list_default',
+        'weight' => 10,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['notes'] = BaseFieldDefinition::create('string_long')
+      ->setLabel(t('Notes'))
+      ->setDescription(t('General notes about this queen.'))
+      ->setDisplayOptions('form', [
+        'type' => 'string_textarea',
+        'weight' => 11,
+        'settings' => [
+          'rows' => 4,
+        ],
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'basic_string',
+        'weight' => 11,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['uid']
+      ->setLabel(t('Owner'))
+      ->setDescription(t('The user who owns this queen record.'))
+      ->setDisplayOptions('form', [
+        'type' => 'entity_reference_autocomplete',
+        'weight' => 12,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['created'] = BaseFieldDefinition::create('created')
+      ->setLabel(t('Created'))
+      ->setDescription(t('The time the queen record was created.'));
+
+    $fields['changed'] = BaseFieldDefinition::create('changed')
+      ->setLabel(t('Changed'))
+      ->setDescription(t('The time the queen record was last updated.'));
+
+    return $fields;
+  }
+
+}

--- a/src/Form/QueenDeleteForm.php
+++ b/src/Form/QueenDeleteForm.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\hivelog\Form;
+
+use Drupal\Core\Entity\ContentEntityDeleteForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Form handler for Queen delete forms.
+ */
+class QueenDeleteForm extends ContentEntityDeleteForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Are you sure you want to delete queen %name?', [
+      '%name' => $this->entity->label(),
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('entity.queen.canonical', ['queen' => $this->entity->id()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $hive_id = $this->entity->get('hive')->target_id;
+    $this->entity->delete();
+    $this->messenger()->addStatus($this->t('Queen %name has been deleted.', [
+      '%name' => $this->entity->label(),
+    ]));
+
+    if ($hive_id) {
+      $form_state->setRedirectUrl(new Url('entity.hive.canonical', ['hive' => $hive_id]));
+    }
+    else {
+      $form_state->setRedirectUrl(new Url('entity.queen.collection'));
+    }
+  }
+
+}

--- a/src/Form/QueenForm.php
+++ b/src/Form/QueenForm.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\hivelog\Form;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Form handler for Queen add/edit forms.
+ */
+class QueenForm extends ContentEntityForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $entity = $this->entity;
+    $status = $entity->save();
+
+    if ($status === SAVED_NEW) {
+      $this->messenger()->addStatus($this->t('Queen %name has been created.', [
+        '%name' => $entity->label(),
+      ]));
+    }
+    else {
+      $this->messenger()->addStatus($this->t('Queen %name has been updated.', [
+        '%name' => $entity->label(),
+      ]));
+    }
+
+    // Redirect to the associated hive when the queen is attached to one;
+    // otherwise fall back to the global queen collection.
+    $hive_id = $entity->get('hive')->target_id;
+    if ($hive_id) {
+      $form_state->setRedirect('entity.hive.canonical', ['hive' => $hive_id]);
+    }
+    else {
+      $form_state->setRedirect('entity.queen.collection');
+    }
+  }
+
+}

--- a/src/QueenAccessControlHandler.php
+++ b/src/QueenAccessControlHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\hivelog;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityAccessControlHandler;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Access control handler for Queen entities.
+ */
+class QueenAccessControlHandler extends EntityAccessControlHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    if ($account->hasPermission('administer hivelog')) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+
+    switch ($operation) {
+      case 'view':
+        return AccessResult::allowedIfHasPermission($account, 'view queen');
+
+      case 'update':
+        return AccessResult::allowedIfHasPermission($account, 'edit queen');
+
+      case 'delete':
+        return AccessResult::allowedIfHasPermission($account, 'delete queen');
+    }
+
+    return AccessResult::neutral();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
+    return AccessResult::allowedIfHasPermissions($account, [
+      'administer hivelog',
+      'add queen',
+    ], 'OR');
+  }
+
+}

--- a/src/QueenListBuilder.php
+++ b/src/QueenListBuilder.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\hivelog;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityListBuilder;
+
+/**
+ * Provides a list builder for Queen entities.
+ *
+ * Columns follow issue #51: colour, hive, date of introduction.
+ */
+class QueenListBuilder extends EntityListBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['name'] = $this->t('Queen');
+    $header['colour'] = $this->t('Colour');
+    $header['hive'] = $this->t('Hive');
+    $header['introduced'] = $this->t('Introduced');
+    $header['status'] = $this->t('Status');
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    $row['name'] = $entity->toLink();
+
+    $colour = $entity->get('queen_colour')->value;
+    $row['colour'] = $colour ? ($entity->get('queen_colour')->getSetting('allowed_values')[$colour] ?? $colour) : '';
+
+    $hive = $entity->get('hive')->entity;
+    $row['hive'] = $hive ? $hive->toLink() : '';
+
+    $row['introduced'] = $entity->get('introduction_date')->value ?? '';
+
+    $status = $entity->get('status')->value;
+    $row['status'] = $entity->get('status')->getSetting('allowed_values')[$status] ?? $status;
+
+    return $row + parent::buildRow($entity);
+  }
+
+}

--- a/tests/src/Kernel/ApiaryTest.php
+++ b/tests/src/Kernel/ApiaryTest.php
@@ -52,6 +52,7 @@ class ApiaryTest extends KernelTestBase {
     $this->installEntitySchema('apiary');
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
+    $this->installEntitySchema('queen');
     $this->installSchema('file', ['file_usage']);
 
     $this->user = User::create([
@@ -226,18 +227,24 @@ class ApiaryTest extends KernelTestBase {
     $route_provider = \Drupal::service('router.route_provider');
     $hive_route = $route_provider->getRouteByName('entity.hive.collection');
     $inspection_route = $route_provider->getRouteByName('entity.hive_inspection.collection');
+    $queen_route = $route_provider->getRouteByName('entity.queen.collection');
 
     $this->assertEquals('/admin/hivelog/hives', $hive_route->getPath());
     $this->assertEquals('/admin/hivelog/inspections', $inspection_route->getPath());
+    $this->assertEquals('/admin/hivelog/queens', $queen_route->getPath());
     $this->assertEquals('view hive+administer hivelog', $hive_route->getRequirement('_permission'));
     $this->assertEquals('view hive inspection+administer hivelog', $inspection_route->getRequirement('_permission'));
+    $this->assertEquals('view queen+administer hivelog', $queen_route->getRequirement('_permission'));
 
     $menu_links = \Drupal::service('plugin.manager.menu.link')->getDefinitions();
     $this->assertArrayHasKey('hivelog.hives', $menu_links);
     $this->assertArrayHasKey('hivelog.inspections', $menu_links);
+    $this->assertArrayHasKey('hivelog.queens', $menu_links);
     $this->assertEquals('entity.hive.collection', $menu_links['hivelog.hives']['route_name']);
     $this->assertEquals('entity.hive_inspection.collection', $menu_links['hivelog.inspections']['route_name']);
+    $this->assertEquals('entity.queen.collection', $menu_links['hivelog.queens']['route_name']);
     $this->assertEquals('hivelog.admin', $menu_links['hivelog.hives']['parent']);
     $this->assertEquals('hivelog.admin', $menu_links['hivelog.inspections']['parent']);
+    $this->assertEquals('hivelog.admin', $menu_links['hivelog.queens']['parent']);
   }
 }

--- a/tests/src/Kernel/ControllerCacheMetadataTest.php
+++ b/tests/src/Kernel/ControllerCacheMetadataTest.php
@@ -51,6 +51,7 @@ class ControllerCacheMetadataTest extends KernelTestBase {
     $this->installEntitySchema('apiary');
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
+    $this->installEntitySchema('queen');
     $this->installSchema('file', ['file_usage']);
 
     $user = User::create([
@@ -134,6 +135,15 @@ class ControllerCacheMetadataTest extends KernelTestBase {
       ->getDefinition('hive_inspection')
       ->getListCacheTags();
     foreach ($inspection_list_tags as $tag) {
+      $this->assertContains($tag, $build['#cache']['tags']);
+    }
+
+    // The hive view now surfaces the active queen, so its list cache tag
+    // must be declared so the page invalidates whenever a queen changes.
+    $queen_list_tags = \Drupal::entityTypeManager()
+      ->getDefinition('queen')
+      ->getListCacheTags();
+    foreach ($queen_list_tags as $tag) {
       $this->assertContains($tag, $build['#cache']['tags']);
     }
 

--- a/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
+++ b/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
@@ -50,6 +50,7 @@ class EmbeddedTableFilterPaginationTest extends KernelTestBase {
     $this->installEntitySchema('apiary');
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
+    $this->installEntitySchema('queen');
     $this->installSchema('file', ['file_usage']);
 
     $user = User::create([

--- a/tests/src/Kernel/HiveInspectionTest.php
+++ b/tests/src/Kernel/HiveInspectionTest.php
@@ -123,6 +123,7 @@ class HiveInspectionTest extends KernelTestBase {
     $this->installEntitySchema('apiary');
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
+    $this->installEntitySchema('queen');
     $this->installSchema('file', ['file_usage']);
 
     $this->user = User::create([

--- a/tests/src/Kernel/HiveTest.php
+++ b/tests/src/Kernel/HiveTest.php
@@ -8,6 +8,7 @@ use Drupal\hivelog\Controller\HiveController;
 use Drupal\hivelog\Entity\Apiary;
 use Drupal\hivelog\Entity\Hive;
 use Drupal\hivelog\Entity\HiveInspection;
+use Drupal\hivelog\Entity\Queen;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\user\Entity\User;
 use PHPUnit\Framework\Attributes\Group;
@@ -36,6 +37,13 @@ class HiveTest extends KernelTestBase {
   ];
 
   /**
+   * {@inheritdoc}
+   */
+  protected function installQueenEntitySchema(): void {
+    $this->installEntitySchema('queen');
+  }
+
+  /**
    * A test apiary.
    *
    * @var \Drupal\hivelog\Entity\Apiary
@@ -52,6 +60,7 @@ class HiveTest extends KernelTestBase {
     $this->installEntitySchema('apiary');
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
+    $this->installQueenEntitySchema();
     $this->installSchema('file', ['file_usage']);
 
     $this->apiary = Apiary::create(['name' => 'Test Apiary']);
@@ -86,7 +95,6 @@ class HiveTest extends KernelTestBase {
       'apiary' => $this->apiary->id(),
       'hive_type' => 'langstroth',
       'hive_material' => 'wood',
-      'queen_year' => 2024,
       'bee_breed' => 'buckfast',
       'temperament' => 'calm',
       'status' => 'active',
@@ -98,7 +106,6 @@ class HiveTest extends KernelTestBase {
     $this->assertEquals('Hive 1', $loaded->label());
     $this->assertEquals('langstroth', $loaded->get('hive_type')->value);
     $this->assertEquals('wood', $loaded->get('hive_material')->value);
-    $this->assertEquals(2024, $loaded->get('queen_year')->value);
     $this->assertEquals('buckfast', $loaded->get('bee_breed')->value);
     $this->assertEquals('calm', $loaded->get('temperament')->value);
     $this->assertEquals('active', $loaded->get('status')->value);
@@ -126,83 +133,21 @@ class HiveTest extends KernelTestBase {
   }
 
   /**
-   * Tests queen colour auto-calculation for all year endings.
+   * Tests that queen info is no longer stored on the hive itself.
    *
-   * International queen marking colours:
-   *   White: years ending 1, 6
-   *   Yellow: years ending 2, 7
-   *   Red: years ending 3, 8
-   *   Green: years ending 4, 9
-   *   Blue: years ending 0, 5
+   * Queen tracking now lives on the separate Queen entity (issue #51); the
+   * hive should not expose queen_year or queen_colour base fields anymore.
    */
-  public function testQueenColourAutoCalculation(): void {
-    $expected = [
-      2020 => 'blue',
-      2021 => 'white',
-      2022 => 'yellow',
-      2023 => 'red',
-      2024 => 'green',
-      2025 => 'blue',
-      2026 => 'white',
-      2027 => 'yellow',
-      2028 => 'red',
-      2029 => 'green',
-    ];
-
-    foreach ($expected as $year => $colour) {
-      $hive = Hive::create([
-        'name' => "Hive $year",
-        'apiary' => $this->apiary->id(),
-        'queen_year' => $year,
-        'status' => 'active',
-      ]);
-      $hive->save();
-
-      $loaded = Hive::load($hive->id());
-      $this->assertEquals(
-        $colour,
-        $loaded->get('queen_colour')->value,
-        "Year $year should produce colour '$colour'."
-      );
-    }
-  }
-
-  /**
-   * Tests that queen colour is empty when no queen year is set.
-   */
-  public function testQueenColourWithoutYear(): void {
+  public function testHiveNoLongerStoresQueenInfoDirectly(): void {
     $hive = Hive::create([
-      'name' => 'No Queen Year',
+      'name' => 'No Inline Queen',
       'apiary' => $this->apiary->id(),
       'status' => 'active',
     ]);
     $hive->save();
 
-    $loaded = Hive::load($hive->id());
-    $this->assertEmpty($loaded->get('queen_colour')->value);
-  }
-
-  /**
-   * Tests that queen colour updates when queen year changes.
-   */
-  public function testQueenColourUpdatesOnYearChange(): void {
-    $hive = Hive::create([
-      'name' => 'Requeened Hive',
-      'apiary' => $this->apiary->id(),
-      'queen_year' => 2023,
-      'status' => 'active',
-    ]);
-    $hive->save();
-
-    $loaded = Hive::load($hive->id());
-    $this->assertEquals('red', $loaded->get('queen_colour')->value);
-
-    // Simulate requeening in a new year.
-    $loaded->set('queen_year', 2025);
-    $loaded->save();
-
-    $reloaded = Hive::load($hive->id());
-    $this->assertEquals('blue', $reloaded->get('queen_colour')->value);
+    $this->assertFalse($hive->hasField('queen_year'));
+    $this->assertFalse($hive->hasField('queen_colour'));
   }
 
   /**
@@ -505,6 +450,102 @@ class HiveTest extends KernelTestBase {
   }
 
   /**
+   * Tests that the hive view renders an empty queen section with an add
+   * action when no active queen exists.
+   */
+  public function testHiveViewShowsAddQueenWhenNoActiveQueen(): void {
+    $this->installConfig(['system']);
+
+    $user = User::create([
+      'name' => 'no-queen-tester',
+      'mail' => 'no-queen-tester@example.com',
+    ]);
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    $hive = Hive::create([
+      'name' => 'Queenless Hive',
+      'apiary' => $this->apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    $this->assertNull($hive->getActiveQueen());
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+
+    $this->assertArrayHasKey('queen', $build);
+    $this->assertStringContainsString('No active queen is recorded for this hive.', $html);
+    $this->assertStringContainsString('Add Queen', $html);
+  }
+
+  /**
+   * Tests that the hive view renders the active queen summary, positioned
+   * between the weight histogram and the inspection table.
+   */
+  public function testHiveViewShowsActiveQueenDetails(): void {
+    $this->installConfig(['system']);
+
+    $user = User::create([
+      'name' => 'queen-tester',
+      'mail' => 'queen-tester@example.com',
+    ]);
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    $hive = Hive::create([
+      'name' => 'Queenright Hive',
+      'apiary' => $this->apiary->id(),
+      'status' => 'active',
+    ]);
+    $hive->save();
+
+    $queen = Queen::create([
+      'name' => 'Q-2024-001',
+      'hive' => $hive->id(),
+      'queen_year' => 2024,
+      'introduction_date' => '2024-05-01',
+      'status' => 'active',
+    ]);
+    $queen->save();
+
+    // Add one inspection with a weight so the histogram renders.
+    HiveInspection::create([
+      'hive' => $hive->id(),
+      'inspection_date' => '2024-06-15',
+      'weight' => 30.0,
+    ])->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(HiveController::class);
+    $build = $controller->view($hive);
+
+    // Queen weight must be after the histogram weight so the histogram
+    // stays on top.
+    $this->assertGreaterThan(
+      $build['weight_histogram']['#weight'],
+      $build['queen']['#weight'],
+      'Queen section should sort after the weight histogram.'
+    );
+    // And before the inspections heading so it still precedes the list.
+    $this->assertLessThan(
+      $build['inspections_heading']['#weight'],
+      $build['queen']['#weight'],
+      'Queen section should sort before the inspections heading.'
+    );
+
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('Q-2024-001', $html);
+    // The queen's marking colour is derived from the hatch year.
+    $this->assertStringContainsString('Green', $html);
+    $this->assertStringContainsString('2024-05-01', $html);
+    $this->assertStringContainsString('Edit Queen', $html);
+  }
+
+  /**
    * Tests that the hive view inspection table includes weight before queen.
    */
   public function testHiveViewInspectionTableWeightColumn(): void {
@@ -542,9 +583,15 @@ class HiveTest extends KernelTestBase {
     $this->assertStringContainsString('Weight', $html);
     $this->assertStringContainsString('32.5 kg', $html);
 
-    // Verify Weight column appears before Queen column in the header.
-    $weight_pos = strpos($html, '>Weight<');
-    $queen_pos = strpos($html, '>Queen<');
+    // Verify Weight column appears before Queen column in the inspections
+    // table. Scope the search to the first <table> onward so the Queen
+    // section heading (rendered earlier on the page) doesn't confuse the
+    // ordering check.
+    $table_start = strpos($html, '<table');
+    $this->assertNotFalse($table_start);
+    $table_html = substr($html, $table_start);
+    $weight_pos = strpos($table_html, '>Weight<');
+    $queen_pos = strpos($table_html, '>Queen<');
     $this->assertNotFalse($weight_pos);
     $this->assertNotFalse($queen_pos);
     $this->assertLessThan($queen_pos, $weight_pos, 'Weight column should appear before Queen column.');

--- a/tests/src/Kernel/ModuleDependencyAuditTest.php
+++ b/tests/src/Kernel/ModuleDependencyAuditTest.php
@@ -46,6 +46,7 @@ class ModuleDependencyAuditTest extends KernelTestBase {
     $this->installEntitySchema('apiary');
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
+    $this->installEntitySchema('queen');
     $this->installSchema('file', ['file_usage']);
   }
 
@@ -81,6 +82,7 @@ class ModuleDependencyAuditTest extends KernelTestBase {
     $this->assertNotNull($entity_type_manager->getDefinition('apiary'));
     $this->assertNotNull($entity_type_manager->getDefinition('hive'));
     $this->assertNotNull($entity_type_manager->getDefinition('hive_inspection'));
+    $this->assertNotNull($entity_type_manager->getDefinition('queen'));
   }
 
 }

--- a/tests/src/Kernel/QueenTest.php
+++ b/tests/src/Kernel/QueenTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\hivelog\Kernel;
+
+use Drupal\hivelog\Entity\Apiary;
+use Drupal\hivelog\Entity\Hive;
+use Drupal\hivelog\Entity\Queen;
+use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests the Queen entity.
+ */
+#[Group('hivelog')]
+#[RunTestsInSeparateProcesses]
+class QueenTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'datetime',
+    'options',
+    'file',
+    'image',
+    'geofield',
+    'hivelog',
+  ];
+
+  /**
+   * A test apiary.
+   */
+  protected Apiary $apiary;
+
+  /**
+   * A test hive.
+   */
+  protected Hive $hive;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('apiary');
+    $this->installEntitySchema('hive');
+    $this->installEntitySchema('hive_inspection');
+    $this->installEntitySchema('queen');
+    $this->installSchema('file', ['file_usage']);
+
+    $this->apiary = Apiary::create(['name' => 'Test Apiary']);
+    $this->apiary->save();
+
+    $this->hive = Hive::create([
+      'name' => 'Test Hive',
+      'apiary' => $this->apiary->id(),
+      'status' => 'active',
+    ]);
+    $this->hive->save();
+  }
+
+  /**
+   * Tests basic queen creation and persisted field values.
+   */
+  public function testCreateQueen(): void {
+    $queen = Queen::create([
+      'name' => 'Q-2024-001',
+      'origin' => 'Local breeder',
+      'queen_year' => 2024,
+      'breed' => 'buckfast',
+      'temperament' => 'calm',
+      'purchase_cost' => '35.50',
+      'purchase_date' => '2024-04-01',
+      'hive' => $this->hive->id(),
+      'introduction_date' => '2024-05-10',
+      'status' => 'active',
+      'notes' => 'Mated locally.',
+    ]);
+    $queen->save();
+
+    $loaded = Queen::load($queen->id());
+    $this->assertEquals('Q-2024-001', $loaded->label());
+    $this->assertEquals('Local breeder', $loaded->get('origin')->value);
+    $this->assertEquals(2024, $loaded->get('queen_year')->value);
+    $this->assertEquals('buckfast', $loaded->get('breed')->value);
+    $this->assertEquals('calm', $loaded->get('temperament')->value);
+    $this->assertEquals('35.50', $loaded->get('purchase_cost')->value);
+    $this->assertEquals('2024-04-01', $loaded->get('purchase_date')->value);
+    $this->assertEquals($this->hive->id(), $loaded->get('hive')->target_id);
+    $this->assertEquals('2024-05-10', $loaded->get('introduction_date')->value);
+    $this->assertEquals('active', $loaded->get('status')->value);
+    $this->assertEquals('Mated locally.', $loaded->get('notes')->value);
+  }
+
+  /**
+   * Tests queen colour auto-calculation for every year ending.
+   */
+  public function testQueenColourAutoCalculation(): void {
+    $expected = [
+      2020 => 'blue',
+      2021 => 'white',
+      2022 => 'yellow',
+      2023 => 'red',
+      2024 => 'green',
+      2025 => 'blue',
+      2026 => 'white',
+      2027 => 'yellow',
+      2028 => 'red',
+      2029 => 'green',
+    ];
+
+    foreach ($expected as $year => $colour) {
+      $queen = Queen::create([
+        'name' => "Q-$year",
+        'queen_year' => $year,
+        'status' => 'active',
+      ]);
+      $queen->save();
+
+      $loaded = Queen::load($queen->id());
+      $this->assertEquals(
+        $colour,
+        $loaded->get('queen_colour')->value,
+        "Year $year should produce colour '$colour'.",
+      );
+    }
+  }
+
+  /**
+   * Tests that queen colour is empty when no year is set.
+   */
+  public function testQueenColourWithoutYear(): void {
+    $queen = Queen::create([
+      'name' => 'Q-unknown',
+      'status' => 'active',
+    ]);
+    $queen->save();
+
+    $this->assertEmpty(Queen::load($queen->id())->get('queen_colour')->value);
+  }
+
+  /**
+   * Tests queen colour updates when the year changes.
+   */
+  public function testQueenColourUpdatesOnYearChange(): void {
+    $queen = Queen::create([
+      'name' => 'Q-renewed',
+      'queen_year' => 2023,
+      'status' => 'active',
+    ]);
+    $queen->save();
+    $this->assertEquals('red', Queen::load($queen->id())->get('queen_colour')->value);
+
+    $queen->set('queen_year', 2025);
+    $queen->save();
+    $this->assertEquals('blue', Queen::load($queen->id())->get('queen_colour')->value);
+  }
+
+  /**
+   * Saving a second active queen on a hive marks the first one inactive.
+   */
+  public function testOneActiveQueenPerHiveInvariant(): void {
+    $first = Queen::create([
+      'name' => 'Q-first',
+      'hive' => $this->hive->id(),
+      'queen_year' => 2024,
+      'status' => 'active',
+    ]);
+    $first->save();
+
+    $second = Queen::create([
+      'name' => 'Q-second',
+      'hive' => $this->hive->id(),
+      'queen_year' => 2025,
+      'status' => 'active',
+    ]);
+    $second->save();
+
+    $reloaded_first = Queen::load($first->id());
+    $reloaded_second = Queen::load($second->id());
+
+    $this->assertEquals('inactive', $reloaded_first->get('status')->value);
+    $this->assertEmpty(
+      $reloaded_first->get('hive')->target_id,
+      'Previous queen should be detached from the hive when a new active queen takes over.'
+    );
+    $this->assertEquals('active', $reloaded_second->get('status')->value);
+    $this->assertEquals($this->hive->id(), $reloaded_second->get('hive')->target_id);
+  }
+
+  /**
+   * Marking a queen inactive does not bump other queens on the same hive.
+   */
+  public function testInactiveSaveDoesNotArchiveOtherActiveQueens(): void {
+    $active = Queen::create([
+      'name' => 'Q-active',
+      'hive' => $this->hive->id(),
+      'queen_year' => 2024,
+      'status' => 'active',
+    ]);
+    $active->save();
+
+    // Another queen saved as inactive with the same hive should not touch
+    // the existing active queen.
+    $inactive = Queen::create([
+      'name' => 'Q-spare',
+      'hive' => $this->hive->id(),
+      'queen_year' => 2023,
+      'status' => 'inactive',
+    ]);
+    $inactive->save();
+
+    $this->assertEquals('active', Queen::load($active->id())->get('status')->value);
+  }
+
+  /**
+   * Hive::getActiveQueen() returns the single active queen for the hive.
+   */
+  public function testHiveGetActiveQueen(): void {
+    // No queen yet.
+    $this->assertNull($this->hive->getActiveQueen());
+
+    $queen = Queen::create([
+      'name' => 'Q-current',
+      'hive' => $this->hive->id(),
+      'queen_year' => 2024,
+      'status' => 'active',
+    ]);
+    $queen->save();
+
+    // Reload hive so any cached references are refreshed.
+    $hive = Hive::load($this->hive->id());
+    $active = $hive->getActiveQueen();
+    $this->assertNotNull($active);
+    $this->assertEquals($queen->id(), $active->id());
+
+    // Archive the queen and detach it; the hive should now report no active
+    // queen even though a queen record still exists.
+    $queen->set('status', 'inactive');
+    $queen->set('hive', NULL);
+    $queen->save();
+    $this->assertNull(Hive::load($this->hive->id())->getActiveQueen());
+  }
+
+  /**
+   * Tests updating and deleting a queen.
+   */
+  public function testUpdateAndDeleteQueen(): void {
+    $queen = Queen::create([
+      'name' => 'Q-lifecycle',
+      'queen_year' => 2024,
+      'status' => 'active',
+    ]);
+    $queen->save();
+    $id = $queen->id();
+
+    $queen->set('status', 'inactive');
+    $queen->save();
+    $this->assertEquals('inactive', Queen::load($id)->get('status')->value);
+
+    $queen->delete();
+    $this->assertNull(Queen::load($id));
+  }
+
+}

--- a/tests/src/Unit/Breadcrumb/HivelogBreadcrumbBuilderTest.php
+++ b/tests/src/Unit/Breadcrumb/HivelogBreadcrumbBuilderTest.php
@@ -113,6 +113,27 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
+   * Tests that applies() returns TRUE for queen entity routes.
+   */
+  #[DataProvider('queenRouteProvider')]
+  public function testAppliesReturnsTrueForQueenRoutes(string $route_name): void {
+    $this->assertTrue($this->builder->applies($this->createRouteMatch($route_name)));
+  }
+
+  /**
+   * Data provider for queen entity routes.
+   */
+  public static function queenRouteProvider(): array {
+    return [
+      'collection' => ['entity.queen.collection'],
+      'canonical'  => ['entity.queen.canonical'],
+      'add_form'   => ['entity.queen.add_form'],
+      'edit_form'  => ['entity.queen.edit_form'],
+      'delete_form' => ['entity.queen.delete_form'],
+    ];
+  }
+
+  /**
    * Tests that applies() returns TRUE for hivelog.* custom routes.
    */
   #[DataProvider('hivelogCustomRouteProvider')]
@@ -127,6 +148,7 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     return [
       'hive add'        => ['hivelog.hive.add'],
       'inspection add'  => ['hivelog.inspection.add'],
+      'queen add'       => ['hivelog.queen.add'],
       'admin'           => ['hivelog.admin'],
     ];
   }
@@ -361,6 +383,84 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $this->assertEquals('entity.hive.canonical', $links[4]->getUrl()->getRouteName());
   }
 
+  /**
+   * Queen canonical: queen is the current page; apiary and hive ancestor
+   * links are added when the queen has a hive, queen link itself is NOT.
+   */
+  public function testBuildQueenCanonical(): void {
+    $apiary = $this->createApiaryMock(1, 'Home Apiary');
+    $hive = $this->createHiveMock(5, 'Hive Alpha', $apiary);
+    $queen = $this->createQueenMock(20, 'Q-2024-001', $hive);
+    $route_match = $this->createRouteMatch('entity.queen.canonical');
+    $route_match->method('getParameter')->willReturnMap([
+      ['apiary', NULL],
+      ['hive', NULL],
+      ['hive_inspection', NULL],
+      ['queen', $queen],
+    ]);
+
+    $breadcrumb = $this->builder->build($route_match);
+    $links = $breadcrumb->getLinks();
+
+    $this->assertCount(5, $links);
+    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
+    $this->assertEquals('Hive Alpha', (string) $links[4]->getText());
+    $this->assertContains('queen:20', $breadcrumb->getCacheTags());
+    $this->assertContains('hive:5', $breadcrumb->getCacheTags());
+    $this->assertContains('apiary:1', $breadcrumb->getCacheTags());
+  }
+
+  /**
+   * Queen edit: apiary, hive, and queen ancestor links are all added
+   * (6 links total).
+   */
+  public function testBuildQueenEditForm(): void {
+    $apiary = $this->createApiaryMock(1, 'Home Apiary');
+    $hive = $this->createHiveMock(5, 'Hive Alpha', $apiary);
+    $queen = $this->createQueenMock(20, 'Q-2024-001', $hive);
+    $route_match = $this->createRouteMatch('entity.queen.edit_form');
+    $route_match->method('getParameter')->willReturnMap([
+      ['apiary', NULL],
+      ['hive', NULL],
+      ['hive_inspection', NULL],
+      ['queen', $queen],
+    ]);
+
+    $breadcrumb = $this->builder->build($route_match);
+    $links = $breadcrumb->getLinks();
+
+    $this->assertCount(6, $links);
+    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
+    $this->assertEquals('Hive Alpha', (string) $links[4]->getText());
+    $this->assertEquals('Q-2024-001', (string) $links[5]->getText());
+    $this->assertEquals('entity.queen.canonical', $links[5]->getUrl()->getRouteName());
+    $this->assertEquals(['queen' => 20], $links[5]->getUrl()->getRouteParameters());
+  }
+
+  /**
+   * hivelog.queen.add carries a {hive} route parameter; apiary and hive
+   * ancestor links should both be added (5 links total).
+   */
+  public function testBuildQueenAddRoute(): void {
+    $apiary = $this->createApiaryMock(1, 'Home Apiary');
+    $hive = $this->createHiveMock(9, 'Hive Gamma', $apiary);
+    $route_match = $this->createRouteMatch('hivelog.queen.add');
+    $route_match->method('getParameter')->willReturnMap([
+      ['apiary', NULL],
+      ['hive', $hive],
+      ['hive_inspection', NULL],
+      ['queen', NULL],
+    ]);
+
+    $breadcrumb = $this->builder->build($route_match);
+    $links = $breadcrumb->getLinks();
+
+    $this->assertCount(5, $links);
+    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
+    $this->assertEquals('Hive Gamma', (string) $links[4]->getText());
+    $this->assertEquals('entity.hive.canonical', $links[4]->getUrl()->getRouteName());
+  }
+
   // -------------------------------------------------------------------------
   // Helper methods
   // -------------------------------------------------------------------------
@@ -421,6 +521,24 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $inspection->method('get')->with('hive')->willReturn($hive_ref);
 
     return $inspection;
+  }
+
+  /**
+   * Creates a mock Queen entity referencing the given hive.
+   */
+  private function createQueenMock(int $id, string $label, ContentEntityInterface $hive): ContentEntityInterface {
+    $queen = $this->createMock(ContentEntityInterface::class);
+    $queen->method('id')->willReturn($id);
+    $queen->method('label')->willReturn($label);
+    $queen->method('getCacheTags')->willReturn(["queen:$id"]);
+    $queen->method('getCacheContexts')->willReturn([]);
+    $queen->method('getCacheMaxAge')->willReturn(-1);
+
+    $hive_ref = new \stdClass();
+    $hive_ref->entity = $hive;
+    $queen->method('get')->with('hive')->willReturn($hive_ref);
+
+    return $queen;
   }
 
 }


### PR DESCRIPTION
## Summary
Closes #51. Queens are now first-class entities with their own identifier, provenance, and active/inactive lifecycle. A queen is linked to the hive it is currently installed in, but hives outlive queens — queen info is no longer stored inline on the hive entity.

Saving an active queen on a hive that already has one automatically marks the previous queen inactive and detaches it from the hive, matching the "a queen can only be assigned to one hive at a time" requirement in the issue.

## Changes
- New `queen` content entity (`hivelog_queen`) with fields for name (ID), origin, queen_year + auto-calculated queen_colour, breed, temperament, purchase_cost, purchase_date, hive, introduction_date, status (active/inactive), notes. Status is **Active** or **Inactive**.
- Removed `queen_year`, `queen_colour`, the `QUEEN_COLOUR_MAP` constant and the `preSave` colour-calc from `Hive`. Added `Hive::getActiveQueen()` helper.
- Hive view page renders a Queen section between the weight histogram and the inspection list. Shows an **Add Queen** button when no active queen exists, or the active queen's summary + **Edit Queen** shortcut otherwise. Histogram still sits on top.
- Routes, permissions, admin menu, task tabs and Add action links for queen CRUD, plus a hive-scoped `/hive/{hive}/queen/add`.
- Breadcrumb builder threads **Apiary → Hive → Queen** for queen routes.
- `hivelog_update_10008` installs the queen entity type and drops the `queen_year` / `queen_colour` columns from hive. No data migration — the module is not yet in production.
- Kernel tests for Queen CRUD, colour auto-calc, the one-active-queen invariant and the new hive view queen section; unit tests for the new breadcrumb branch; `ControllerCacheMetadataTest` guards the new queen list cache tag on the hive view; `ApiaryTest` guards the new menu link and collection route.
- `README.md` and `AGENTS.md` updated to describe the four-entity model.

## Test plan
Full hivelog phpunit suite: **115 tests, 1262 assertions, all green**.

```
ddev exec "SIMPLETEST_DB=mysql://db:db@db:3306/db \
  SIMPLETEST_BASE_URL=http://web \
  php /var/www/html/vendor/bin/phpunit \
  -c /var/www/html/web/core \
  /var/www/html/web/modules/hivelog/tests/ \
  --group hivelog"
```

## Artifacts
- Plan: https://app.warp.dev/drive/notebook/ZK4Zw8GzrQEMuPahe11W9A
- Conversation: https://app.warp.dev/conversation/a3e70cfc-076a-4ec4-9541-7f82cc96c30f

Co-Authored-By: Oz <oz-agent@warp.dev>