### PR TITLE
Issue #59: per-user Central Beehive Registration (CBR) number

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,13 @@ After installation, navigate to **Administration → Structure → HiveLog**
    - Free-text notes
    - Photos (multi-value image field)
 
-5. **Log inspections** — From the hive view page, click "Add Inspection". Each
+5. **Record your CBR number** — Each user can store a Central Beehive
+   Registration (CBR) number on their account (`/user/{uid}/edit`). The
+   number is shown as a caption on the HiveLog landing page and rendered
+   as the first column of every apiary row, so the apiary list always
+   identifies the registered owner alongside the apiary.
+
+6. **Log inspections** — From the hive view page, click "Add Inspection". Each
    inspection captures:
    - **External check (before opening)** — Flight activity, dead bees, signs of
      robbing, wasps, hive weight (hefting)
@@ -286,7 +292,9 @@ drush cr
      signal is already captured by `queen_cells`).
    - `10008` — Install the `queen` entity type and drop the `queen_year` /
      `queen_colour` columns from `hive`. No data migration.
-   - `10009` — Install the `queen_observation` entity type.
+  - `10009` — Install the `queen_observation` entity type.
+  - `10010` — Install the `cbr_number` (Central Beehive Registration) base
+    field on the `user` entity. No data migration.
 3. `drush cr` — Rebuilds caches so Drupal picks up any changes to entity
    definitions, routing, or services.
 

--- a/hivelog.install
+++ b/hivelog.install
@@ -303,3 +303,32 @@ function hivelog_update_10009(&$sandbox) {
 
   return t('Installed the Queen Observation entity type.');
 }
+
+/**
+ * Add Central Beehive Registration (CBR) number field to user accounts.
+ *
+ * Issue #59: each user can record a national/central beehive registration
+ * number on their profile. The CBR is surfaced on the HiveLog landing page
+ * and on each apiary row. The field is provided by hivelog via
+ * hook_entity_base_field_info(), and this hook makes the storage available
+ * on existing sites.
+ */
+function hivelog_update_10010(&$sandbox) {
+  $manager = \Drupal::entityDefinitionUpdateManager();
+  if ($manager->getFieldStorageDefinition('cbr_number', 'user')) {
+    return t('CBR field already installed; nothing to do.');
+  }
+
+  $entity_type = \Drupal::entityTypeManager()->getDefinition('user');
+  $fields = hivelog_entity_base_field_info($entity_type);
+  if (isset($fields['cbr_number'])) {
+    $manager->installFieldStorageDefinition(
+      'cbr_number',
+      'user',
+      'hivelog',
+      $fields['cbr_number']
+    );
+  }
+
+  return t('Added CBR number field to user accounts.');
+}

--- a/hivelog.module
+++ b/hivelog.module
@@ -4,3 +4,40 @@
  * @file
  * Primary module hooks for HiveLog module.
  */
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+
+/**
+ * Implements hook_entity_base_field_info().
+ *
+ * Adds a Central Beehive Registration (CBR) number base field to the user
+ * entity so each user can record their national/central beehive
+ * registration number on their profile. The field is surfaced on the
+ * standard user form/view and on the HiveLog landing page.
+ */
+function hivelog_entity_base_field_info(EntityTypeInterface $entity_type) {
+  if ($entity_type->id() !== 'user') {
+    return [];
+  }
+
+  $fields = [];
+  $fields['cbr_number'] = BaseFieldDefinition::create('string')
+    ->setLabel(t('Central Beehive Registration (CBR) number'))
+    ->setDescription(t('Your national/central beehive registration number, if any.'))
+    ->setProvider('hivelog')
+    ->setSetting('max_length', 64)
+    ->setDisplayOptions('form', [
+      'type' => 'string_textfield',
+      'weight' => 5,
+    ])
+    ->setDisplayOptions('view', [
+      'type' => 'string',
+      'label' => 'inline',
+      'weight' => 5,
+    ])
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDisplayConfigurable('view', TRUE);
+
+  return $fields;
+}

