### PR TITLE
Add Queen Observation entity and surface it in the UI (#55)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,17 @@ This file provides guidance to WARP (warp.dev) when working with code in this re
 
 HiveLog is a custom Drupal 11 module (located at `web/modules/hivelog` inside a
 larger CMS checkout) that provides a beekeeping activity logger. It defines
-four custom content entities. Apiaries, hives and inspections form a strict
+five custom content entities. Apiaries, hives and inspections form a strict
 parent–child hierarchy; queens are tracked separately and linked to the
-hive they are currently installed in (hives outlive queens):
+hive they are currently installed in (hives outlive queens); queen
+observations hang off a queen:
 
 ```
 Apiary → Hive → Hive Inspection
               ↑
             Queen (active ↔ inactive)
+              ↓
+            Queen Observation
 ```
 
 Required contrib dependencies: `geofield`, `leaflet` (see
@@ -93,6 +96,13 @@ requires a corresponding update hook (see `hivelog.install`).
   constant (international queen marking convention) AND enforces the
   "one active queen per hive" invariant by demoting any previously active
   queen on the same hive to `inactive` and clearing its `hive` reference.
+- `QueenObservation` — references a `Queen` via `queen` entity_reference
+  (required). Captures point-in-time queen-specific notes separate from
+  hive-level inspections: `observation_date`, `health` (excellent / good /
+  fair / poor), `temperament` (calm / moderate / aggressive), `active`
+  (boolean — observed actively laying / moving), `notes`, `images`.
+  Surfaced from the hive page via an **Add Observation** button next to
+  **Edit Queen**, and listed at the end of the queen canonical page.
 
 Allowed-value lists for hive `type`, `material`, `breed`, `temperament`,
 `status`, queen `breed` / `temperament` / `status`, and the various

--- a/README.md
+++ b/README.md
@@ -15,15 +15,19 @@ HiveLog provides a structured system for beekeepers to:
   queens, so queen info is not stored on the hive itself)
 - Record detailed **inspection logs** covering queen status, brood, stores,
   health, feeding, and management actions
+- Log **queen observations** separately from hive inspections for
+  queen-specific notes (health, temperament, active laying, photos)
 
-The module uses four custom content entities. Apiaries, hives and
+The module uses five custom content entities. Apiaries, hives and
 inspections form a strict parent–child hierarchy; queens are tracked
-separately and linked to a hive:
+separately and linked to a hive; queen observations hang off a queen:
 
 ```
 Apiary → Hive → Hive Inspection
               ↑
             Queen (active ↔ inactive)
+              ↓
+            Queen Observation
 ```
 
 ## Requirements
@@ -75,7 +79,18 @@ After installation, navigate to **Administration → Structure → HiveLog**
    queen on a hive that already has one automatically marks the previous
    queen inactive and detaches it from the hive.
 
-4. **Log inspections** — From the hive view page, click "Add Inspection". Each
+4. **Log queen observations** — From the hive view page, beside the
+   **Edit Queen** button, an **Add Observation** button opens a form
+   scoped to the currently-active queen. Observations are listed at the
+   bottom of the queen page (newest first). Each observation captures:
+   - Observation date
+   - Health (Excellent / Good / Fair / Poor)
+   - Temperament (Calm / Moderate / Aggressive)
+   - Active (was the queen observed actively laying / moving)
+   - Free-text notes
+   - Photos (multi-value image field)
+
+5. **Log inspections** — From the hive view page, click "Add Inspection". Each
    inspection captures:
    - **External check (before opening)** — Flight activity, dead bees, signs of
      robbing, wasps, hive weight (hefting)
@@ -128,6 +143,7 @@ View, Edit, and Delete tabs are available on each entity page.
 | View/Add/Edit/Delete hives       | Per-operation access to hives    |
 | View/Add/Edit/Delete hive inspections | Per-operation access to inspections |
 | View/Add/Edit/Delete queens      | Per-operation access to queens   |
+| View/Add/Edit/Delete queen observations | Per-operation access to queen observations |
 
 Users with "Administer HiveLog" bypass all individual permission checks.
 
@@ -156,6 +172,11 @@ Users with "Administer HiveLog" bypass all individual permission checks.
 | `/admin/hivelog/queen/{id}`                   | View queen             |
 | `/admin/hivelog/queen/{id}/edit`              | Edit queen             |
 | `/admin/hivelog/queen/{id}/delete`            | Delete queen           |
+| `/admin/hivelog/queen-observations`           | Queen observation list |
+| `/admin/hivelog/queen/{id}/observation/add`   | Add observation to queen |
+| `/admin/hivelog/queen-observation/{id}`       | View queen observation |
+| `/admin/hivelog/queen-observation/{id}/edit`  | Edit queen observation |
+| `/admin/hivelog/queen-observation/{id}/delete` | Delete queen observation |
 
 ## Module Structure
 
@@ -176,7 +197,8 @@ hivelog/
 │   │   ├── Apiary.php            # Apiary content entity
 │   │   ├── Hive.php              # Hive content entity
 │   │   ├── HiveInspection.php    # Inspection content entity
-│   │   └── Queen.php             # Queen content entity
+│   │   ├── Queen.php             # Queen content entity
+│   │   └── QueenObservation.php  # Queen observation content entity
 │   ├── Form/
 │   │   ├── ApiaryForm.php        # Apiary add/edit form
 │   │   ├── ApiaryDeleteForm.php
@@ -185,29 +207,35 @@ hivelog/
 │   │   ├── HiveInspectionForm.php    # Inspection add/edit form
 │   │   ├── HiveInspectionDeleteForm.php
 │   │   ├── QueenForm.php         # Queen add/edit form
-│   │   └── QueenDeleteForm.php
+│   │   ├── QueenDeleteForm.php
+│   │   ├── QueenObservationForm.php  # Queen observation add/edit form
+│   │   └── QueenObservationDeleteForm.php
 │   ├── Controller/
 │   │   ├── ApiaryController.php      # Apiary view (with hives table)
 │   │   ├── HiveController.php        # Hive view (queen + histogram + inspections)
 │   │   ├── HiveInspectionController.php  # Inspection view
-│   │   └── QueenController.php       # Queen view + hive-scoped add
+│   │   ├── QueenController.php       # Queen view + hive-scoped add
+│   │   └── QueenObservationController.php  # Observation view + queen-scoped add
 │   ├── Breadcrumb/
 │   │   └── HivelogBreadcrumbBuilder.php  # Breadcrumb builder service
 │   ├── ApiaryListBuilder.php
 │   ├── HiveListBuilder.php
 │   ├── HiveInspectionListBuilder.php
 │   ├── QueenListBuilder.php
+│   ├── QueenObservationListBuilder.php
 │   ├── ApiaryAccessControlHandler.php
 │   ├── HiveAccessControlHandler.php
 │   ├── HiveInspectionAccessControlHandler.php
-│   └── QueenAccessControlHandler.php
+│   ├── QueenAccessControlHandler.php
+│   └── QueenObservationAccessControlHandler.php
 └── tests/
     └── src/
         ├── Kernel/
         │   ├── ApiaryTest.php            # Apiary entity tests
         │   ├── HiveTest.php              # Hive entity + queen section tests
         │   ├── HiveInspectionTest.php    # Inspection entity tests
-        │   └── QueenTest.php             # Queen CRUD + colour + invariant tests
+        │   ├── QueenTest.php             # Queen CRUD + colour + invariant tests
+        │   └── QueenObservationTest.php  # Queen observation CRUD + view tests
         └── Unit/
             └── Breadcrumb/
                 └── HivelogBreadcrumbBuilderTest.php  # Breadcrumb unit tests
@@ -258,6 +286,7 @@ drush cr
      signal is already captured by `queen_cells`).
    - `10008` — Install the `queen` entity type and drop the `queen_year` /
      `queen_colour` columns from `hive`. No data migration.
+   - `10009` — Install the `queen_observation` entity type.
 3. `drush cr` — Rebuilds caches so Drupal picks up any changes to entity
    definitions, routing, or services.
 

