### PR TITLE
Format queen view with grouped sections and actions (#53)

### DIFF
--- a/src/Controller/QueenController.php
+++ b/src/Controller/QueenController.php
@@ -2,8 +2,10 @@
 
 namespace Drupal\hivelog\Controller;
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityFormBuilderInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\hivelog\Entity\Hive;
@@ -15,15 +17,22 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class QueenController extends ControllerBase {
 
+  /**
+   * The date formatter.
+   */
+  protected DateFormatterInterface $dateFormatter;
+
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     EntityFormBuilderInterface $entity_form_builder,
+    DateFormatterInterface $date_formatter,
   ) {
     // $entityTypeManager and $entityFormBuilder are untyped properties
     // inherited from ControllerBase; assign them rather than redeclaring
     // them with types.
     $this->entityTypeManager = $entity_type_manager;
     $this->entityFormBuilder = $entity_form_builder;
+    $this->dateFormatter = $date_formatter;
   }
 
   /**
@@ -33,6 +42,7 @@ class QueenController extends ControllerBase {
     return new static(
       $container->get('entity_type.manager'),
       $container->get('entity.form_builder'),
+      $container->get('date.formatter'),
     );
   }
 
@@ -51,14 +61,45 @@ class QueenController extends ControllerBase {
   }
 
   /**
-   * Displays a queen entity.
+   * Displays a queen with its fields grouped into readable sections.
+   *
+   * Mirrors the layout used by HiveInspectionController::view so the queen
+   * page looks consistent with the rest of the module rather than dumping
+   * every field inline.
    */
   public function view(Queen $queen) {
-    $view_builder = $this->entityTypeManager->getViewBuilder('queen');
     $build = [
-      'queen' => $view_builder->view($queen),
+      'actions' => $this->buildActions($queen),
     ];
 
+    $build += [
+      'overview' => $this->buildSection($this->t('Overview'), $queen, [
+        'name',
+        'status',
+        'hive',
+        'uid',
+      ]),
+      'identity' => $this->buildSection($this->t('Identity'), $queen, [
+        'origin',
+        'queen_year',
+        'queen_colour',
+        'breed',
+        'temperament',
+      ]),
+      'acquisition' => $this->buildSection($this->t('Acquisition'), $queen, [
+        'purchase_cost',
+        'purchase_date',
+        'introduction_date',
+      ]),
+      'notes' => $this->buildSection($this->t('Notes'), $queen, [
+        'notes',
+      ]),
+    ];
+
+    // Explicit cache metadata.
+    // - user.permissions: action button visibility depends on the current
+    //   user's update/delete access on the queen.
+    // - Queen's own cache tags: invalidate on any update/delete.
     $cache = CacheableMetadata::createFromRenderArray($build)
       ->addCacheContexts(['user.permissions'])
       ->addCacheableDependency($queen);
@@ -72,6 +113,145 @@ class QueenController extends ControllerBase {
    */
   public function title(Queen $queen) {
     return $queen->label();
+  }
+
+  /**
+   * Builds Edit and Delete action links for the queen view.
+   */
+  protected function buildActions(Queen $queen): array {
+    $links = [];
+
+    if ($queen->access('update')) {
+      $links['edit'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Edit'),
+        '#url' => $queen->toUrl('edit-form'),
+        '#attributes' => ['class' => ['button', 'button--primary']],
+      ];
+    }
+
+    if ($queen->access('delete')) {
+      $links['delete'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Delete'),
+        '#url' => $queen->toUrl('delete-form'),
+        '#attributes' => ['class' => ['button', 'button--danger']],
+      ];
+    }
+
+    if (empty($links)) {
+      return [];
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['hivelog-queen-actions']],
+      '#weight' => -10,
+    ] + $links;
+  }
+
+  /**
+   * Builds a consistently formatted queen section.
+   */
+  protected function buildSection($title, Queen $queen, array $fields): array {
+    return [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['hivelog-queen-section'],
+      ],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $title,
+      ],
+      'table' => [
+        '#type' => 'table',
+        '#header' => [
+          $this->t('Field'),
+          $this->t('Value'),
+        ],
+        '#rows' => $this->buildRows($queen, $fields),
+        '#attributes' => [
+          'class' => ['hivelog-queen-table'],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Builds rows for a section table.
+   */
+  protected function buildRows(Queen $queen, array $fields): array {
+    $rows = [];
+
+    foreach ($fields as $field_name) {
+      $rows[] = [
+        [
+          'data' => [
+            '#plain_text' => (string) $queen->get($field_name)->getFieldDefinition()->getLabel(),
+          ],
+        ],
+        [
+          'data' => $this->buildFieldValue($queen, $field_name),
+        ],
+      ];
+    }
+
+    return $rows;
+  }
+
+  /**
+   * Builds the display value for a single queen field.
+   */
+  protected function buildFieldValue(Queen $queen, string $field_name): array {
+    $field = $queen->get($field_name);
+
+    if ($field->isEmpty()) {
+      return [
+        '#plain_text' => (string) $this->t('—'),
+      ];
+    }
+
+    switch ($field_name) {
+      case 'hive':
+      case 'uid':
+        return $field->entity ? $field->entity->toLink()->toRenderable() : [
+          '#plain_text' => (string) $this->t('—'),
+        ];
+
+      case 'purchase_date':
+      case 'introduction_date':
+        $timestamp = strtotime($field->value . ' 00:00:00 UTC');
+        return [
+          '#plain_text' => $timestamp !== FALSE
+            ? $this->dateFormatter->format($timestamp, 'custom', 'Y-m-d')
+            : (string) $field->value,
+        ];
+
+      case 'purchase_cost':
+        return [
+          '#plain_text' => number_format((float) $field->value, 2),
+        ];
+
+      case 'status':
+      case 'queen_colour':
+      case 'breed':
+      case 'temperament':
+        $allowed_values = $field->getSetting('allowed_values');
+        return [
+          '#plain_text' => (string) ($allowed_values[$field->value] ?? $field->value),
+        ];
+
+      case 'notes':
+        return [
+          '#markup' => nl2br(Html::escape((string) $field->value)),
+        ];
+
+      default:
+        return [
+          '#plain_text' => (string) $field->value,
+        ];
+    }
   }
 
 }

--- a/tests/src/Kernel/QueenTest.php
+++ b/tests/src/Kernel/QueenTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\hivelog\Kernel;
 
+use Drupal\hivelog\Controller\QueenController;
 use Drupal\hivelog\Entity\Apiary;
 use Drupal\hivelog\Entity\Hive;
 use Drupal\hivelog\Entity\Queen;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\Role;
+use Drupal\user\Entity\User;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
@@ -268,6 +271,129 @@ class QueenTest extends KernelTestBase {
 
     $queen->delete();
     $this->assertNull(Queen::load($id));
+  }
+
+  /**
+   * Renders the queen canonical view and asserts the sectioned layout,
+   * formatted values, and Edit / Delete action buttons are present.
+   */
+  public function testQueenViewRendersSectionedLayout(): void {
+    $this->installConfig(['system']);
+
+    $user = User::create([
+      'name' => 'queen-view-tester',
+      'mail' => 'queen-view-tester@example.com',
+    ]);
+    $user->save();
+
+    // Grant edit + delete on queens so the action buttons render.
+    $role = Role::create([
+      'id' => 'queen_editor',
+      'label' => 'Queen editor',
+    ]);
+    $role->grantPermission('view queen');
+    $role->grantPermission('edit queen');
+    $role->grantPermission('delete queen');
+    $role->save();
+    $user->addRole('queen_editor');
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    $queen = Queen::create([
+      'name' => 'Q-2024-007',
+      'origin' => 'Highlands Apiaries',
+      'queen_year' => 2024,
+      'breed' => 'buckfast',
+      'temperament' => 'calm',
+      'purchase_cost' => '42.50',
+      'purchase_date' => '2024-04-01',
+      'hive' => $this->hive->id(),
+      'introduction_date' => '2024-05-10',
+      'status' => 'active',
+      'notes' => "Line 1.\nLine 2.",
+      'uid' => $user->id(),
+    ]);
+    $queen->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(QueenController::class);
+    $build = $controller->view($queen);
+
+    // Section render arrays are keyed in the expected order.
+    $this->assertArrayHasKey('actions', $build);
+    $this->assertArrayHasKey('overview', $build);
+    $this->assertArrayHasKey('identity', $build);
+    $this->assertArrayHasKey('acquisition', $build);
+    $this->assertArrayHasKey('notes', $build);
+    $this->assertArrayHasKey('edit', $build['actions']);
+    $this->assertArrayHasKey('delete', $build['actions']);
+
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+
+    // Section headings.
+    $this->assertStringContainsString('Overview', $html);
+    $this->assertStringContainsString('Identity', $html);
+    $this->assertStringContainsString('Acquisition', $html);
+    $this->assertStringContainsString('Notes', $html);
+    // Field / Value column headers from the shared section tables.
+    $this->assertStringContainsString('>Field<', $html);
+    $this->assertStringContainsString('>Value<', $html);
+
+    // Formatted values.
+    $this->assertStringContainsString('Q-2024-007', $html);
+    $this->assertStringContainsString('Highlands Apiaries', $html);
+    // Status and breed are shown using their human-readable labels, not
+    // the raw machine names.
+    $this->assertStringContainsString('Active', $html);
+    $this->assertStringContainsString('Buckfast', $html);
+    // Queen colour derived from the 2024 year → green.
+    $this->assertStringContainsString('Green', $html);
+    // Purchase cost renders with two decimals via number_format.
+    $this->assertStringContainsString('42.50', $html);
+    $this->assertStringContainsString('2024-04-01', $html);
+    $this->assertStringContainsString('2024-05-10', $html);
+    // Notes preserve line breaks as <br />.
+    $this->assertStringContainsString('Line 1.<br', $html);
+
+    // Action buttons.
+    $this->assertStringContainsString('button--primary', $html);
+    $this->assertStringContainsString('button--danger', $html);
+    // Edit button appears before the Delete button.
+    $edit_pos = strpos($html, '>Edit<');
+    $delete_pos = strpos($html, '>Delete<');
+    $this->assertNotFalse($edit_pos);
+    $this->assertNotFalse($delete_pos);
+    $this->assertLessThan($delete_pos, $edit_pos);
+  }
+
+  /**
+   * Empty fields render as an em-dash rather than being hidden or echoing
+   * raw empty values.
+   */
+  public function testQueenViewShowsEmDashForEmptyFields(): void {
+    $this->installConfig(['system']);
+
+    $user = User::create([
+      'name' => 'sparse-queen-tester',
+      'mail' => 'sparse-queen-tester@example.com',
+    ]);
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    $queen = Queen::create([
+      'name' => 'Q-minimal',
+      'status' => 'active',
+    ]);
+    $queen->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(QueenController::class);
+    $build = $controller->view($queen);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+
+    // At least one em-dash should appear for the empty origin / breed /
+    // purchase_date / etc. rows.
+    $this->assertStringContainsString('—', $html);
   }
 
 }


### PR DESCRIPTION
## Summary
Closes #53. The queen canonical page previously used the default view builder, which dumps every field inline with no grouping. This PR refactors `QueenController::view` to mirror `HiveInspectionController::view`, giving the queen page the same sectioned look-and-feel as the rest of the module.

## What changed
- **Edit / Delete action buttons** at the top, gated on per-entity access (primary + danger styling, matching the inspection view).
- **Four sections**, each rendered as an `<h3>` heading + a 2-column Field/Value table:
  - **Overview** — name, status, hive, owner
  - **Identity** — origin, year, colour, breed, temperament
  - **Acquisition** — purchase cost, purchase date, introduction date
  - **Notes**
- **Typed value formatting**:
  - Entity references (`hive`, `uid`) render as links.
  - `purchase_date` and `introduction_date` go through `DateFormatter` (`Y-m-d`).
  - `purchase_cost` is rendered with `number_format(.., 2)`.
  - Enum-backed fields (`status`, `queen_colour`, `breed`, `temperament`) show their human-readable label.
  - Notes preserve newlines via `nl2br(Html::escape(...))`.
  - Empty fields render an em-dash (`—`) instead of a blank.
- Cache metadata declares `user.permissions` + the queen's own tags so the page invalidates correctly when the queen is updated/deleted or when the viewer's access changes.

## Tests
- New `QueenTest::testQueenViewRendersSectionedLayout` asserts every section key, heading, formatted value, action-button classes, and that Edit appears before Delete.
- New `QueenTest::testQueenViewShowsEmDashForEmptyFields` covers the empty-field placeholder.
- Full hivelog phpunit suite: **117 tests, 1310 assertions, all green.**

```
ddev exec "SIMPLETEST_DB=mysql://db:db@db:3306/db \
  SIMPLETEST_BASE_URL=http://web \
  php /var/www/html/vendor/bin/phpunit \
  -c /var/www/html/web/core \
  /var/www/html/web/modules/hivelog/tests/ \
  --group hivelog"
```

## Artifacts
- Conversation: https://app.warp.dev/conversation/a3e70cfc-076a-4ec4-9541-7f82cc96c30f

Co-Authored-By: Oz <oz-agent@warp.dev>