--- a/src/ApiaryListBuilder.php
+++ b/src/ApiaryListBuilder.php
@@ -2,18 +2,65 @@
 
 namespace Drupal\hivelog;
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityListBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a list builder for Apiary entities.
  */
 class ApiaryListBuilder extends EntityListBuilder {
 
+  use StringTranslationTrait;
+
+  /**
+   * The current user account.
+   */
+  protected AccountInterface $currentUser;
+
+  /**
+   * The user storage handler.
+   */
+  protected EntityStorageInterface $userStorage;
+
+  /**
+   * Constructs a new ApiaryListBuilder.
+   */
+  public function __construct(
+    EntityTypeInterface $entity_type,
+    EntityStorageInterface $storage,
+    AccountInterface $current_user,
+    EntityStorageInterface $user_storage,
+  ) {
+    parent::__construct($entity_type, $storage);
+    $this->currentUser = $current_user;
+    $this->userStorage = $user_storage;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    $entity_type_manager = $container->get('entity_type.manager');
+    return new static(
+      $entity_type,
+      $entity_type_manager->getStorage($entity_type->id()),
+      $container->get('current_user'),
+      $entity_type_manager->getStorage('user'),
+    );
+  }
+
   /**
    * {@inheritdoc}
    */
   public function buildHeader() {
+    $header['cbr'] = $this->t('CBR');
     $header['name'] = $this->t('Name');
     $header['location'] = $this->t('Location');
     $header['owner'] = $this->t('Owner');
@@ -24,10 +71,71 @@ class ApiaryListBuilder extends EntityListBuilder {
    * {@inheritdoc}
    */
   public function buildRow(EntityInterface $entity) {
+    $owner = $entity->getOwner();
+    $row['cbr'] = $this->extractCbr($owner) ?: '—';
     $row['name'] = $entity->toLink();
-    $row['location'] = $entity->get('location')->value ? mb_strimwidth($entity->get('location')->value, 0, 60, '...') : '';
-    $row['owner'] = $entity->getOwner() ? $entity->getOwner()->getDisplayName() : '';
+    $row['location'] = $entity->get('location')->value
+      ? mb_strimwidth($entity->get('location')->value, 0, 60, '...')
+      : '';
+    $row['owner'] = $owner ? $owner->getDisplayName() : '';
     return $row + parent::buildRow($entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    $build = parent::render();
+
+    /** @var \Drupal\user\UserInterface|null $current */
+    $current = $this->userStorage->load($this->currentUser->id());
+    $cbr = $this->extractCbr($current);
+
+    if ($cbr !== '') {
+      $message = [
+        '#markup' => $this->t('Your CBR number: @cbr', ['@cbr' => $cbr]),
+      ];
+    }
+    elseif ($current) {
+      $message = [
+        '#type' => 'inline_template',
+        '#template' => '{% trans %}You have not set a CBR number yet. <a href="{{ url }}">Update your profile</a> to add one.{% endtrans %}',
+        '#context' => [
+          'url' => $current->toUrl('edit-form')->toString(),
+        ],
+      ];
+    }
+    else {
+      $message = [
+        '#markup' => $this->t('Sign in to record your CBR number.'),
+      ];
+    }
+
+    $build['cbr_summary'] = [
+      '#type' => 'container',
+      '#weight' => -100,
+      '#attributes' => ['class' => ['hivelog-cbr-summary']],
+      'message' => $message,
+    ];
+
+    $cache = CacheableMetadata::createFromRenderArray($build)
+      ->addCacheContexts(['user']);
+    if ($current) {
+      $cache->addCacheableDependency($current);
+    }
+    $cache->applyTo($build);
+
+    return $build;
+  }
+
+  /**
+   * Extracts a trimmed CBR number from a user, if any.
+   */
+  protected function extractCbr(?UserInterface $user): string {
+    if (!$user || !$user->hasField('cbr_number')) {
+      return '';
+    }
+    return trim((string) $user->get('cbr_number')->value);
   }
 
 }

--- a/tests/src/Kernel/CbrFieldTest.php
+++ b/tests/src/Kernel/CbrFieldTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\hivelog\Kernel;
+
+use Drupal\hivelog\Entity\Apiary;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests the per-user Central Beehive Registration (CBR) number field.
+ *
+ * Issue #59: a CBR field lives on the user entity, is rendered on the
+ * apiary collection landing page (caption + first column of each row),
+ * and is editable from the standard user form.
+ */
+#[Group('hivelog')]
+#[RunTestsInSeparateProcesses]
+class CbrFieldTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'datetime',
+    'options',
+    'file',
+    'image',
+    'geofield',
+    'hivelog',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('apiary');
+    $this->installEntitySchema('hive');
+    $this->installEntitySchema('hive_inspection');
+    $this->installEntitySchema('queen');
+    $this->installEntitySchema('queen_observation');
+    $this->installSchema('file', ['file_usage']);
+  }
+
+  /**
+   * The CBR field is registered as a base field on the user entity.
+   */
+  public function testCbrBaseFieldDefinition(): void {
+    $definitions = \Drupal::service('entity_field.manager')
+      ->getBaseFieldDefinitions('user');
+
+    $this->assertArrayHasKey('cbr_number', $definitions);
+    $field = $definitions['cbr_number'];
+    $this->assertSame('string', $field->getType());
+    $this->assertSame(64, $field->getSetting('max_length'));
+    $this->assertFalse($field->isRequired());
+    $this->assertSame(1, $field->getCardinality());
+    $this->assertSame('hivelog', $field->getProvider());
+  }
+
+  /**
+   * CBR values round-trip through user save/load.
+   */
+  public function testCbrRoundTrip(): void {
+    $user = User::create([
+      'name' => 'beekeeper',
+      'mail' => 'beekeeper@example.com',
+      'cbr_number' => 'IE-0001',
+    ]);
+    $user->save();
+
+    $reloaded = User::load($user->id());
+    $this->assertSame('IE-0001', $reloaded->get('cbr_number')->value);
+  }
+
+  /**
+   * The list builder header is CBR, Name, Location, Owner — in that order.
+   */
+  public function testListBuilderHeaderOrder(): void {
+    $list_builder = \Drupal::entityTypeManager()->getListBuilder('apiary');
+    $header = $list_builder->buildHeader();
+    $keys = array_keys($header);
+    // Drop trailing 'operations' (or other parent::buildHeader() keys).
+    $leading = array_slice($keys, 0, 4);
+    $this->assertSame(['cbr', 'name', 'location', 'owner'], $leading);
+  }
+
+  /**
+   * Each apiary row shows the owner's CBR or an em-dash fallback.
+   */
+  public function testListBuilderRowCbrColumn(): void {
+    $with_cbr = User::create([
+      'name' => 'with-cbr',
+      'mail' => 'with@example.com',
+      'cbr_number' => 'IE-1234',
+    ]);
+    $with_cbr->save();
+
+    $without_cbr = User::create([
+      'name' => 'without-cbr',
+      'mail' => 'without@example.com',
+    ]);
+    $without_cbr->save();
+
+    $apiary_with = Apiary::create([
+      'name' => 'With CBR',
+      'uid' => $with_cbr->id(),
+    ]);
+    $apiary_with->save();
+
+    $apiary_without = Apiary::create([
+      'name' => 'Without CBR',
+      'uid' => $without_cbr->id(),
+    ]);
+    $apiary_without->save();
+
+    $list_builder = \Drupal::entityTypeManager()->getListBuilder('apiary');
+    $row_with = $list_builder->buildRow($apiary_with);
+    $row_without = $list_builder->buildRow($apiary_without);
+
+    $this->assertSame('IE-1234', $row_with['cbr']);
+    $this->assertSame('—', $row_without['cbr']);
+  }
+
+  /**
+   * The landing page caption shows the current user's CBR or an invitation.
+   */
+  public function testRenderedCaptionForCurrentUser(): void {
+    $with_cbr = User::create([
+      'name' => 'caption-with',
+      'mail' => 'caption-with@example.com',
+      'cbr_number' => 'IE-9999',
+    ]);
+    $with_cbr->save();
+
+    $without_cbr = User::create([
+      'name' => 'caption-without',
+      'mail' => 'caption-without@example.com',
+    ]);
+    $without_cbr->save();
+
+    $renderer = \Drupal::service('renderer');
+
+    \Drupal::currentUser()->setAccount($with_cbr);
+    $build = \Drupal::entityTypeManager()->getListBuilder('apiary')->render();
+    $html_with = (string) $renderer->renderInIsolation($build);
+    $this->assertStringContainsString('Your CBR number: IE-9999', $html_with);
+
+    \Drupal::currentUser()->setAccount($without_cbr);
+    $build = \Drupal::entityTypeManager()->getListBuilder('apiary')->render();
+    $html_without = (string) $renderer->renderInIsolation($build);
+    $this->assertStringContainsString('have not set a CBR number yet', $html_without);
+    $this->assertStringContainsString('Update your profile', $html_without);
+  }
+
+}


### PR DESCRIPTION
Closes #59.

## Summary
Adds a Central Beehive Registration (CBR) number to user accounts and surfaces it on the HiveLog landing page.

- New `cbr_number` base field on the `user` entity, registered via `hook_entity_base_field_info()` in `hivelog.module` (string, max 64, optional, form/view configurable).
- New `hivelog_update_10010()` to install the storage on existing sites, guarded so it is safe to re-run.
- `ApiaryListBuilder` now:
  - Depends on `current_user` and the `user` storage handler (DI via `createInstance()`).
  - Renders **CBR** as the leading column on every apiary row, with an em-dash fallback when the owner has not set one.
  - Overrides `render()` to prepend a per-user caption — *"Your CBR number: …"* when set, or a profile-edit prompt when unset — and attaches `user` cache context plus the current user as a cacheable dependency so per-account changes invalidate cleanly.
- README updated with a new workflow step and the `10010` deployment note.

## Tests
New kernel test `tests/src/Kernel/CbrFieldTest.php` covers:
- Field definition (`string`, `max_length` 64, single-cardinality, optional, provider `hivelog`).
- Save/load round-trip of the CBR value on a user.
- Header column order on the apiary list (`cbr`, `name`, `location`, `owner`).
- Row content for both CBR-set (`IE-1234`) and CBR-unset (em-dash) apiary owners.
- `render()` caption rendering for both states (current-user shows their CBR vs. "Update your profile" link).

Full `--group hivelog` PHPUnit suite: 135 tests, 1671 assertions, 0 failures (only unrelated contrib `*_requirements` legacy-hook deprecations).

## Out of scope
- CBR format validation (jurisdiction-dependent and unspecified by the issue).
- A dedicated hivelog permission for editing CBR — covered by core's user-account permissions.
- Backfilling CBR for existing accounts — no source data exists.

## Artifacts
- Plan: https://app.warp.dev/drive/notebook/BIt1BD144vPgFCwkHA3cAA
- Conversation: https://app.warp.dev/conversation/1de39660-ac3a-4d9a-89b3-b2776c9fd087

Co-Authored-By: Oz <oz-agent@warp.dev>