--- a/hivelog.install
+++ b/hivelog.install
@@ -284,3 +284,22 @@ function hivelog_update_10008(&$sandbox) {
 
   return t('Installed the Queen entity type and removed queen_year/queen_colour from hives.');
 }
+
+/**
+ * Install the Queen Observation entity type.
+ *
+ * Issue #55: queen-specific observations (health, temperament, active laying,
+ * notes, photos) are recorded separately from hive-level inspections. The
+ * module is not yet in production, so no data migration is required.
+ */
+function hivelog_update_10009(&$sandbox) {
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+  $entity_type_manager = \Drupal::entityTypeManager();
+
+  if (!$entity_definition_update_manager->getEntityType('queen_observation')) {
+    $observation_type = $entity_type_manager->getDefinition('queen_observation');
+    $entity_definition_update_manager->installEntityType($observation_type);
+  }
+
+  return t('Installed the Queen Observation entity type.');
+}

--- a/hivelog.links.menu.yml
+++ b/hivelog.links.menu.yml
@@ -25,3 +25,10 @@ hivelog.queens:
   route_name: entity.queen.collection
   parent: hivelog.admin
   weight: 3
+
+hivelog.queen_observations:
+  title: 'Queen Observations'
+  description: 'View all queen observations.'
+  route_name: entity.queen_observation.collection
+  parent: hivelog.admin
+  weight: 4

--- a/hivelog.links.task.yml
+++ b/hivelog.links.task.yml
@@ -65,3 +65,20 @@ hivelog.queen.delete_tab:
   title: 'Delete'
   base_route: entity.queen.canonical
   weight: 10
+
+# Queen observation tabs.
+hivelog.queen_observation.view_tab:
+  route_name: entity.queen_observation.canonical
+  title: 'View'
+  base_route: entity.queen_observation.canonical
+
+hivelog.queen_observation.edit_tab:
+  route_name: entity.queen_observation.edit_form
+  title: 'Edit'
+  base_route: entity.queen_observation.canonical
+
+hivelog.queen_observation.delete_tab:
+  route_name: entity.queen_observation.delete_form
+  title: 'Delete'
+  base_route: entity.queen_observation.canonical
+  weight: 10

--- a/hivelog.permissions.yml
+++ b/hivelog.permissions.yml
@@ -49,3 +49,15 @@ edit queen:
 
 delete queen:
   title: 'Delete queens'
+
+view queen observation:
+  title: 'View queen observations'
+
+add queen observation:
+  title: 'Add queen observations'
+
+edit queen observation:
+  title: 'Edit queen observations'
+
+delete queen observation:
+  title: 'Delete queen observations'

--- a/hivelog.routing.yml
+++ b/hivelog.routing.yml
@@ -229,3 +229,60 @@ entity.queen.delete_form:
     parameters:
       queen:
         type: entity:queen
+
+# Queen observation routes.
+entity.queen_observation.collection:
+  path: '/admin/hivelog/queen-observations'
+  defaults:
+    _entity_list: 'queen_observation'
+    _title: 'HiveLog - Queen Observations'
+  requirements:
+    _permission: 'view queen observation+administer hivelog'
+
+hivelog.queen_observation.add:
+  path: '/admin/hivelog/queen/{queen}/observation/add'
+  defaults:
+    _controller: '\Drupal\hivelog\Controller\QueenObservationController::addForm'
+    _title: 'Add Queen Observation'
+  requirements:
+    _permission: 'add queen observation+administer hivelog'
+  options:
+    parameters:
+      queen:
+        type: entity:queen
+
+entity.queen_observation.canonical:
+  path: '/admin/hivelog/queen-observation/{queen_observation}'
+  defaults:
+    _controller: '\Drupal\hivelog\Controller\QueenObservationController::view'
+    _title_callback: '\Drupal\hivelog\Controller\QueenObservationController::title'
+  requirements:
+    _permission: 'view queen observation+administer hivelog'
+  options:
+    parameters:
+      queen_observation:
+        type: entity:queen_observation
+
+entity.queen_observation.edit_form:
+  path: '/admin/hivelog/queen-observation/{queen_observation}/edit'
+  defaults:
+    _entity_form: 'queen_observation.edit'
+    _title: 'Edit Queen Observation'
+  requirements:
+    _permission: 'edit queen observation+administer hivelog'
+  options:
+    parameters:
+      queen_observation:
+        type: entity:queen_observation
+
+entity.queen_observation.delete_form:
+  path: '/admin/hivelog/queen-observation/{queen_observation}/delete'
+  defaults:
+    _entity_form: 'queen_observation.delete'
+    _title: 'Delete Queen Observation'
+  requirements:
+    _permission: 'delete queen observation+administer hivelog'
+  options:
+    parameters:
+      queen_observation:
+        type: entity:queen_observation

--- a/src/Breadcrumb/HivelogBreadcrumbBuilder.php
+++ b/src/Breadcrumb/HivelogBreadcrumbBuilder.php
@@ -44,6 +44,7 @@ class HivelogBreadcrumbBuilder implements BreadcrumbBuilderInterface {
       || str_starts_with($route_name, 'entity.hive.')
       || str_starts_with($route_name, 'entity.hive_inspection.')
       || str_starts_with($route_name, 'entity.queen.')
+      || str_starts_with($route_name, 'entity.queen_observation.')
       || str_starts_with($route_name, 'hivelog.');
   }
 
@@ -121,6 +122,31 @@ class HivelogBreadcrumbBuilder implements BreadcrumbBuilderInterface {
       }
       if ($route_name !== 'entity.queen.canonical') {
         $breadcrumb->addLink(Link::createFromRoute($queen->label(), 'entity.queen.canonical', ['queen' => $queen->id()]));
+      }
+    }
+
+    // Queen observation routes: thread Apiary → Hive → Queen ancestry for
+    // observations, skipping hive/apiary if the queen is unassigned.
+    $observation = $route_match->getParameter('queen_observation');
+    if ($observation && is_object($observation)) {
+      $breadcrumb->addCacheableDependency($observation);
+      $observation_queen = $observation->get('queen')->entity;
+      if ($observation_queen) {
+        $breadcrumb->addCacheableDependency($observation_queen);
+        $observation_hive = $observation_queen->get('hive')->entity;
+        if ($observation_hive) {
+          $breadcrumb->addCacheableDependency($observation_hive);
+          $observation_apiary = $observation_hive->get('apiary')->entity;
+          if ($observation_apiary) {
+            $breadcrumb->addCacheableDependency($observation_apiary);
+            $breadcrumb->addLink(Link::createFromRoute($observation_apiary->label(), 'entity.apiary.canonical', ['apiary' => $observation_apiary->id()]));
+          }
+          $breadcrumb->addLink(Link::createFromRoute($observation_hive->label(), 'entity.hive.canonical', ['hive' => $observation_hive->id()]));
+        }
+        $breadcrumb->addLink(Link::createFromRoute($observation_queen->label(), 'entity.queen.canonical', ['queen' => $observation_queen->id()]));
+      }
+      if ($route_name !== 'entity.queen_observation.canonical') {
+        $breadcrumb->addLink(Link::createFromRoute($observation->label(), 'entity.queen_observation.canonical', ['queen_observation' => $observation->id()]));
       }
     }
 

--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -305,6 +305,14 @@ class HiveController extends ControllerBase {
           'class' => ['button', 'hivelog-list-heading__action'],
         ],
       ];
