### PR TITLE
Resolve apiary.geolocation field-storage drift on status page (#61)

### DIFF
--- a/hivelog.install
+++ b/hivelog.install
@@ -332,3 +332,40 @@ function hivelog_update_10010(&$sandbox) {
 
   return t('Added CBR number field to user accounts.');
 }
+
+/**
+ * Re-sync the apiary.geolocation stored field storage definition.
+ *
+ * Issue #61: the Drupal status page reports "Apiary — The Geolocation
+ * field needs to be updated" because the BaseFieldDefinition snapshot
+ * recorded by hivelog_update_10002 has drifted from the live
+ * Apiary::baseFieldDefinitions(). Two later commits modified the field
+ * without a paired update hook:
+ *
+ * - PR #2 swapped the form widget from `geofield_latlon` to
+ *   `leaflet_widget_default` (with leaflet map settings) and expanded
+ *   the description.
+ * - PR #5 changed the view formatter label from `above` to `hidden`.
+ *
+ * EntityDefinitionUpdateManager compares storage definitions strictly,
+ * so any drift — including non-schema-affecting display options —
+ * triggers the warning. The underlying geofield columns are unchanged;
+ * only the recorded definition needs to be refreshed.
+ */
+function hivelog_update_10011(&$sandbox) {
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+  $entity_field_manager = \Drupal::service('entity_field.manager');
+
+  // Use the entity field manager so the definition we hand over has its
+  // name, target entity type id and provider populated —
+  // updateFieldStorageDefinition() looks the existing definition up via
+  // those properties.
+  $apiary_fields = $entity_field_manager->getBaseFieldDefinitions('apiary');
+  if (isset($apiary_fields['geolocation'])) {
+    $entity_definition_update_manager->updateFieldStorageDefinition(
+      $apiary_fields['geolocation']
+    );
+  }
+
+  return t('Re-synced apiary.geolocation stored field storage definition.');
+}


### PR DESCRIPTION
Fixes #61.

## Summary
Adds `hivelog_update_10011` to clear the **Apiary — The Geolocation field needs to be updated** entry from `/admin/reports/status` under "Mismatched entity and/or field definitions".

The geofield's stored `BaseFieldDefinition` (snapshotted by `hivelog_update_10002`) drifted from the live definition: form widget `geofield_latlon` → `leaflet_widget_default`, view formatter label `above` → `hidden`, plus an expanded description. No table-schema change is needed; only the recorded definition has to be re-synced via `updateFieldStorageDefinition()`.

The companion *user.cbr_number needs to be uninstalled* status-page entry that originally appeared alongside this one is **not** addressed here — it was a transient symptom of being one commit behind PR #60, which legitimately implements that field via `hook_entity_base_field_info()` and installs storage in `hivelog_update_10010`. Pulling `main` and running `drush updb` clears it without any further code change.

## Implementation notes
- Uses `entity_field.manager` rather than `Apiary::baseFieldDefinitions()` directly so the update receives a fully-realized definition (with `name` / `target_entity_type_id` / `provider` set) — `updateFieldStorageDefinition()` looks the existing record up via those properties.

## Verification
- `ddev drush updb -y` reports `Update completed: hivelog_update_10011`.
- After the update, `EntityDefinitionUpdateManager::getChangeList()` is empty.
- `last_installed_schema.repository.user` still lists `cbr_number` (correctly, since PR #60 installs it).
- Full hivelog test suite: 135 tests, 1671 assertions, 0 failures (22 unrelated contrib deprecations).

Generated with [Warp](https://app.warp.dev/conversation/84f3e4f7-b576-4a1c-99e6-4744db009a19).

Co-Authored-By: Oz <oz-agent@warp.dev>