+      $section['add_observation'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Add Observation'),
+        '#url' => Url::fromRoute('hivelog.queen_observation.add', ['queen' => $queen->id()]),
+        '#attributes' => [
+          'class' => ['button', 'hivelog-list-heading__action'],
+        ],
+      ];
     }
     else {
       $section['empty'] = [

--- a/src/Controller/QueenController.php
+++ b/src/Controller/QueenController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityFormBuilderInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Url;
 use Drupal\hivelog\Entity\Hive;
 use Drupal\hivelog\Entity\Queen;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -16,6 +17,16 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Controller for Queen pages.
  */
 class QueenController extends ControllerBase {
+
+  /**
+   * Default number of observations shown per page in the embedded list.
+   */
+  public const OBSERVATIONS_PER_PAGE = 20;
+
+  /**
+   * Pager element id for the embedded observation table.
+   */
+  protected const OBSERVATIONS_PAGER_ELEMENT = 0;
 
   /**
    * The date formatter.
@@ -96,13 +107,108 @@ class QueenController extends ControllerBase {
       ]),
     ];
 
+    // Observations list: rendered at the end of the page in the same style
+    // as the inspections table on the hive page.
+    $build['observations_heading'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['hivelog-list-heading']],
+      '#weight' => 20,
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Observations'),
+        '#attributes' => ['class' => ['hivelog-list-heading__title']],
+      ],
+      'add' => [
+        '#type' => 'link',
+        '#title' => $this->t('Add Observation'),
+        '#url' => Url::fromRoute('hivelog.queen_observation.add', ['queen' => $queen->id()]),
+        '#attributes' => [
+          'class' => ['button', 'button--primary', 'hivelog-list-heading__action'],
+        ],
+      ],
+    ];
+
+    $query = $this->entityTypeManager
+      ->getStorage('queen_observation')
+      ->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('queen', $queen->id())
+      ->sort('observation_date', 'DESC')
+      ->pager(static::OBSERVATIONS_PER_PAGE, static::OBSERVATIONS_PAGER_ELEMENT);
+    $observation_ids = $query->execute();
+
+    $observations = $observation_ids
+      ? $this->entityTypeManager->getStorage('queen_observation')->loadMultiple($observation_ids)
+      : [];
+
+    $header = [
+      $this->t('Date'),
+      $this->t('Health'),
+      $this->t('Temperament'),
+      $this->t('Active'),
+      $this->t('Operations'),
+    ];
+
+    $rows = [];
+    foreach ($observations as $observation) {
+      $health = $observation->get('health')->value;
+      $temperament = $observation->get('temperament')->value;
+      $rows[] = [
+        $observation->toLink($observation->get('observation_date')->value ?: $this->t('N/A'))->toString(),
+        $health ? ($observation->get('health')->getSetting('allowed_values')[$health] ?? $health) : '',
+        $temperament ? ($observation->get('temperament')->getSetting('allowed_values')[$temperament] ?? $temperament) : '',
+        $observation->get('active')->value ? $this->t('Yes') : $this->t('No'),
+        [
+          'data' => [
+            '#type' => 'operations',
+            '#links' => [
+              'view' => [
+                'title' => $this->t('View'),
+                'url' => $observation->toUrl('canonical'),
+              ],
+              'edit' => [
+                'title' => $this->t('Edit'),
+                'url' => $observation->toUrl('edit-form'),
+              ],
+              'delete' => [
+                'title' => $this->t('Delete'),
+                'url' => $observation->toUrl('delete-form'),
+              ],
+            ],
+          ],
+        ],
+      ];
+    }
+
+    $build['observations_table'] = [
+      '#type' => 'table',
+      '#header' => $header,
+      '#rows' => $rows,
+      '#empty' => $this->t('No observations have been recorded for this queen yet.'),
+      '#weight' => 21,
+    ];
+
+    $build['observations_pager'] = [
+      '#type' => 'pager',
+      '#element' => static::OBSERVATIONS_PAGER_ELEMENT,
+      '#weight' => 22,
+    ];
+
     // Explicit cache metadata.
+    // - url.query_args: pager state travels in the query string.
     // - user.permissions: action button visibility depends on the current
-    //   user's update/delete access on the queen.
+    //   user's update/delete access on the queen and observations.
     // - Queen's own cache tags: invalidate on any update/delete.
+    // - Observation list cache tag + each rendered observation's tags:
+    //   invalidate on any observation change.
     $cache = CacheableMetadata::createFromRenderArray($build)
-      ->addCacheContexts(['user.permissions'])
-      ->addCacheableDependency($queen);
+      ->addCacheContexts(['url.query_args', 'user.permissions'])
+      ->addCacheableDependency($queen)
+      ->addCacheTags($this->entityTypeManager->getDefinition('queen_observation')->getListCacheTags());
+    foreach ($observations as $observation) {
+      $cache->addCacheableDependency($observation);
+    }
     $cache->applyTo($build);
 
     return $build;

--- a/src/Controller/QueenObservationController.php
+++ b/src/Controller/QueenObservationController.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace Drupal\hivelog\Controller;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityFormBuilderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\hivelog\Entity\Queen;
+use Drupal\hivelog\Entity\QueenObservation;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Controller for Queen Observation pages.
+ */
+class QueenObservationController extends ControllerBase {
+
+  /**
+   * The file URL generator.
+   */
+  protected FileUrlGeneratorInterface $fileUrlGenerator;
+
+  /**
+   * The date formatter.
+   */
+  protected DateFormatterInterface $dateFormatter;
+
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityFormBuilderInterface $entity_form_builder,
+    FileUrlGeneratorInterface $file_url_generator,
+    DateFormatterInterface $date_formatter,
+  ) {
+    // $entityTypeManager / $entityFormBuilder are untyped ControllerBase
+    // properties; assign them rather than redeclaring them with types.
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityFormBuilder = $entity_form_builder;
+    $this->fileUrlGenerator = $file_url_generator;
+    $this->dateFormatter = $date_formatter;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('entity.form_builder'),
+      $container->get('file_url_generator'),
+      $container->get('date.formatter'),
+    );
+  }
+
+  /**
+   * Provides the add form for an observation within a queen context.
+   */
+  public function addForm(Queen $queen) {
+    $observation = $this->entityTypeManager->getStorage('queen_observation')->create([
+      'queen' => $queen->id(),
+    ]);
+    return $this->entityFormBuilder->getForm($observation, 'add');
+  }
+
+  /**
+   * Displays a queen observation.
+   */
+  public function view(QueenObservation $queen_observation) {
+    $build = [
+      'actions' => $this->buildActions($queen_observation),
+    ];
+
+    $build += [
+      'overview' => $this->buildSection($this->t('Overview'), $queen_observation, [
+        'queen',
+        'observation_date',
+        'uid',
+      ]),
+      'observations' => $this->buildSection($this->t('Observations'), $queen_observation, [
+        'health',
+        'temperament',
+        'active',
+      ]),
+      'notes' => $this->buildSection($this->t('Notes'), $queen_observation, [
+        'notes',
+      ]),
+    ];
+
+    // Photos grid (displayed after notes when images are present).
+    $photos = $this->buildPhotosGrid($queen_observation);
+    if (!empty($photos)) {
+      $build['photos'] = $photos;
+    }
+
+    $cache = CacheableMetadata::createFromRenderArray($build)
+      ->addCacheContexts(['user.permissions'])
+      ->addCacheableDependency($queen_observation);
+    $cache->applyTo($build);
+
+    return $build;
+  }
+
+  /**
+   * Title callback for the observation view page.
+   */
+  public function title(QueenObservation $queen_observation) {
+    return $queen_observation->label();
+  }
+
+  /**
+   * Builds Edit and Delete action links for the observation view.
+   */
+  protected function buildActions(QueenObservation $queen_observation): array {
+    $links = [];
+
+    if ($queen_observation->access('update')) {
+      $links['edit'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Edit'),
+        '#url' => $queen_observation->toUrl('edit-form'),
+        '#attributes' => ['class' => ['button', 'button--primary']],
+      ];
+    }
+
+    if ($queen_observation->access('delete')) {
+      $links['delete'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Delete'),
+        '#url' => $queen_observation->toUrl('delete-form'),
+        '#attributes' => ['class' => ['button', 'button--danger']],
+      ];
+    }
+
+    if (empty($links)) {
+      return [];
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['hivelog-queen-observation-actions']],
+      '#weight' => -10,
+    ] + $links;
+  }
+
+  /**
+   * Builds a grid of observation photos with links to the full-size image.
+   */
+  protected function buildPhotosGrid(QueenObservation $queen_observation): array {
+    if ($queen_observation->get('images')->isEmpty()) {
+      return [];
+    }
+
+    $image_style = $this->entityTypeManager
+      ->getStorage('image_style')
+      ->load('thumbnail');
+
+    $items = [];
+    foreach ($queen_observation->get('images') as $delta => $item) {
+      /** @var \Drupal\file\FileInterface|null $file */
+      $file = $item->entity;
+      if (!$file) {
+        continue;
+      }
+
+      $full_url = $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri());
+      $thumb_url = $image_style ? $image_style->buildUrl($file->getFileUri()) : $full_url;
+      $alt = (string) ($item->alt ?? '');
+
+      $items[] = [
+        'full_url' => $full_url,
+        'thumb_url' => $thumb_url,
+        'alt' => $alt,
+      ];
+    }
+
+    if (empty($items)) {
+      return [];
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['hivelog-queen-observation-section', 'hivelog-queen-observation-photos'],
+      ],
+      '#attached' => [
+        'library' => ['hivelog/images'],
+      ],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $this->t('Photos'),
+      ],
+      'grid' => [
+        '#type' => 'inline_template',
+        '#template' => '<div class="hivelog-photos-grid">{% for item in items %}<a class="hivelog-photos-grid__item" href="{{ item.full_url }}" target="_blank" rel="noopener"><img src="{{ item.thumb_url }}" alt="{{ item.alt }}" loading="lazy" /></a>{% endfor %}</div>',
+        '#context' => [
+          'items' => $items,
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Builds a consistently formatted observation section.
+   */
+  protected function buildSection($title, QueenObservation $queen_observation, array $fields): array {
+    return [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['hivelog-queen-observation-section'],
+      ],
+      'heading' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $title,
+      ],
+      'table' => [
+        '#type' => 'table',
+        '#header' => [
+          $this->t('Field'),
+          $this->t('Value'),
+        ],
+        '#rows' => $this->buildRows($queen_observation, $fields),
+        '#attributes' => [
+          'class' => ['hivelog-queen-observation-table'],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Builds rows for a section table.
+   */
+  protected function buildRows(QueenObservation $queen_observation, array $fields): array {
+    $rows = [];
+
+    foreach ($fields as $field_name) {
+      $rows[] = [
+        [
+          'data' => [
+            '#plain_text' => (string) $queen_observation->get($field_name)->getFieldDefinition()->getLabel(),
+          ],
+        ],
+        [
+          'data' => $this->buildFieldValue($queen_observation, $field_name),
+        ],
+      ];
+    }
+
+    return $rows;
+  }
+
+  /**
+   * Builds the display value for a single observation field.
+   */
+  protected function buildFieldValue(QueenObservation $queen_observation, string $field_name): array {
+    $field = $queen_observation->get($field_name);
+
+    if ($field->isEmpty()) {
+      return [
+        '#plain_text' => (string) $this->t('—'),
+      ];
+    }
+
+    switch ($field_name) {
+      case 'queen':
+      case 'uid':
+        return $field->entity ? $field->entity->toLink()->toRenderable() : [
+          '#plain_text' => (string) $this->t('—'),
+        ];
+
+      case 'observation_date':
+        $timestamp = strtotime($field->value . ' 00:00:00 UTC');
+        return [
+          '#plain_text' => $timestamp !== FALSE
+            ? $this->dateFormatter->format($timestamp, 'custom', 'Y-m-d')
+            : (string) $field->value,
+        ];
+
+      case 'active':
+        return [
+          '#plain_text' => $field->value ? (string) $this->t('Yes') : (string) $this->t('No'),
+        ];
+
+      case 'health':
+      case 'temperament':
+        $allowed_values = $field->getSetting('allowed_values');
+        return [
+          '#plain_text' => (string) ($allowed_values[$field->value] ?? $field->value),
+        ];
+
+      case 'notes':
+        return [
+          '#markup' => nl2br(Html::escape((string) $field->value)),
+        ];
+
+      default:
+        return [
+          '#plain_text' => (string) $field->value,
+        ];
+    }
+  }
+
+}

--- a/src/Entity/QueenObservation.php
+++ b/src/Entity/QueenObservation.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\hivelog\Entity;
+
+use Drupal\Core\Entity\Attribute\ContentEntityType;
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityChangedInterface;
+use Drupal\Core\Entity\EntityChangedTrait;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\hivelog\Form\QueenObservationDeleteForm;
+use Drupal\hivelog\Form\QueenObservationForm;
+use Drupal\hivelog\QueenObservationAccessControlHandler;
+use Drupal\hivelog\QueenObservationListBuilder;
+use Drupal\user\EntityOwnerInterface;
+use Drupal\user\EntityOwnerTrait;
+
+/**
+ * Defines the Queen Observation entity.
+ *
+ * A queen observation captures queen-specific notes (health, temperament,
+ * laying activity, photos, free text) taken at a point in time, separately
+ * from hive-level inspections. Observations reference a queen, which in
+ * turn references the hive the queen is installed in.
+ */
+#[ContentEntityType(
+  id: 'queen_observation',
+  label: new TranslatableMarkup('Queen Observation'),
+  label_collection: new TranslatableMarkup('Queen Observations'),
+  label_singular: new TranslatableMarkup('queen observation'),
+  label_plural: new TranslatableMarkup('queen observations'),
+  handlers: [
+    'list_builder' => QueenObservationListBuilder::class,
+    'form' => [
+      'default' => QueenObservationForm::class,
+      'add' => QueenObservationForm::class,
+      'edit' => QueenObservationForm::class,
+      'delete' => QueenObservationDeleteForm::class,
+    ],
+    'access' => QueenObservationAccessControlHandler::class,
+  ],
+  base_table: 'hivelog_queen_observation',
+  admin_permission: 'administer hivelog',
+  entity_keys: [
+    'id' => 'id',
+    'uuid' => 'uuid',
+    'owner' => 'uid',
+  ],
+  links: [
+    'canonical' => '/admin/hivelog/queen-observation/{queen_observation}',
+    'edit-form' => '/admin/hivelog/queen-observation/{queen_observation}/edit',
+    'delete-form' => '/admin/hivelog/queen-observation/{queen_observation}/delete',
+    'collection' => '/admin/hivelog/queen-observations',
+  ],
+)]
+class QueenObservation extends ContentEntityBase implements EntityChangedInterface, EntityOwnerInterface {
+
+  use EntityChangedTrait;
+  use EntityOwnerTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function label() {
+    $date = $this->get('observation_date')->value;
+    $queen = $this->get('queen')->entity;
+    $queen_name = $queen ? $queen->label() : t('Unknown');
+    return t('Observation of @queen on @date', [
+      '@queen' => $queen_name,
+      '@date' => $date ?: t('unknown date'),
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+    $fields = parent::baseFieldDefinitions($entity_type);
+    $fields += static::ownerBaseFieldDefinitions($entity_type);
+
+    $fields['queen'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Queen'))
+      ->setDescription(t('The queen being observed.'))
+      ->setRequired(TRUE)
+      ->setSetting('target_type', 'queen')
+      ->setDisplayOptions('form', [
+        'type' => 'entity_reference_autocomplete',
+        'weight' => 0,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'entity_reference_label',
+        'weight' => 0,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['observation_date'] = BaseFieldDefinition::create('datetime')
+      ->setLabel(t('Observation Date'))
+      ->setDescription(t('The date of the observation.'))
+      ->setRequired(TRUE)
+      ->setSetting('datetime_type', 'date')
+      ->setDisplayOptions('form', [
+        'type' => 'datetime_default',
+        'weight' => 1,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'datetime_default',
+        'weight' => 1,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['health'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(t('Health'))
+      ->setDescription(t('The queen\'s apparent health at the time of this observation.'))
+      ->setSetting('allowed_values', [
+        'excellent' => 'Excellent',
+        'good' => 'Good',
+        'fair' => 'Fair',
+        'poor' => 'Poor',
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'options_select',
+        'weight' => 2,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'list_default',
+        'weight' => 2,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['temperament'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(t('Temperament'))
+      ->setDescription(t('The queen\'s temperament as observed.'))
+      ->setSetting('allowed_values', [
+        'calm' => 'Calm',
+        'moderate' => 'Moderate',
+        'aggressive' => 'Aggressive',
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'options_select',
+        'weight' => 3,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'list_default',
+        'weight' => 3,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['active'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Active'))
+      ->setDescription(t('Was the queen observed actively laying / moving on the comb?'))
+      ->setDefaultValue(FALSE)
+      ->setDisplayOptions('form', [
+        'type' => 'boolean_checkbox',
+        'weight' => 4,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'inline',
+        'type' => 'boolean',
+        'weight' => 4,
+        'settings' => [
+          'format' => 'yes-no',
+        ],
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['notes'] = BaseFieldDefinition::create('string_long')
+      ->setLabel(t('Notes'))
+      ->setDescription(t('Free-text observations about the queen.'))
+      ->setDisplayOptions('form', [
+        'type' => 'string_textarea',
+        'weight' => 5,
+        'settings' => [
+          'rows' => 4,
+        ],
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'basic_string',
+        'weight' => 5,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['images'] = BaseFieldDefinition::create('image')
+      ->setLabel(t('Pictures'))
+      ->setDescription(t('Photos taken during this queen observation.'))
+      ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+      ->setSetting('file_directory', 'hivelog/queen-observation')
+      ->setSetting('file_extensions', 'png gif jpg jpeg webp')
+      ->setSetting('alt_field', TRUE)
+      ->setSetting('alt_field_required', FALSE)
+      ->setDisplayOptions('form', [
+        'type' => 'image_image',
+        'weight' => 6,
+        'settings' => [
+          'progress_indicator' => 'throbber',
+          'preview_image_style' => 'thumbnail',
+        ],
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'hidden',
+        'type' => 'image',
+        'weight' => 6,
+        'settings' => [
+          'image_style' => 'medium',
+          'image_link' => 'file',
+        ],
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['uid']
+      ->setLabel(t('Observer'))
+      ->setDescription(t('The user who made this observation.'))
+      ->setDisplayOptions('form', [
+        'type' => 'entity_reference_autocomplete',
+        'weight' => 7,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'entity_reference_label',
+        'weight' => 7,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['created'] = BaseFieldDefinition::create('created')
+      ->setLabel(t('Created'))
+      ->setDescription(t('The time the observation was recorded.'));
+
+    $fields['changed'] = BaseFieldDefinition::create('changed')
+      ->setLabel(t('Changed'))
+      ->setDescription(t('The time the observation was last updated.'));
+
+    return $fields;
+  }
+
+}

--- a/src/Form/QueenObservationDeleteForm.php
+++ b/src/Form/QueenObservationDeleteForm.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\hivelog\Form;
+
+use Drupal\Core\Entity\ContentEntityDeleteForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Form handler for Queen Observation delete forms.
+ */
+class QueenObservationDeleteForm extends ContentEntityDeleteForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Are you sure you want to delete this queen observation?');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('entity.queen_observation.canonical', [
+      'queen_observation' => $this->entity->id(),
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $queen_id = $this->entity->get('queen')->target_id;
+    $this->entity->delete();
+    $this->messenger()->addStatus($this->t('Queen observation has been deleted.'));
+
+    if ($queen_id) {
+      $form_state->setRedirectUrl(new Url('entity.queen.canonical', ['queen' => $queen_id]));
+    }
+    else {
+      $form_state->setRedirectUrl(new Url('entity.queen.collection'));
+    }
+  }
+
+}

--- a/src/Form/QueenObservationForm.php
+++ b/src/Form/QueenObservationForm.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\hivelog\Form;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Form handler for Queen Observation add/edit forms.
+ */
+class QueenObservationForm extends ContentEntityForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    // Default observation_date to today for new observations so the user
+    // can usually skip straight to the content.
+    if ($this->entity->isNew() && $this->entity->get('observation_date')->isEmpty()) {
+      $this->entity->set('observation_date', date('Y-m-d'));
+    }
+    return parent::form($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $entity = $this->entity;
+    $status = $entity->save();
+
+    if ($status === SAVED_NEW) {
+      $this->messenger()->addStatus($this->t('Queen observation has been recorded.'));
+    }
+    else {
+      $this->messenger()->addStatus($this->t('Queen observation has been updated.'));
+    }
+
+    // Redirect to the parent queen view when possible.
+    $queen_id = $entity->get('queen')->target_id;
+    if ($queen_id) {
+      $form_state->setRedirect('entity.queen.canonical', ['queen' => $queen_id]);
+    }
+    else {
+      $form_state->setRedirect('entity.queen.collection');
+    }
+  }
+
+}

--- a/src/QueenObservationAccessControlHandler.php
+++ b/src/QueenObservationAccessControlHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\hivelog;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityAccessControlHandler;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Access control handler for Queen Observation entities.
+ */
+class QueenObservationAccessControlHandler extends EntityAccessControlHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    if ($account->hasPermission('administer hivelog')) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+
+    switch ($operation) {
+      case 'view':
+        return AccessResult::allowedIfHasPermission($account, 'view queen observation');
+
+      case 'update':
+        return AccessResult::allowedIfHasPermission($account, 'edit queen observation');
+
+      case 'delete':
+        return AccessResult::allowedIfHasPermission($account, 'delete queen observation');
+    }
+
+    return AccessResult::neutral();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
+    return AccessResult::allowedIfHasPermissions($account, [
+      'administer hivelog',
+      'add queen observation',
+    ], 'OR');
+  }
+
+}

--- a/src/QueenObservationListBuilder.php
+++ b/src/QueenObservationListBuilder.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\hivelog;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityListBuilder;
+
+/**
+ * Provides a list builder for Queen Observation entities.
+ */
+class QueenObservationListBuilder extends EntityListBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['date'] = $this->t('Date');
+    $header['queen'] = $this->t('Queen');
+    $header['health'] = $this->t('Health');
+    $header['temperament'] = $this->t('Temperament');
+    $header['active'] = $this->t('Active');
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    $row['date'] = $entity->toLink($entity->get('observation_date')->value ?: $this->t('N/A'));
+
+    $queen = $entity->get('queen')->entity;
+    $row['queen'] = $queen ? $queen->toLink() : '';
+
+    $health = $entity->get('health')->value;
+    $row['health'] = $health ? ($entity->get('health')->getSetting('allowed_values')[$health] ?? $health) : '';
+
+    $temperament = $entity->get('temperament')->value;
+    $row['temperament'] = $temperament ? ($entity->get('temperament')->getSetting('allowed_values')[$temperament] ?? $temperament) : '';
+
+    $row['active'] = $entity->get('active')->value ? $this->t('Yes') : $this->t('No');
+
+    return $row + parent::buildRow($entity);
+  }
+
+}

--- a/tests/src/Kernel/ApiaryTest.php
+++ b/tests/src/Kernel/ApiaryTest.php
@@ -53,6 +53,7 @@ class ApiaryTest extends KernelTestBase {
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
     $this->installEntitySchema('queen');
+    $this->installEntitySchema('queen_observation');
     $this->installSchema('file', ['file_usage']);
 
     $this->user = User::create([
@@ -228,23 +229,29 @@ class ApiaryTest extends KernelTestBase {
     $hive_route = $route_provider->getRouteByName('entity.hive.collection');
     $inspection_route = $route_provider->getRouteByName('entity.hive_inspection.collection');
     $queen_route = $route_provider->getRouteByName('entity.queen.collection');
+    $observation_route = $route_provider->getRouteByName('entity.queen_observation.collection');
 
     $this->assertEquals('/admin/hivelog/hives', $hive_route->getPath());
     $this->assertEquals('/admin/hivelog/inspections', $inspection_route->getPath());
     $this->assertEquals('/admin/hivelog/queens', $queen_route->getPath());
+    $this->assertEquals('/admin/hivelog/queen-observations', $observation_route->getPath());
     $this->assertEquals('view hive+administer hivelog', $hive_route->getRequirement('_permission'));
     $this->assertEquals('view hive inspection+administer hivelog', $inspection_route->getRequirement('_permission'));
     $this->assertEquals('view queen+administer hivelog', $queen_route->getRequirement('_permission'));
+    $this->assertEquals('view queen observation+administer hivelog', $observation_route->getRequirement('_permission'));
 
     $menu_links = \Drupal::service('plugin.manager.menu.link')->getDefinitions();
     $this->assertArrayHasKey('hivelog.hives', $menu_links);
     $this->assertArrayHasKey('hivelog.inspections', $menu_links);
     $this->assertArrayHasKey('hivelog.queens', $menu_links);
+    $this->assertArrayHasKey('hivelog.queen_observations', $menu_links);
     $this->assertEquals('entity.hive.collection', $menu_links['hivelog.hives']['route_name']);
     $this->assertEquals('entity.hive_inspection.collection', $menu_links['hivelog.inspections']['route_name']);
     $this->assertEquals('entity.queen.collection', $menu_links['hivelog.queens']['route_name']);
+    $this->assertEquals('entity.queen_observation.collection', $menu_links['hivelog.queen_observations']['route_name']);
     $this->assertEquals('hivelog.admin', $menu_links['hivelog.hives']['parent']);
     $this->assertEquals('hivelog.admin', $menu_links['hivelog.inspections']['parent']);
     $this->assertEquals('hivelog.admin', $menu_links['hivelog.queens']['parent']);
+    $this->assertEquals('hivelog.admin', $menu_links['hivelog.queen_observations']['parent']);
   }
 }

--- a/tests/src/Kernel/ControllerCacheMetadataTest.php
+++ b/tests/src/Kernel/ControllerCacheMetadataTest.php
@@ -52,6 +52,7 @@ class ControllerCacheMetadataTest extends KernelTestBase {
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
     $this->installEntitySchema('queen');
+    $this->installEntitySchema('queen_observation');
     $this->installSchema('file', ['file_usage']);
 
     $user = User::create([

--- a/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
+++ b/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
@@ -51,6 +51,7 @@ class EmbeddedTableFilterPaginationTest extends KernelTestBase {
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
     $this->installEntitySchema('queen');
+    $this->installEntitySchema('queen_observation');
     $this->installSchema('file', ['file_usage']);
 
     $user = User::create([

--- a/tests/src/Kernel/HiveInspectionTest.php
+++ b/tests/src/Kernel/HiveInspectionTest.php
@@ -124,6 +124,7 @@ class HiveInspectionTest extends KernelTestBase {
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
     $this->installEntitySchema('queen');
+    $this->installEntitySchema('queen_observation');
     $this->installSchema('file', ['file_usage']);
 
     $this->user = User::create([

--- a/tests/src/Kernel/HiveTest.php
+++ b/tests/src/Kernel/HiveTest.php
@@ -41,6 +41,7 @@ class HiveTest extends KernelTestBase {
    */
   protected function installQueenEntitySchema(): void {
     $this->installEntitySchema('queen');
+    $this->installEntitySchema('queen_observation');
   }
 
   /**
@@ -543,6 +544,17 @@ class HiveTest extends KernelTestBase {
     $this->assertStringContainsString('Green', $html);
     $this->assertStringContainsString('2024-05-01', $html);
     $this->assertStringContainsString('Edit Queen', $html);
+    // Issue #55: Add Observation button renders beside Edit Queen.
+    $this->assertStringContainsString('Add Observation', $html);
+    $edit_pos = strpos($html, 'Edit Queen');
+    $add_pos = strpos($html, 'Add Observation');
+    $this->assertNotFalse($edit_pos);
+    $this->assertNotFalse($add_pos);
+    $this->assertLessThan(
+      $add_pos,
+      $edit_pos,
+      'Edit Queen button should render before Add Observation button.'
+    );
   }
 
   /**

--- a/tests/src/Kernel/ModuleDependencyAuditTest.php
+++ b/tests/src/Kernel/ModuleDependencyAuditTest.php
@@ -47,6 +47,7 @@ class ModuleDependencyAuditTest extends KernelTestBase {
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
     $this->installEntitySchema('queen');
+    $this->installEntitySchema('queen_observation');
     $this->installSchema('file', ['file_usage']);
   }
 
@@ -83,6 +84,7 @@ class ModuleDependencyAuditTest extends KernelTestBase {
     $this->assertNotNull($entity_type_manager->getDefinition('hive'));
     $this->assertNotNull($entity_type_manager->getDefinition('hive_inspection'));
     $this->assertNotNull($entity_type_manager->getDefinition('queen'));
+    $this->assertNotNull($entity_type_manager->getDefinition('queen_observation'));
   }
 
 }

--- a/tests/src/Kernel/QueenObservationTest.php
+++ b/tests/src/Kernel/QueenObservationTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\hivelog\Kernel;
+
+use Drupal\hivelog\Controller\QueenObservationController;
+use Drupal\hivelog\Entity\Apiary;
+use Drupal\hivelog\Entity\Hive;
+use Drupal\hivelog\Entity\Queen;
+use Drupal\hivelog\Entity\QueenObservation;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\Role;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests the Queen Observation entity.
+ */
+#[Group('hivelog')]
+#[RunTestsInSeparateProcesses]
+class QueenObservationTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'datetime',
+    'options',
+    'file',
+    'image',
+    'geofield',
+    'hivelog',
+  ];
+
+  /**
+   * A test apiary.
+   */
+  protected Apiary $apiary;
+
+  /**
+   * A test hive.
+   */
+  protected Hive $hive;
+
+  /**
+   * A test queen.
+   */
+  protected Queen $queen;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('apiary');
+    $this->installEntitySchema('hive');
+    $this->installEntitySchema('hive_inspection');
+    $this->installEntitySchema('queen');
+    $this->installEntitySchema('queen_observation');
+    $this->installSchema('file', ['file_usage']);
+
+    $this->apiary = Apiary::create(['name' => 'Test Apiary']);
+    $this->apiary->save();
+
+    $this->hive = Hive::create([
+      'name' => 'Test Hive',
+      'apiary' => $this->apiary->id(),
+      'status' => 'active',
+    ]);
+    $this->hive->save();
+
+    $this->queen = Queen::create([
+      'name' => 'Q-test',
+      'hive' => $this->hive->id(),
+      'queen_year' => 2024,
+      'status' => 'active',
+    ]);
+    $this->queen->save();
+  }
+
+  /**
+   * Tests creating, updating and deleting a queen observation.
+   */
+  public function testCrud(): void {
+    $observation = QueenObservation::create([
+      'queen' => $this->queen->id(),
+      'observation_date' => '2025-06-15',
+      'health' => 'good',
+      'temperament' => 'calm',
+      'active' => TRUE,
+      'notes' => 'Laying well on multiple frames.',
+    ]);
+    $observation->save();
+
+    $loaded = QueenObservation::load($observation->id());
+    $this->assertEquals($this->queen->id(), $loaded->get('queen')->target_id);
+    $this->assertEquals('2025-06-15', $loaded->get('observation_date')->value);
+    $this->assertEquals('good', $loaded->get('health')->value);
+    $this->assertEquals('calm', $loaded->get('temperament')->value);
+    $this->assertTrue((bool) $loaded->get('active')->value);
+    $this->assertEquals('Laying well on multiple frames.', $loaded->get('notes')->value);
+
+    // Label mentions the queen name and date.
+    $this->assertStringContainsString('Q-test', (string) $loaded->label());
+    $this->assertStringContainsString('2025-06-15', (string) $loaded->label());
+
+    // Update.
+    $observation->set('health', 'fair');
+    $observation->set('active', FALSE);
+    $observation->save();
+    $reloaded = QueenObservation::load($observation->id());
+    $this->assertEquals('fair', $reloaded->get('health')->value);
+    $this->assertFalse((bool) $reloaded->get('active')->value);
+
+    // Delete.
+    $id = $observation->id();
+    $observation->delete();
+    $this->assertNull(QueenObservation::load($id));
+  }
+
+  /**
+   * Tests the queen-scoped add form pre-populates the queen reference on
+   * the new observation entity.
+   */
+  public function testAddFormPrePopulatesQueenReference(): void {
+    $this->installConfig(['system']);
+
+    $user = User::create([
+      'name' => 'observation-add-tester',
+      'mail' => 'observation-add-tester@example.com',
+    ]);
+    $user->save();
+    $role = Role::create([
+      'id' => 'observation_adder',
+      'label' => 'Observation adder',
+    ]);
+    $role->grantPermission('add queen observation');
+    $role->save();
+    $user->addRole('observation_adder');
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    // Build the form via the controller's addForm() method. We can't easily
+    // introspect the rendered widget's default value, so instead mirror the
+    // entity creation step the controller performs and assert the queen
+    // reference is set correctly on the new observation. This also exercises
+    // the route-parameter → entity path.
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(QueenObservationController::class);
+    $form = $controller->addForm($this->queen);
+    $this->assertIsArray($form);
+
+    $new = \Drupal::entityTypeManager()->getStorage('queen_observation')->create([
+      'queen' => $this->queen->id(),
+    ]);
+    $this->assertEquals($this->queen->id(), $new->get('queen')->target_id);
+  }
+
+  /**
+   * Renders the queen observation canonical view and asserts the sectioned
+   * layout, formatted values and Edit/Delete action buttons.
+   */
+  public function testObservationViewRendersSectionedLayout(): void {
+    $this->installConfig(['system']);
+
+    $user = User::create([
+      'name' => 'observation-view-tester',
+      'mail' => 'observation-view-tester@example.com',
+    ]);
+    $user->save();
+    $role = Role::create([
+      'id' => 'observation_editor',
+      'label' => 'Observation editor',
+    ]);
+    $role->grantPermission('view queen observation');
+    $role->grantPermission('edit queen observation');
+    $role->grantPermission('delete queen observation');
+    $role->save();
+    $user->addRole('observation_editor');
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    $observation = QueenObservation::create([
+      'queen' => $this->queen->id(),
+      'observation_date' => '2025-06-15',
+      'health' => 'excellent',
+      'temperament' => 'calm',
+      'active' => TRUE,
+      'notes' => "Line 1.\nLine 2.",
+      'uid' => $user->id(),
+    ]);
+    $observation->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(QueenObservationController::class);
+    $build = $controller->view($observation);
+
+    $this->assertArrayHasKey('actions', $build);
+    $this->assertArrayHasKey('overview', $build);
+    $this->assertArrayHasKey('observations', $build);
+    $this->assertArrayHasKey('notes', $build);
+    $this->assertArrayHasKey('edit', $build['actions']);
+    $this->assertArrayHasKey('delete', $build['actions']);
+
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('Overview', $html);
+    $this->assertStringContainsString('Observations', $html);
+    $this->assertStringContainsString('Notes', $html);
+    // Human-readable enum labels.
+    $this->assertStringContainsString('Excellent', $html);
+    $this->assertStringContainsString('Calm', $html);
+    // Yes/No for the active boolean.
+    $this->assertStringContainsString('Yes', $html);
+    // Notes preserve newlines.
+    $this->assertStringContainsString('Line 1.<br', $html);
+    // Action buttons.
+    $this->assertStringContainsString('button--primary', $html);
+    $this->assertStringContainsString('button--danger', $html);
+  }
+
+}

--- a/tests/src/Kernel/QueenTest.php
+++ b/tests/src/Kernel/QueenTest.php
@@ -57,6 +57,7 @@ class QueenTest extends KernelTestBase {
     $this->installEntitySchema('hive');
     $this->installEntitySchema('hive_inspection');
     $this->installEntitySchema('queen');
+    $this->installEntitySchema('queen_observation');
     $this->installSchema('file', ['file_usage']);
 
     $this->apiary = Apiary::create(['name' => 'Test Apiary']);
@@ -364,6 +365,99 @@ class QueenTest extends KernelTestBase {
     $this->assertNotFalse($edit_pos);
     $this->assertNotFalse($delete_pos);
     $this->assertLessThan($delete_pos, $edit_pos);
+  }
+
+  /**
+   * The queen page embeds an observations list with an Add Observation
+   * action and renders each recorded observation with health/temperament
+   * labels.
+   */
+  public function testQueenViewRendersObservationsList(): void {
+    $this->installConfig(['system']);
+
+    $user = User::create([
+      'name' => 'observation-list-tester',
+      'mail' => 'observation-list-tester@example.com',
+    ]);
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    $queen = Queen::create([
+      'name' => 'Q-observed',
+      'hive' => $this->hive->id(),
+      'queen_year' => 2024,
+      'status' => 'active',
+    ]);
+    $queen->save();
+
+    $storage = \Drupal::entityTypeManager()->getStorage('queen_observation');
+    $storage->create([
+      'queen' => $queen->id(),
+      'observation_date' => '2025-06-01',
+      'health' => 'good',
+      'temperament' => 'calm',
+      'active' => TRUE,
+      'notes' => 'Laying in a solid pattern.',
+    ])->save();
+    $storage->create([
+      'queen' => $queen->id(),
+      'observation_date' => '2025-07-15',
+      'health' => 'fair',
+      'temperament' => 'moderate',
+      'active' => FALSE,
+    ])->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(QueenController::class);
+    $build = $controller->view($queen);
+
+    $this->assertArrayHasKey('observations_heading', $build);
+    $this->assertArrayHasKey('observations_table', $build);
+    $this->assertArrayHasKey('observations_pager', $build);
+    // Two observation rows rendered.
+    $this->assertCount(2, $build['observations_table']['#rows']);
+
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('Observations', $html);
+    $this->assertStringContainsString('Add Observation', $html);
+    $this->assertStringContainsString('2025-06-01', $html);
+    $this->assertStringContainsString('2025-07-15', $html);
+    // Human-readable labels rendered for enum fields.
+    $this->assertStringContainsString('Good', $html);
+    $this->assertStringContainsString('Fair', $html);
+    $this->assertStringContainsString('Moderate', $html);
+  }
+
+  /**
+   * Empty observations list shows a sensible empty message.
+   */
+  public function testQueenViewObservationsListEmptyMessage(): void {
+    $this->installConfig(['system']);
+
+    $user = User::create([
+      'name' => 'empty-observation-tester',
+      'mail' => 'empty-observation-tester@example.com',
+    ]);
+    $user->save();
+    \Drupal::currentUser()->setAccount($user);
+
+    $queen = Queen::create([
+      'name' => 'Q-empty-observations',
+      'hive' => $this->hive->id(),
+      'queen_year' => 2024,
+      'status' => 'active',
+    ]);
+    $queen->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(QueenController::class);
+    $build = $controller->view($queen);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+
+    $this->assertStringContainsString(
+      'No observations have been recorded for this queen yet.',
+      $html
+    );
   }
 
   /**

--- a/tests/src/Unit/Breadcrumb/HivelogBreadcrumbBuilderTest.php
+++ b/tests/src/Unit/Breadcrumb/HivelogBreadcrumbBuilderTest.php
@@ -134,6 +134,26 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
+   * Tests that applies() returns TRUE for queen observation entity routes.
+   */
+  #[DataProvider('queenObservationRouteProvider')]
+  public function testAppliesReturnsTrueForQueenObservationRoutes(string $route_name): void {
+    $this->assertTrue($this->builder->applies($this->createRouteMatch($route_name)));
+  }
+
+  /**
+   * Data provider for queen observation entity routes.
+   */
+  public static function queenObservationRouteProvider(): array {
+    return [
+      'collection' => ['entity.queen_observation.collection'],
+      'canonical'  => ['entity.queen_observation.canonical'],
+      'edit_form'  => ['entity.queen_observation.edit_form'],
+      'delete_form' => ['entity.queen_observation.delete_form'],
+    ];
+  }
+
+  /**
    * Tests that applies() returns TRUE for hivelog.* custom routes.
    */
   #[DataProvider('hivelogCustomRouteProvider')]
@@ -149,6 +169,7 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
       'hive add'        => ['hivelog.hive.add'],
       'inspection add'  => ['hivelog.inspection.add'],
       'queen add'       => ['hivelog.queen.add'],
+      'observation add' => ['hivelog.queen_observation.add'],
       'admin'           => ['hivelog.admin'],
     ];
   }
@@ -438,6 +459,94 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
   }
 
   /**
+   * Queen observation canonical: observation is the current page; apiary,
+   * hive, and queen ancestor links are added when the queen has a hive;
+   * the observation link itself is NOT.
+   */
+  public function testBuildQueenObservationCanonical(): void {
+    $apiary = $this->createApiaryMock(1, 'Home Apiary');
+    $hive = $this->createHiveMock(5, 'Hive Alpha', $apiary);
+    $queen = $this->createQueenMock(20, 'Q-2024-001', $hive);
+    $observation = $this->createObservationMock(30, 'Observation A', $queen);
+    $route_match = $this->createRouteMatch('entity.queen_observation.canonical');
+    $route_match->method('getParameter')->willReturnMap([
+      ['apiary', NULL],
+      ['hive', NULL],
+      ['hive_inspection', NULL],
+      ['queen', NULL],
+      ['queen_observation', $observation],
+    ]);
+
+    $breadcrumb = $this->builder->build($route_match);
+    $links = $breadcrumb->getLinks();
+
+    $this->assertCount(6, $links);
+    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
+    $this->assertEquals('Hive Alpha', (string) $links[4]->getText());
+    $this->assertEquals('Q-2024-001', (string) $links[5]->getText());
+    $this->assertContains('queen_observation:30', $breadcrumb->getCacheTags());
+    $this->assertContains('queen:20', $breadcrumb->getCacheTags());
+    $this->assertContains('hive:5', $breadcrumb->getCacheTags());
+    $this->assertContains('apiary:1', $breadcrumb->getCacheTags());
+  }
+
+  /**
+   * Queen observation edit: apiary, hive, queen, and observation ancestor
+   * links are added (7 links total).
+   */
+  public function testBuildQueenObservationEditForm(): void {
+    $apiary = $this->createApiaryMock(1, 'Home Apiary');
+    $hive = $this->createHiveMock(5, 'Hive Alpha', $apiary);
+    $queen = $this->createQueenMock(20, 'Q-2024-001', $hive);
+    $observation = $this->createObservationMock(30, 'Observation A', $queen);
+    $route_match = $this->createRouteMatch('entity.queen_observation.edit_form');
+    $route_match->method('getParameter')->willReturnMap([
+      ['apiary', NULL],
+      ['hive', NULL],
+      ['hive_inspection', NULL],
+      ['queen', NULL],
+      ['queen_observation', $observation],
+    ]);
+
+    $breadcrumb = $this->builder->build($route_match);
+    $links = $breadcrumb->getLinks();
+
+    $this->assertCount(7, $links);
+    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
+    $this->assertEquals('Hive Alpha', (string) $links[4]->getText());
+    $this->assertEquals('Q-2024-001', (string) $links[5]->getText());
+    $this->assertEquals('Observation A', (string) $links[6]->getText());
+    $this->assertEquals('entity.queen_observation.canonical', $links[6]->getUrl()->getRouteName());
+  }
+
+  /**
+   * hivelog.queen_observation.add carries a {queen} route parameter;
+   * apiary, hive and queen ancestor links should be added (6 links total).
+   */
+  public function testBuildQueenObservationAddRoute(): void {
+    $apiary = $this->createApiaryMock(1, 'Home Apiary');
+    $hive = $this->createHiveMock(5, 'Hive Alpha', $apiary);
+    $queen = $this->createQueenMock(20, 'Q-2024-001', $hive);
+    $route_match = $this->createRouteMatch('hivelog.queen_observation.add');
+    $route_match->method('getParameter')->willReturnMap([
+      ['apiary', NULL],
+      ['hive', NULL],
+      ['hive_inspection', NULL],
+      ['queen', $queen],
+      ['queen_observation', NULL],
+    ]);
+
+    $breadcrumb = $this->builder->build($route_match);
+    $links = $breadcrumb->getLinks();
+
+    $this->assertCount(6, $links);
+    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
+    $this->assertEquals('Hive Alpha', (string) $links[4]->getText());
+    $this->assertEquals('Q-2024-001', (string) $links[5]->getText());
+    $this->assertEquals('entity.queen.canonical', $links[5]->getUrl()->getRouteName());
+  }
+
+  /**
    * hivelog.queen.add carries a {hive} route parameter; apiary and hive
    * ancestor links should both be added (5 links total).
    */
@@ -539,6 +648,24 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $queen->method('get')->with('hive')->willReturn($hive_ref);
 
     return $queen;
+  }
+
+  /**
+   * Creates a mock QueenObservation entity referencing the given queen.
+   */
+  private function createObservationMock(int $id, string $label, ContentEntityInterface $queen): ContentEntityInterface {
+    $observation = $this->createMock(ContentEntityInterface::class);
+    $observation->method('id')->willReturn($id);
+    $observation->method('label')->willReturn($label);
+    $observation->method('getCacheTags')->willReturn(["queen_observation:$id"]);
+    $observation->method('getCacheContexts')->willReturn([]);
+    $observation->method('getCacheMaxAge')->willReturn(-1);
+
+    $queen_ref = new \stdClass();
+    $queen_ref->entity = $queen;
+    $observation->method('get')->with('queen')->willReturn($queen_ref);
+
+    return $observation;
   }
 
 }


### PR DESCRIPTION
## Summary
Closes #55. Adds a fifth content entity, `QueenObservation`, so beekeepers can log queen-specific notes that are independent of hive inspections, and wires it into the UI as requested in the issue.

## What changed
### New `queen_observation` entity
- Fields: `queen` (required), `observation_date` (required, defaults to today on new forms), `health` (excellent/good/fair/poor), `temperament` (calm/moderate/aggressive), `active` (boolean — was she observed laying / moving?), `notes` (string_long), `images` (multi-value image), plus owner/timestamps.
- Entity + access control handler + list builder + add/edit/delete forms.
- Controller with queen-scoped `addForm(Queen)` and a sectioned view (**Overview** / **Observations** / **Notes** / **Photos**) plus Edit/Delete action buttons — mirrors the `HiveInspection` view pattern.

### Wiring
- Routes under `/admin/hivelog/queen-observation(s)/...` plus a queen-scoped `/admin/hivelog/queen/{queen}/observation/add`.
- Permissions: `view / add / edit / delete queen observation`.
- Admin menu link: **Queen Observations** under HiveLog.
- Local task tabs for View/Edit/Delete.
- `hivelog_update_10009` installs the entity type (no data migration — the module is not yet in production).

### UI changes
- **Hive page**: next to the existing **Edit Queen** button, a new **Add Observation** button links to the queen-scoped add route. Present whenever the hive has an active queen.
- **Queen page**: observations list rendered at the bottom in the same style as the inspections table on the hive page, with heading + Add Observation button, paginated table (Date / Health / Temperament / Active / Operations), pager, and empty-state message. Cache metadata declares the `queen_observation` list tag.
- **Breadcrumb**: threads **Apiary → Hive → Queen → Observation** on observation routes.

## Tests
- `QueenObservationTest` (kernel): CRUD, queen-scoped add flow, sectioned view + formatted values + action buttons.
- `QueenTest`: observations list rendering with populated rows and the empty-state message.
- `HiveTest`: Edit Queen and Add Observation buttons both present on the hive page queen section, in the correct order.
- Breadcrumb unit tests: applies() cases + canonical/edit/add route ancestry threading.
- `ApiaryTest`: queen_observation collection route and `hivelog.queen_observations` menu link guarded; `queen_observation` entity type asserted in `ModuleDependencyAuditTest`.

Full hivelog phpunit suite: **130 tests, 1598 assertions, all green.**

```
ddev exec "SIMPLETEST_DB=mysql://db:db@db:3306/db \
  SIMPLETEST_BASE_URL=http://web \
  php /var/www/html/vendor/bin/phpunit \
  -c /var/www/html/web/core \
  /var/www/html/web/modules/hivelog/tests/ \
  --group hivelog"
```

## Artifacts
- Conversation: https://app.warp.dev/conversation/a3e70cfc-076a-4ec4-9541-7f82cc96c30f

Co-Authored-By: Oz <oz-agent@warp.dev>