### PR TITLE
Enforce ownership and apiary-scoped access control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ control handlers in `src/*AccessControlHandler.php` mirror the same rule.
 Only one service is registered (`hivelog.services.yml`):
 `hivelog.breadcrumb` — a `BreadcrumbBuilder` with priority 100 that produces
 the Apiary → Hive → Inspection trail on any hivelog route. When adding new
-routes under `/admin/hivelog/...` make sure the breadcrumb builder's
+routes under `/hivelog/...` make sure the breadcrumb builder's
 `applies()` logic still matches.
 
 ### Tests

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Entity database tables are created automatically on install.
 ## Usage
 
 After installation, navigate to **Administration → Structure → HiveLog**
-(`/admin/hivelog`).
+(`/hivelog`).
 
 ### Workflow
 
@@ -157,32 +157,32 @@ Users with "Administer HiveLog" bypass all individual permission checks.
 
 | Path                                          | Description            |
 |-----------------------------------------------|------------------------|
-| `/admin/hivelog`                              | Apiary list            |
-| `/admin/hivelog/hives`                        | Hive list              |
-| `/admin/hivelog/inspections`                  | Inspection list        |
-| `/admin/hivelog/apiary/add`                   | Add apiary             |
-| `/admin/hivelog/apiary/{id}`                  | View apiary            |
-| `/admin/hivelog/apiary/{id}/edit`             | Edit apiary            |
-| `/admin/hivelog/apiary/{id}/delete`           | Delete apiary          |
-| `/admin/hivelog/apiary/{id}/hive/add`         | Add hive to apiary     |
-| `/admin/hivelog/hive/{id}`                    | View hive              |
-| `/admin/hivelog/hive/{id}/edit`               | Edit hive              |
-| `/admin/hivelog/hive/{id}/delete`             | Delete hive            |
-| `/admin/hivelog/hive/{id}/inspection/add`     | Add inspection to hive |
-| `/admin/hivelog/inspection/{id}`              | View inspection        |
-| `/admin/hivelog/inspection/{id}/edit`         | Edit inspection        |
-| `/admin/hivelog/inspection/{id}/delete`       | Delete inspection      |
-| `/admin/hivelog/queens`                       | Queen list             |
-| `/admin/hivelog/queen/add`                    | Add queen              |
-| `/admin/hivelog/hive/{id}/queen/add`          | Add queen to hive      |
-| `/admin/hivelog/queen/{id}`                   | View queen             |
-| `/admin/hivelog/queen/{id}/edit`              | Edit queen             |
-| `/admin/hivelog/queen/{id}/delete`            | Delete queen           |
-| `/admin/hivelog/queen-observations`           | Queen observation list |
-| `/admin/hivelog/queen/{id}/observation/add`   | Add observation to queen |
-| `/admin/hivelog/queen-observation/{id}`       | View queen observation |
-| `/admin/hivelog/queen-observation/{id}/edit`  | Edit queen observation |
-| `/admin/hivelog/queen-observation/{id}/delete` | Delete queen observation |
+| `/hivelog`                              | Apiary list            |
+| `/hivelog/hives`                        | Hive list              |
+| `/hivelog/inspections`                  | Inspection list        |
+| `/hivelog/apiary/add`                   | Add apiary             |
+| `/hivelog/apiary/{id}`                  | View apiary            |
+| `/hivelog/apiary/{id}/edit`             | Edit apiary            |
+| `/hivelog/apiary/{id}/delete`           | Delete apiary          |
+| `/hivelog/apiary/{id}/hive/add`         | Add hive to apiary     |
+| `/hivelog/hive/{id}`                    | View hive              |
+| `/hivelog/hive/{id}/edit`               | Edit hive              |
+| `/hivelog/hive/{id}/delete`             | Delete hive            |
+| `/hivelog/hive/{id}/inspection/add`     | Add inspection to hive |
+| `/hivelog/inspection/{id}`              | View inspection        |
+| `/hivelog/inspection/{id}/edit`         | Edit inspection        |
+| `/hivelog/inspection/{id}/delete`       | Delete inspection      |
+| `/hivelog/queens`                       | Queen list             |
+| `/hivelog/queen/add`                    | Add queen              |
+| `/hivelog/hive/{id}/queen/add`          | Add queen to hive      |
+| `/hivelog/queen/{id}`                   | View queen             |
+| `/hivelog/queen/{id}/edit`              | Edit queen             |
+| `/hivelog/queen/{id}/delete`            | Delete queen           |
+| `/hivelog/queen-observations`           | Queen observation list |
+| `/hivelog/queen/{id}/observation/add`   | Add observation to queen |
+| `/hivelog/queen-observation/{id}`       | View queen observation |
+| `/hivelog/queen-observation/{id}/edit`  | Edit queen observation |
+| `/hivelog/queen-observation/{id}/delete` | Delete queen observation |
 
 ## Module Structure
 

--- a/hivelog.install
+++ b/hivelog.install
@@ -422,3 +422,38 @@ function hivelog_update_10012(&$sandbox) {
   }
   return t('No roles had old hivelog permissions to migrate.');
 }
+
+/**
+ * Install beekeepers and visibility fields on the Apiary entity.
+ *
+ * Issue #66: apiary-scoped access control. The apiary owner can assign
+ * beekeepers who may then view and edit hives/inspections within the
+ * apiary. The visibility field controls whether non-members can view
+ * the apiary and its children. Existing apiaries default to 'private'
+ * with an empty beekeepers list (owner-only access, same as before).
+ */
+function hivelog_update_10013(&$sandbox) {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+
+  $field_definitions = \Drupal\hivelog\Entity\Apiary::baseFieldDefinitions(
+    $entity_type_manager->getDefinition('apiary')
+  );
+
+  foreach (['beekeepers', 'visibility'] as $field_name) {
+    if (isset($field_definitions[$field_name])) {
+      $existing = $entity_definition_update_manager
+        ->getFieldStorageDefinition($field_name, 'apiary');
+      if (!$existing) {
+        $entity_definition_update_manager->installFieldStorageDefinition(
+          $field_name,
+          'apiary',
+          'hivelog',
+          $field_definitions[$field_name]
+        );
+      }
+    }
+  }
+
+  return t('Installed beekeepers and visibility fields on the Apiary entity.');
+}

--- a/hivelog.install
+++ b/hivelog.install
@@ -369,3 +369,56 @@ function hivelog_update_10011(&$sandbox) {
 
   return t('Re-synced apiary.geolocation stored field storage definition.');
 }
+
+/**
+ * Migrate old hivelog permissions to new own/any variants.
+ *
+ * Issue #64: access control handlers now enforce ownership-based restrictions.
+ * The old flat permissions (e.g. 'view apiary', 'edit hive') have been
+ * replaced with own/any variants (e.g. 'view own apiary', 'view any apiary').
+ * This hook maps every old permission to its 'any' equivalent so existing
+ * roles retain the same effective access they had before the change.
+ */
+function hivelog_update_10012(&$sandbox) {
+  $permission_map = [
+    'view apiary' => 'view any apiary',
+    'edit apiary' => 'edit any apiary',
+    'delete apiary' => 'delete any apiary',
+    'view hive' => 'view any hive',
+    'edit hive' => 'edit any hive',
+    'delete hive' => 'delete any hive',
+    'view hive inspection' => 'view any hive inspection',
+    'edit hive inspection' => 'edit any hive inspection',
+    'delete hive inspection' => 'delete any hive inspection',
+    'view queen' => 'view any queen',
+    'edit queen' => 'edit any queen',
+    'delete queen' => 'delete any queen',
+    'view queen observation' => 'view any queen observation',
+    'edit queen observation' => 'edit any queen observation',
+    'delete queen observation' => 'delete any queen observation',
+  ];
+
+  $roles = \Drupal\user\Entity\Role::loadMultiple();
+  $updated = [];
+  foreach ($roles as $role) {
+    $changed = FALSE;
+    foreach ($permission_map as $old => $new) {
+      if ($role->hasPermission($old)) {
+        $role->revokePermission($old);
+        $role->grantPermission($new);
+        $changed = TRUE;
+      }
+    }
+    if ($changed) {
+      $role->save();
+      $updated[] = $role->id();
+    }
+  }
+
+  if ($updated) {
+    return t('Migrated hivelog permissions to own/any variants for roles: @roles.', [
+      '@roles' => implode(', ', $updated),
+    ]);
+  }
+  return t('No roles had old hivelog permissions to migrate.');
+}

--- a/hivelog.links.menu.yml
+++ b/hivelog.links.menu.yml
@@ -2,7 +2,7 @@ hivelog.admin:
   title: 'HiveLog'
   description: 'Manage apiaries, hives, and inspections.'
   route_name: entity.apiary.collection
-  parent: system.admin_structure
+  menu_name: main
   weight: 10
 
 hivelog.hives:

--- a/hivelog.permissions.yml
+++ b/hivelog.permissions.yml
@@ -2,62 +2,82 @@ administer hivelog:
   title: 'Administer HiveLog'
   description: 'Full administrative access to the HiveLog module.'
 
-view apiary:
-  title: 'View apiaries'
-
+# Apiary permissions.
+view own apiary:
+  title: 'View own apiaries'
+view any apiary:
+  title: 'View any apiary'
 add apiary:
   title: 'Add apiaries'
+edit own apiary:
+  title: 'Edit own apiaries'
+edit any apiary:
+  title: 'Edit any apiary'
+delete own apiary:
+  title: 'Delete own apiaries'
+delete any apiary:
+  title: 'Delete any apiary'
 
-edit apiary:
-  title: 'Edit apiaries'
-
-delete apiary:
-  title: 'Delete apiaries'
-
-view hive:
-  title: 'View hives'
-
+# Hive permissions.
+view own hive:
+  title: 'View own hives'
+view any hive:
+  title: 'View any hive'
 add hive:
   title: 'Add hives'
+edit own hive:
+  title: 'Edit own hives'
+edit any hive:
+  title: 'Edit any hive'
+delete own hive:
+  title: 'Delete own hives'
+delete any hive:
+  title: 'Delete any hive'
 
-edit hive:
-  title: 'Edit hives'
-
-delete hive:
-  title: 'Delete hives'
-
-view hive inspection:
-  title: 'View hive inspections'
-
+# Hive inspection permissions.
+view own hive inspection:
+  title: 'View own hive inspections'
+view any hive inspection:
+  title: 'View any hive inspection'
 add hive inspection:
   title: 'Add hive inspections'
+edit own hive inspection:
+  title: 'Edit own hive inspections'
+edit any hive inspection:
+  title: 'Edit any hive inspection'
+delete own hive inspection:
+  title: 'Delete own hive inspections'
+delete any hive inspection:
+  title: 'Delete any hive inspection'
 
-edit hive inspection:
-  title: 'Edit hive inspections'
-
-delete hive inspection:
-  title: 'Delete hive inspections'
-
-view queen:
-  title: 'View queens'
-
+# Queen permissions.
+view own queen:
+  title: 'View own queens'
+view any queen:
+  title: 'View any queen'
 add queen:
   title: 'Add queens'
+edit own queen:
+  title: 'Edit own queens'
+edit any queen:
+  title: 'Edit any queen'
+delete own queen:
+  title: 'Delete own queens'
+delete any queen:
+  title: 'Delete any queen'
 
-edit queen:
-  title: 'Edit queens'
-
-delete queen:
-  title: 'Delete queens'
-
-view queen observation:
-  title: 'View queen observations'
-
+# Queen observation permissions.
+view own queen observation:
+  title: 'View own queen observations'
+view any queen observation:
+  title: 'View any queen observation'
 add queen observation:
   title: 'Add queen observations'
-
-edit queen observation:
-  title: 'Edit queen observations'
-
-delete queen observation:
-  title: 'Delete queen observations'
+edit own queen observation:
+  title: 'Edit own queen observations'
+edit any queen observation:
+  title: 'Edit any queen observation'
+delete own queen observation:
+  title: 'Delete own queen observations'
+delete any queen observation:
+  title: 'Delete any queen observation'

--- a/hivelog.routing.yml
+++ b/hivelog.routing.yml
@@ -5,7 +5,7 @@ entity.apiary.collection:
     _entity_list: 'apiary'
     _title: 'HiveLog - Apiaries'
   requirements:
-    _permission: 'view apiary+administer hivelog'
+    _permission: 'view own apiary+view any apiary+administer hivelog'
 
 entity.apiary.add_form:
   path: '/admin/hivelog/apiary/add'
@@ -21,7 +21,7 @@ entity.apiary.canonical:
     _controller: '\Drupal\hivelog\Controller\ApiaryController::view'
     _title_callback: '\Drupal\hivelog\Controller\ApiaryController::title'
   requirements:
-    _permission: 'view apiary+administer hivelog'
+    _permission: 'view own apiary+view any apiary+administer hivelog'
   options:
     parameters:
       apiary:
@@ -33,7 +33,7 @@ entity.apiary.edit_form:
     _entity_form: 'apiary.edit'
     _title: 'Edit Apiary'
   requirements:
-    _permission: 'edit apiary+administer hivelog'
+    _permission: 'edit own apiary+edit any apiary+administer hivelog'
   options:
     parameters:
       apiary:
@@ -45,7 +45,7 @@ entity.apiary.delete_form:
     _entity_form: 'apiary.delete'
     _title: 'Delete Apiary'
   requirements:
-    _permission: 'delete apiary+administer hivelog'
+    _permission: 'delete own apiary+delete any apiary+administer hivelog'
   options:
     parameters:
       apiary:
@@ -58,7 +58,7 @@ entity.hive.collection:
     _entity_list: 'hive'
     _title: 'HiveLog - Hives'
   requirements:
-    _permission: 'view hive+administer hivelog'
+    _permission: 'view own hive+view any hive+administer hivelog'
 
 hivelog.hive.add:
   path: '/admin/hivelog/apiary/{apiary}/hive/add'
@@ -78,7 +78,7 @@ entity.hive.canonical:
     _controller: '\Drupal\hivelog\Controller\HiveController::view'
     _title_callback: '\Drupal\hivelog\Controller\HiveController::title'
   requirements:
-    _permission: 'view hive+administer hivelog'
+    _permission: 'view own hive+view any hive+administer hivelog'
   options:
     parameters:
       hive:
@@ -90,7 +90,7 @@ entity.hive.edit_form:
     _entity_form: 'hive.edit'
     _title: 'Edit Hive'
   requirements:
-    _permission: 'edit hive+administer hivelog'
+    _permission: 'edit own hive+edit any hive+administer hivelog'
   options:
     parameters:
       hive:
@@ -102,7 +102,7 @@ entity.hive.delete_form:
     _entity_form: 'hive.delete'
     _title: 'Delete Hive'
   requirements:
-    _permission: 'delete hive+administer hivelog'
+    _permission: 'delete own hive+delete any hive+administer hivelog'
   options:
     parameters:
       hive:
@@ -115,7 +115,7 @@ entity.hive_inspection.collection:
     _entity_list: 'hive_inspection'
     _title: 'HiveLog - Inspections'
   requirements:
-    _permission: 'view hive inspection+administer hivelog'
+    _permission: 'view own hive inspection+view any hive inspection+administer hivelog'
 
 hivelog.inspection.add:
   path: '/admin/hivelog/hive/{hive}/inspection/add'
@@ -135,7 +135,7 @@ entity.hive_inspection.canonical:
     _controller: '\Drupal\hivelog\Controller\HiveInspectionController::view'
     _title_callback: '\Drupal\hivelog\Controller\HiveInspectionController::title'
   requirements:
-    _permission: 'view hive inspection+administer hivelog'
+    _permission: 'view own hive inspection+view any hive inspection+administer hivelog'
   options:
     parameters:
       hive_inspection:
@@ -147,7 +147,7 @@ entity.hive_inspection.edit_form:
     _entity_form: 'hive_inspection.edit'
     _title: 'Edit Inspection'
   requirements:
-    _permission: 'edit hive inspection+administer hivelog'
+    _permission: 'edit own hive inspection+edit any hive inspection+administer hivelog'
   options:
     parameters:
       hive_inspection:
@@ -159,7 +159,7 @@ entity.hive_inspection.delete_form:
     _entity_form: 'hive_inspection.delete'
     _title: 'Delete Inspection'
   requirements:
-    _permission: 'delete hive inspection+administer hivelog'
+    _permission: 'delete own hive inspection+delete any hive inspection+administer hivelog'
   options:
     parameters:
       hive_inspection:
@@ -172,7 +172,7 @@ entity.queen.collection:
     _entity_list: 'queen'
     _title: 'HiveLog - Queens'
   requirements:
-    _permission: 'view queen+administer hivelog'
+    _permission: 'view own queen+view any queen+administer hivelog'
 
 entity.queen.add_form:
   path: '/admin/hivelog/queen/add'
@@ -200,7 +200,7 @@ entity.queen.canonical:
     _controller: '\Drupal\hivelog\Controller\QueenController::view'
     _title_callback: '\Drupal\hivelog\Controller\QueenController::title'
   requirements:
-    _permission: 'view queen+administer hivelog'
+    _permission: 'view own queen+view any queen+administer hivelog'
   options:
     parameters:
       queen:
@@ -212,7 +212,7 @@ entity.queen.edit_form:
     _entity_form: 'queen.edit'
     _title: 'Edit Queen'
   requirements:
-    _permission: 'edit queen+administer hivelog'
+    _permission: 'edit own queen+edit any queen+administer hivelog'
   options:
     parameters:
       queen:
@@ -224,7 +224,7 @@ entity.queen.delete_form:
     _entity_form: 'queen.delete'
     _title: 'Delete Queen'
   requirements:
-    _permission: 'delete queen+administer hivelog'
+    _permission: 'delete own queen+delete any queen+administer hivelog'
   options:
     parameters:
       queen:
@@ -237,7 +237,7 @@ entity.queen_observation.collection:
     _entity_list: 'queen_observation'
     _title: 'HiveLog - Queen Observations'
   requirements:
-    _permission: 'view queen observation+administer hivelog'
+    _permission: 'view own queen observation+view any queen observation+administer hivelog'
 
 hivelog.queen_observation.add:
   path: '/admin/hivelog/queen/{queen}/observation/add'
@@ -257,7 +257,7 @@ entity.queen_observation.canonical:
     _controller: '\Drupal\hivelog\Controller\QueenObservationController::view'
     _title_callback: '\Drupal\hivelog\Controller\QueenObservationController::title'
   requirements:
-    _permission: 'view queen observation+administer hivelog'
+    _permission: 'view own queen observation+view any queen observation+administer hivelog'
   options:
     parameters:
       queen_observation:
@@ -269,7 +269,7 @@ entity.queen_observation.edit_form:
     _entity_form: 'queen_observation.edit'
     _title: 'Edit Queen Observation'
   requirements:
-    _permission: 'edit queen observation+administer hivelog'
+    _permission: 'edit own queen observation+edit any queen observation+administer hivelog'
   options:
     parameters:
       queen_observation:
@@ -281,7 +281,7 @@ entity.queen_observation.delete_form:
     _entity_form: 'queen_observation.delete'
     _title: 'Delete Queen Observation'
   requirements:
-    _permission: 'delete queen observation+administer hivelog'
+    _permission: 'delete own queen observation+delete any queen observation+administer hivelog'
   options:
     parameters:
       queen_observation:

--- a/hivelog.routing.yml
+++ b/hivelog.routing.yml
@@ -1,6 +1,6 @@
 # Apiary routes.
 entity.apiary.collection:
-  path: '/admin/hivelog'
+  path: '/hivelog'
   defaults:
     _entity_list: 'apiary'
     _title: 'HiveLog - Apiaries'
@@ -8,7 +8,7 @@ entity.apiary.collection:
     _permission: 'view own apiary+view any apiary+administer hivelog'
 
 entity.apiary.add_form:
-  path: '/admin/hivelog/apiary/add'
+  path: '/hivelog/apiary/add'
   defaults:
     _entity_form: 'apiary.add'
     _title: 'Add Apiary'
@@ -16,7 +16,7 @@ entity.apiary.add_form:
     _permission: 'add apiary+administer hivelog'
 
 entity.apiary.canonical:
-  path: '/admin/hivelog/apiary/{apiary}'
+  path: '/hivelog/apiary/{apiary}'
   defaults:
     _controller: '\Drupal\hivelog\Controller\ApiaryController::view'
     _title_callback: '\Drupal\hivelog\Controller\ApiaryController::title'
@@ -28,7 +28,7 @@ entity.apiary.canonical:
         type: entity:apiary
 
 entity.apiary.edit_form:
-  path: '/admin/hivelog/apiary/{apiary}/edit'
+  path: '/hivelog/apiary/{apiary}/edit'
   defaults:
     _entity_form: 'apiary.edit'
     _title: 'Edit Apiary'
@@ -40,7 +40,7 @@ entity.apiary.edit_form:
         type: entity:apiary
 
 entity.apiary.delete_form:
-  path: '/admin/hivelog/apiary/{apiary}/delete'
+  path: '/hivelog/apiary/{apiary}/delete'
   defaults:
     _entity_form: 'apiary.delete'
     _title: 'Delete Apiary'
@@ -53,7 +53,7 @@ entity.apiary.delete_form:
 
 # Hive routes.
 entity.hive.collection:
-  path: '/admin/hivelog/hives'
+  path: '/hivelog/hives'
   defaults:
     _entity_list: 'hive'
     _title: 'HiveLog - Hives'
@@ -61,7 +61,7 @@ entity.hive.collection:
     _permission: 'view own hive+view any hive+administer hivelog'
 
 hivelog.hive.add:
-  path: '/admin/hivelog/apiary/{apiary}/hive/add'
+  path: '/hivelog/apiary/{apiary}/hive/add'
   defaults:
     _controller: '\Drupal\hivelog\Controller\HiveController::addForm'
     _title: 'Add Hive'
@@ -73,7 +73,7 @@ hivelog.hive.add:
         type: entity:apiary
 
 entity.hive.canonical:
-  path: '/admin/hivelog/hive/{hive}'
+  path: '/hivelog/hive/{hive}'
   defaults:
     _controller: '\Drupal\hivelog\Controller\HiveController::view'
     _title_callback: '\Drupal\hivelog\Controller\HiveController::title'
@@ -85,7 +85,7 @@ entity.hive.canonical:
         type: entity:hive
 
 entity.hive.edit_form:
-  path: '/admin/hivelog/hive/{hive}/edit'
+  path: '/hivelog/hive/{hive}/edit'
   defaults:
     _entity_form: 'hive.edit'
     _title: 'Edit Hive'
@@ -97,7 +97,7 @@ entity.hive.edit_form:
         type: entity:hive
 
 entity.hive.delete_form:
-  path: '/admin/hivelog/hive/{hive}/delete'
+  path: '/hivelog/hive/{hive}/delete'
   defaults:
     _entity_form: 'hive.delete'
     _title: 'Delete Hive'
@@ -110,7 +110,7 @@ entity.hive.delete_form:
 
 # Inspection routes.
 entity.hive_inspection.collection:
-  path: '/admin/hivelog/inspections'
+  path: '/hivelog/inspections'
   defaults:
     _entity_list: 'hive_inspection'
     _title: 'HiveLog - Inspections'
@@ -118,7 +118,7 @@ entity.hive_inspection.collection:
     _permission: 'view own hive inspection+view any hive inspection+administer hivelog'
 
 hivelog.inspection.add:
-  path: '/admin/hivelog/hive/{hive}/inspection/add'
+  path: '/hivelog/hive/{hive}/inspection/add'
   defaults:
     _controller: '\Drupal\hivelog\Controller\HiveInspectionController::addForm'
     _title: 'Add Inspection'
@@ -130,7 +130,7 @@ hivelog.inspection.add:
         type: entity:hive
 
 entity.hive_inspection.canonical:
-  path: '/admin/hivelog/inspection/{hive_inspection}'
+  path: '/hivelog/inspection/{hive_inspection}'
   defaults:
     _controller: '\Drupal\hivelog\Controller\HiveInspectionController::view'
     _title_callback: '\Drupal\hivelog\Controller\HiveInspectionController::title'
@@ -142,7 +142,7 @@ entity.hive_inspection.canonical:
         type: entity:hive_inspection
 
 entity.hive_inspection.edit_form:
-  path: '/admin/hivelog/inspection/{hive_inspection}/edit'
+  path: '/hivelog/inspection/{hive_inspection}/edit'
   defaults:
     _entity_form: 'hive_inspection.edit'
     _title: 'Edit Inspection'
@@ -154,7 +154,7 @@ entity.hive_inspection.edit_form:
         type: entity:hive_inspection
 
 entity.hive_inspection.delete_form:
-  path: '/admin/hivelog/inspection/{hive_inspection}/delete'
+  path: '/hivelog/inspection/{hive_inspection}/delete'
   defaults:
     _entity_form: 'hive_inspection.delete'
     _title: 'Delete Inspection'
@@ -167,7 +167,7 @@ entity.hive_inspection.delete_form:
 
 # Queen routes.
 entity.queen.collection:
-  path: '/admin/hivelog/queens'
+  path: '/hivelog/queens'
   defaults:
     _entity_list: 'queen'
     _title: 'HiveLog - Queens'
@@ -175,7 +175,7 @@ entity.queen.collection:
     _permission: 'view own queen+view any queen+administer hivelog'
 
 entity.queen.add_form:
-  path: '/admin/hivelog/queen/add'
+  path: '/hivelog/queen/add'
   defaults:
     _entity_form: 'queen.add'
     _title: 'Add Queen'
@@ -183,7 +183,7 @@ entity.queen.add_form:
     _permission: 'add queen+administer hivelog'
 
 hivelog.queen.add:
-  path: '/admin/hivelog/hive/{hive}/queen/add'
+  path: '/hivelog/hive/{hive}/queen/add'
   defaults:
     _controller: '\Drupal\hivelog\Controller\QueenController::addForm'
     _title: 'Add Queen'
@@ -195,7 +195,7 @@ hivelog.queen.add:
         type: entity:hive
 
 entity.queen.canonical:
-  path: '/admin/hivelog/queen/{queen}'
+  path: '/hivelog/queen/{queen}'
   defaults:
     _controller: '\Drupal\hivelog\Controller\QueenController::view'
     _title_callback: '\Drupal\hivelog\Controller\QueenController::title'
@@ -207,7 +207,7 @@ entity.queen.canonical:
         type: entity:queen
 
 entity.queen.edit_form:
-  path: '/admin/hivelog/queen/{queen}/edit'
+  path: '/hivelog/queen/{queen}/edit'
   defaults:
     _entity_form: 'queen.edit'
     _title: 'Edit Queen'
@@ -219,7 +219,7 @@ entity.queen.edit_form:
         type: entity:queen
 
 entity.queen.delete_form:
-  path: '/admin/hivelog/queen/{queen}/delete'
+  path: '/hivelog/queen/{queen}/delete'
   defaults:
     _entity_form: 'queen.delete'
     _title: 'Delete Queen'
@@ -232,7 +232,7 @@ entity.queen.delete_form:
 
 # Queen observation routes.
 entity.queen_observation.collection:
-  path: '/admin/hivelog/queen-observations'
+  path: '/hivelog/queen-observations'
   defaults:
     _entity_list: 'queen_observation'
     _title: 'HiveLog - Queen Observations'
@@ -240,7 +240,7 @@ entity.queen_observation.collection:
     _permission: 'view own queen observation+view any queen observation+administer hivelog'
 
 hivelog.queen_observation.add:
-  path: '/admin/hivelog/queen/{queen}/observation/add'
+  path: '/hivelog/queen/{queen}/observation/add'
   defaults:
     _controller: '\Drupal\hivelog\Controller\QueenObservationController::addForm'
     _title: 'Add Queen Observation'
@@ -252,7 +252,7 @@ hivelog.queen_observation.add:
         type: entity:queen
 
 entity.queen_observation.canonical:
-  path: '/admin/hivelog/queen-observation/{queen_observation}'
+  path: '/hivelog/queen-observation/{queen_observation}'
   defaults:
     _controller: '\Drupal\hivelog\Controller\QueenObservationController::view'
     _title_callback: '\Drupal\hivelog\Controller\QueenObservationController::title'
@@ -264,7 +264,7 @@ entity.queen_observation.canonical:
         type: entity:queen_observation
 
 entity.queen_observation.edit_form:
-  path: '/admin/hivelog/queen-observation/{queen_observation}/edit'
+  path: '/hivelog/queen-observation/{queen_observation}/edit'
   defaults:
     _entity_form: 'queen_observation.edit'
     _title: 'Edit Queen Observation'
@@ -276,7 +276,7 @@ entity.queen_observation.edit_form:
         type: entity:queen_observation
 
 entity.queen_observation.delete_form:
-  path: '/admin/hivelog/queen-observation/{queen_observation}/delete'
+  path: '/hivelog/queen-observation/{queen_observation}/delete'
   defaults:
     _entity_form: 'queen_observation.delete'
     _title: 'Delete Queen Observation'

--- a/src/ApiaryAccessControlHandler.php
+++ b/src/ApiaryAccessControlHandler.php
@@ -6,6 +6,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\user\EntityOwnerInterface;
 
 /**
  * Access control handler for Apiary entities.
@@ -20,15 +21,18 @@ class ApiaryAccessControlHandler extends EntityAccessControlHandler {
       return AccessResult::allowed()->cachePerPermissions();
     }
 
+    $is_owner = ($entity instanceof EntityOwnerInterface)
+      && ((int) $entity->getOwnerId() === (int) $account->id());
+
     switch ($operation) {
       case 'view':
-        return AccessResult::allowedIfHasPermission($account, 'view apiary');
+        return $this->checkOwnershipAccess($account, $is_owner, 'view any apiary', 'view own apiary');
 
       case 'update':
-        return AccessResult::allowedIfHasPermission($account, 'edit apiary');
+        return $this->checkOwnershipAccess($account, $is_owner, 'edit any apiary', 'edit own apiary');
 
       case 'delete':
-        return AccessResult::allowedIfHasPermission($account, 'delete apiary');
+        return $this->checkOwnershipAccess($account, $is_owner, 'delete any apiary', 'delete own apiary');
     }
 
     return AccessResult::neutral();
@@ -42,6 +46,19 @@ class ApiaryAccessControlHandler extends EntityAccessControlHandler {
       'administer hivelog',
       'add apiary',
     ], 'OR');
+  }
+
+  /**
+   * Checks access based on "any" and "own" permissions.
+   */
+  protected function checkOwnershipAccess(AccountInterface $account, bool $is_owner, string $any_permission, string $own_permission): AccessResult {
+    if ($account->hasPermission($any_permission)) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+    if ($is_owner && $account->hasPermission($own_permission)) {
+      return AccessResult::allowed()->cachePerPermissions()->cachePerUser();
+    }
+    return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
   }
 
 }

--- a/src/ApiaryAccessControlHandler.php
+++ b/src/ApiaryAccessControlHandler.php
@@ -6,12 +6,17 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\user\EntityOwnerInterface;
 
 /**
  * Access control handler for Apiary entities.
+ *
+ * - view: site-wide "any" OR apiary member OR public apiary.
+ * - update: site-wide "any" OR apiary owner only.
+ * - delete: site-wide "any" OR apiary owner only.
  */
 class ApiaryAccessControlHandler extends EntityAccessControlHandler {
+
+  use ApiaryAccessTrait;
 
   /**
    * {@inheritdoc}
@@ -21,18 +26,18 @@ class ApiaryAccessControlHandler extends EntityAccessControlHandler {
       return AccessResult::allowed()->cachePerPermissions();
     }
 
-    $is_owner = ($entity instanceof EntityOwnerInterface)
-      && ((int) $entity->getOwnerId() === (int) $account->id());
+    $apiary = $this->resolveApiary($entity);
 
     switch ($operation) {
       case 'view':
-        return $this->checkOwnershipAccess($account, $is_owner, 'view any apiary', 'view own apiary');
+        return $this->checkApiaryViewAccess($apiary, $account, 'view any apiary', 'view own apiary');
 
       case 'update':
-        return $this->checkOwnershipAccess($account, $is_owner, 'edit any apiary', 'edit own apiary');
+        // Only apiary owner can edit the apiary itself.
+        return $this->checkApiaryOwnerDeleteAccess($apiary, $account, 'edit any apiary', 'edit own apiary');
 
       case 'delete':
-        return $this->checkOwnershipAccess($account, $is_owner, 'delete any apiary', 'delete own apiary');
+        return $this->checkApiaryOwnerDeleteAccess($apiary, $account, 'delete any apiary', 'delete own apiary');
     }
 
     return AccessResult::neutral();
@@ -46,19 +51,6 @@ class ApiaryAccessControlHandler extends EntityAccessControlHandler {
       'administer hivelog',
       'add apiary',
     ], 'OR');
-  }
-
-  /**
-   * Checks access based on "any" and "own" permissions.
-   */
-  protected function checkOwnershipAccess(AccountInterface $account, bool $is_owner, string $any_permission, string $own_permission): AccessResult {
-    if ($account->hasPermission($any_permission)) {
-      return AccessResult::allowed()->cachePerPermissions();
-    }
-    if ($is_owner && $account->hasPermission($own_permission)) {
-      return AccessResult::allowed()->cachePerPermissions()->cachePerUser();
-    }
-    return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
   }
 
 }

--- a/src/ApiaryAccessTrait.php
+++ b/src/ApiaryAccessTrait.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Drupal\hivelog;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\hivelog\Entity\Apiary;
+
+/**
+ * Shared helpers for apiary-scoped access control.
+ *
+ * Used by all hivelog entity access control handlers to resolve the parent
+ * apiary from a child entity and check membership / visibility.
+ */
+trait ApiaryAccessTrait {
+
+  /**
+   * Resolves the parent Apiary from a child entity.
+   *
+   * Traverses the entity reference chain:
+   * - Apiary: returns itself.
+   * - Hive: hive → apiary.
+   * - HiveInspection: inspection → hive → apiary.
+   * - Queen: queen → hive → apiary (hive may be NULL).
+   * - QueenObservation: observation → queen → hive → apiary.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to resolve the apiary from.
+   *
+   * @return \Drupal\hivelog\Entity\Apiary|null
+   *   The parent apiary, or NULL if the chain is broken.
+   */
+  protected function resolveApiary(EntityInterface $entity): ?Apiary {
+    if ($entity instanceof Apiary) {
+      return $entity;
+    }
+
+    $entity_type = $entity->getEntityTypeId();
+
+    // Hive → apiary.
+    if ($entity_type === 'hive') {
+      return $entity->get('apiary')->entity;
+    }
+
+    // HiveInspection → hive → apiary.
+    if ($entity_type === 'hive_inspection') {
+      $hive = $entity->get('hive')->entity;
+      return $hive ? $hive->get('apiary')->entity : NULL;
+    }
+
+    // Queen → hive → apiary (hive is optional on queens).
+    if ($entity_type === 'queen') {
+      $hive = $entity->get('hive')->entity;
+      return $hive ? $hive->get('apiary')->entity : NULL;
+    }
+
+    // QueenObservation → queen → hive → apiary.
+    if ($entity_type === 'queen_observation') {
+      $queen = $entity->get('queen')->entity;
+      if ($queen) {
+        $hive = $queen->get('hive')->entity;
+        return $hive ? $hive->get('apiary')->entity : NULL;
+      }
+      return NULL;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Checks view access considering apiary membership and visibility.
+   *
+   * @param \Drupal\hivelog\Entity\Apiary|null $apiary
+   *   The parent apiary (NULL if the chain is broken).
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param string $any_permission
+   *   The "any" permission (site-wide override).
+   * @param string $own_permission
+   *   The "own" permission (apiary-member scoped).
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   The access result.
+   */
+  protected function checkApiaryViewAccess(?Apiary $apiary, AccountInterface $account, string $any_permission, string $own_permission): AccessResult {
+    // Site-wide "any" permission always grants access.
+    if ($account->hasPermission($any_permission)) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+
+    if (!$apiary) {
+      return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
+    }
+
+    // Apiary member with the "own" permission.
+    if ($apiary->isApiaryMember($account) && $account->hasPermission($own_permission)) {
+      return AccessResult::allowed()
+        ->cachePerPermissions()
+        ->cachePerUser()
+        ->addCacheableDependency($apiary);
+    }
+
+    // Public apiary: any user with the "own" permission can view.
+    if ($apiary->isPublic() && $account->hasPermission($own_permission)) {
+      return AccessResult::allowed()
+        ->cachePerPermissions()
+        ->cachePerUser()
+        ->addCacheableDependency($apiary);
+    }
+
+    return AccessResult::neutral()
+      ->cachePerPermissions()
+      ->cachePerUser()
+      ->addCacheableDependency($apiary);
+  }
+
+  /**
+   * Checks edit access considering apiary membership.
+   *
+   * Grants access to the apiary owner and approved beekeepers.
+   *
+   * @param \Drupal\hivelog\Entity\Apiary|null $apiary
+   *   The parent apiary.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param string $any_permission
+   *   The "any" permission (site-wide override).
+   * @param string $own_permission
+   *   The "own" permission (apiary-member scoped).
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   The access result.
+   */
+  protected function checkApiaryEditAccess(?Apiary $apiary, AccountInterface $account, string $any_permission, string $own_permission): AccessResult {
+    if ($account->hasPermission($any_permission)) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+
+    if (!$apiary) {
+      return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
+    }
+
+    if ($apiary->isApiaryMember($account) && $account->hasPermission($own_permission)) {
+      return AccessResult::allowed()
+        ->cachePerPermissions()
+        ->cachePerUser()
+        ->addCacheableDependency($apiary);
+    }
+
+    return AccessResult::neutral()
+      ->cachePerPermissions()
+      ->cachePerUser()
+      ->addCacheableDependency($apiary);
+  }
+
+  /**
+   * Checks delete access — apiary owner only (plus site-wide "any").
+   *
+   * @param \Drupal\hivelog\Entity\Apiary|null $apiary
+   *   The parent apiary.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param string $any_permission
+   *   The "any" permission (site-wide override).
+   * @param string $own_permission
+   *   The "own" permission (owner-scoped).
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   The access result.
+   */
+  protected function checkApiaryOwnerDeleteAccess(?Apiary $apiary, AccountInterface $account, string $any_permission, string $own_permission): AccessResult {
+    if ($account->hasPermission($any_permission)) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+
+    if (!$apiary) {
+      return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
+    }
+
+    // Only the apiary owner can delete.
+    $is_owner = (int) $apiary->getOwnerId() === (int) $account->id();
+    if ($is_owner && $account->hasPermission($own_permission)) {
+      return AccessResult::allowed()
+        ->cachePerPermissions()
+        ->cachePerUser()
+        ->addCacheableDependency($apiary);
+    }
+
+    return AccessResult::neutral()
+      ->cachePerPermissions()
+      ->cachePerUser()
+      ->addCacheableDependency($apiary);
+  }
+
+  /**
+   * Checks delete access — apiary owner OR the entity creator.
+   *
+   * Used for inspections and observations where the beekeeper who created
+   * the record may also delete it.
+   *
+   * @param \Drupal\hivelog\Entity\Apiary|null $apiary
+   *   The parent apiary.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity being deleted.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param string $any_permission
+   *   The "any" permission.
+   * @param string $own_permission
+   *   The "own" permission.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   The access result.
+   */
+  protected function checkApiaryMemberDeleteAccess(?Apiary $apiary, EntityInterface $entity, AccountInterface $account, string $any_permission, string $own_permission): AccessResult {
+    if ($account->hasPermission($any_permission)) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+
+    if (!$apiary) {
+      return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
+    }
+
+    $is_apiary_owner = (int) $apiary->getOwnerId() === (int) $account->id();
+    $is_entity_creator = method_exists($entity, 'getOwnerId')
+      && (int) $entity->getOwnerId() === (int) $account->id();
+
+    if (($is_apiary_owner || ($apiary->isApiaryMember($account) && $is_entity_creator))
+      && $account->hasPermission($own_permission)) {
+      return AccessResult::allowed()
+        ->cachePerPermissions()
+        ->cachePerUser()
+        ->addCacheableDependency($apiary);
+    }
+
+    return AccessResult::neutral()
+      ->cachePerPermissions()
+      ->cachePerUser()
+      ->addCacheableDependency($apiary);
+  }
+
+}

--- a/src/Breadcrumb/HivelogBreadcrumbBuilder.php
+++ b/src/Breadcrumb/HivelogBreadcrumbBuilder.php
@@ -55,9 +55,8 @@ class HivelogBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     $breadcrumb = new Breadcrumb();
     $breadcrumb->addCacheContexts(['route']);
 
-    // Home > Structure > HiveLog.
+    // Home > HiveLog.
     $breadcrumb->addLink(Link::createFromRoute($this->t('Home'), '<front>'));
-    $breadcrumb->addLink(Link::createFromRoute($this->t('Structure'), 'system.admin_structure'));
     $breadcrumb->addLink(Link::createFromRoute($this->t('HiveLog'), 'entity.apiary.collection'));
 
     $route_name = $route_match->getRouteName();

--- a/src/Entity/Apiary.php
+++ b/src/Entity/Apiary.php
@@ -10,6 +10,8 @@ use Drupal\Core\Entity\EntityChangedInterface;
 use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\hivelog\ApiaryAccessControlHandler;
 use Drupal\hivelog\ApiaryListBuilder;
@@ -57,6 +59,40 @@ class Apiary extends ContentEntityBase implements EntityChangedInterface, Entity
 
   use EntityChangedTrait;
   use EntityOwnerTrait;
+
+  /**
+   * Checks whether the given account is a member of this apiary.
+   *
+   * A member is either the apiary owner or a user listed in the
+   * beekeepers field.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account to check.
+   *
+   * @return bool
+   *   TRUE if the account is the apiary owner or an approved beekeeper.
+   */
+  public function isApiaryMember(AccountInterface $account): bool {
+    if ((int) $this->getOwnerId() === (int) $account->id()) {
+      return TRUE;
+    }
+    foreach ($this->get('beekeepers') as $item) {
+      if ((int) $item->target_id === (int) $account->id()) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Checks whether this apiary is publicly visible.
+   *
+   * @return bool
+   *   TRUE if the visibility field is set to 'public'.
+   */
+  public function isPublic(): bool {
+    return $this->get('visibility')->value === 'public';
+  }
 
   /**
    * {@inheritdoc}
@@ -145,12 +181,44 @@ class Apiary extends ContentEntityBase implements EntityChangedInterface, Entity
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
+    $fields['beekeepers'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Beekeepers'))
+      ->setDescription(t('Users who are approved to manage hives and record inspections in this apiary. The apiary owner always has full access and does not need to be listed here.'))
+      ->setSetting('target_type', 'user')
+      ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+      ->setDisplayOptions('form', [
+        'type' => 'entity_reference_autocomplete',
+        'weight' => 5,
+        'settings' => [
+          'match_operator' => 'CONTAINS',
+          'size' => 60,
+        ],
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['visibility'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(t('Visibility'))
+      ->setDescription(t('Controls whether non-members can view this apiary and its hives. Private apiaries are only visible to the owner and approved beekeepers.'))
+      ->setRequired(TRUE)
+      ->setDefaultValue('private')
+      ->setSetting('allowed_values', [
+        'private' => 'Private',
+        'public' => 'Public',
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'options_select',
+        'weight' => 6,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
     $fields['uid']
       ->setLabel(t('Owner'))
       ->setDescription(t('The user who owns this apiary.'))
       ->setDisplayOptions('form', [
         'type' => 'entity_reference_autocomplete',
-        'weight' => 5,
+        'weight' => 7,
         'settings' => [
           'match_operator' => 'CONTAINS',
           'size' => 60,

--- a/src/Entity/Apiary.php
+++ b/src/Entity/Apiary.php
@@ -46,11 +46,11 @@ use Drupal\user\EntityOwnerTrait;
     'owner' => 'uid',
   ],
   links: [
-    'canonical' => '/admin/hivelog/apiary/{apiary}',
-    'add-form' => '/admin/hivelog/apiary/add',
-    'edit-form' => '/admin/hivelog/apiary/{apiary}/edit',
-    'delete-form' => '/admin/hivelog/apiary/{apiary}/delete',
-    'collection' => '/admin/hivelog',
+    'canonical' => '/hivelog/apiary/{apiary}',
+    'add-form' => '/hivelog/apiary/add',
+    'edit-form' => '/hivelog/apiary/{apiary}/edit',
+    'delete-form' => '/hivelog/apiary/{apiary}/delete',
+    'collection' => '/hivelog',
   ],
 )]
 class Apiary extends ContentEntityBase implements EntityChangedInterface, EntityOwnerInterface {

--- a/src/Entity/Hive.php
+++ b/src/Entity/Hive.php
@@ -48,9 +48,9 @@ use Drupal\user\EntityOwnerTrait;
     'owner' => 'uid',
   ],
   links: [
-    'canonical' => '/admin/hivelog/hive/{hive}',
-    'edit-form' => '/admin/hivelog/hive/{hive}/edit',
-    'delete-form' => '/admin/hivelog/hive/{hive}/delete',
+    'canonical' => '/hivelog/hive/{hive}',
+    'edit-form' => '/hivelog/hive/{hive}/edit',
+    'delete-form' => '/hivelog/hive/{hive}/delete',
   ],
 )]
 class Hive extends ContentEntityBase implements EntityChangedInterface, EntityOwnerInterface {

--- a/src/Entity/HiveInspection.php
+++ b/src/Entity/HiveInspection.php
@@ -46,9 +46,9 @@ use Drupal\user\EntityOwnerTrait;
     'owner' => 'uid',
   ],
   links: [
-    'canonical' => '/admin/hivelog/inspection/{hive_inspection}',
-    'edit-form' => '/admin/hivelog/inspection/{hive_inspection}/edit',
-    'delete-form' => '/admin/hivelog/inspection/{hive_inspection}/delete',
+    'canonical' => '/hivelog/inspection/{hive_inspection}',
+    'edit-form' => '/hivelog/inspection/{hive_inspection}/edit',
+    'delete-form' => '/hivelog/inspection/{hive_inspection}/delete',
   ],
 )]
 class HiveInspection extends ContentEntityBase implements EntityChangedInterface, EntityOwnerInterface {

--- a/src/Entity/Queen.php
+++ b/src/Entity/Queen.php
@@ -53,11 +53,11 @@ use Drupal\user\EntityOwnerTrait;
     'owner' => 'uid',
   ],
   links: [
-    'canonical' => '/admin/hivelog/queen/{queen}',
-    'add-form' => '/admin/hivelog/queen/add',
-    'edit-form' => '/admin/hivelog/queen/{queen}/edit',
-    'delete-form' => '/admin/hivelog/queen/{queen}/delete',
-    'collection' => '/admin/hivelog/queens',
+    'canonical' => '/hivelog/queen/{queen}',
+    'add-form' => '/hivelog/queen/add',
+    'edit-form' => '/hivelog/queen/{queen}/edit',
+    'delete-form' => '/hivelog/queen/{queen}/delete',
+    'collection' => '/hivelog/queens',
   ],
 )]
 class Queen extends ContentEntityBase implements EntityChangedInterface, EntityOwnerInterface {

--- a/src/Entity/QueenObservation.php
+++ b/src/Entity/QueenObservation.php
@@ -51,10 +51,10 @@ use Drupal\user\EntityOwnerTrait;
     'owner' => 'uid',
   ],
   links: [
-    'canonical' => '/admin/hivelog/queen-observation/{queen_observation}',
-    'edit-form' => '/admin/hivelog/queen-observation/{queen_observation}/edit',
-    'delete-form' => '/admin/hivelog/queen-observation/{queen_observation}/delete',
-    'collection' => '/admin/hivelog/queen-observations',
+    'canonical' => '/hivelog/queen-observation/{queen_observation}',
+    'edit-form' => '/hivelog/queen-observation/{queen_observation}/edit',
+    'delete-form' => '/hivelog/queen-observation/{queen_observation}/delete',
+    'collection' => '/hivelog/queen-observations',
   ],
 )]
 class QueenObservation extends ContentEntityBase implements EntityChangedInterface, EntityOwnerInterface {

--- a/src/HiveAccessControlHandler.php
+++ b/src/HiveAccessControlHandler.php
@@ -6,6 +6,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\user\EntityOwnerInterface;
 
 /**
  * Access control handler for Hive entities.
@@ -20,15 +21,18 @@ class HiveAccessControlHandler extends EntityAccessControlHandler {
       return AccessResult::allowed()->cachePerPermissions();
     }
 
+    $is_owner = ($entity instanceof EntityOwnerInterface)
+      && ((int) $entity->getOwnerId() === (int) $account->id());
+
     switch ($operation) {
       case 'view':
-        return AccessResult::allowedIfHasPermission($account, 'view hive');
+        return $this->checkOwnershipAccess($account, $is_owner, 'view any hive', 'view own hive');
 
       case 'update':
-        return AccessResult::allowedIfHasPermission($account, 'edit hive');
+        return $this->checkOwnershipAccess($account, $is_owner, 'edit any hive', 'edit own hive');
 
       case 'delete':
-        return AccessResult::allowedIfHasPermission($account, 'delete hive');
+        return $this->checkOwnershipAccess($account, $is_owner, 'delete any hive', 'delete own hive');
     }
 
     return AccessResult::neutral();
@@ -42,6 +46,19 @@ class HiveAccessControlHandler extends EntityAccessControlHandler {
       'administer hivelog',
       'add hive',
     ], 'OR');
+  }
+
+  /**
+   * Checks access based on "any" and "own" permissions.
+   */
+  protected function checkOwnershipAccess(AccountInterface $account, bool $is_owner, string $any_permission, string $own_permission): AccessResult {
+    if ($account->hasPermission($any_permission)) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+    if ($is_owner && $account->hasPermission($own_permission)) {
+      return AccessResult::allowed()->cachePerPermissions()->cachePerUser();
+    }
+    return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
   }
 
 }

--- a/src/HiveAccessControlHandler.php
+++ b/src/HiveAccessControlHandler.php
@@ -6,12 +6,18 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\user\EntityOwnerInterface;
 
 /**
  * Access control handler for Hive entities.
+ *
+ * Access is scoped to the parent apiary:
+ * - view: site-wide "any" OR apiary member OR public apiary.
+ * - update: site-wide "any" OR apiary member (owner + beekeepers).
+ * - delete: site-wide "any" OR apiary owner only.
  */
 class HiveAccessControlHandler extends EntityAccessControlHandler {
+
+  use ApiaryAccessTrait;
 
   /**
    * {@inheritdoc}
@@ -21,18 +27,17 @@ class HiveAccessControlHandler extends EntityAccessControlHandler {
       return AccessResult::allowed()->cachePerPermissions();
     }
 
-    $is_owner = ($entity instanceof EntityOwnerInterface)
-      && ((int) $entity->getOwnerId() === (int) $account->id());
+    $apiary = $this->resolveApiary($entity);
 
     switch ($operation) {
       case 'view':
-        return $this->checkOwnershipAccess($account, $is_owner, 'view any hive', 'view own hive');
+        return $this->checkApiaryViewAccess($apiary, $account, 'view any hive', 'view own hive');
 
       case 'update':
-        return $this->checkOwnershipAccess($account, $is_owner, 'edit any hive', 'edit own hive');
+        return $this->checkApiaryEditAccess($apiary, $account, 'edit any hive', 'edit own hive');
 
       case 'delete':
-        return $this->checkOwnershipAccess($account, $is_owner, 'delete any hive', 'delete own hive');
+        return $this->checkApiaryOwnerDeleteAccess($apiary, $account, 'delete any hive', 'delete own hive');
     }
 
     return AccessResult::neutral();
@@ -46,19 +51,6 @@ class HiveAccessControlHandler extends EntityAccessControlHandler {
       'administer hivelog',
       'add hive',
     ], 'OR');
-  }
-
-  /**
-   * Checks access based on "any" and "own" permissions.
-   */
-  protected function checkOwnershipAccess(AccountInterface $account, bool $is_owner, string $any_permission, string $own_permission): AccessResult {
-    if ($account->hasPermission($any_permission)) {
-      return AccessResult::allowed()->cachePerPermissions();
-    }
-    if ($is_owner && $account->hasPermission($own_permission)) {
-      return AccessResult::allowed()->cachePerPermissions()->cachePerUser();
-    }
-    return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
   }
 
 }

--- a/src/HiveInspectionAccessControlHandler.php
+++ b/src/HiveInspectionAccessControlHandler.php
@@ -6,6 +6,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\user\EntityOwnerInterface;
 
 /**
  * Access control handler for Hive Inspection entities.
@@ -20,15 +21,18 @@ class HiveInspectionAccessControlHandler extends EntityAccessControlHandler {
       return AccessResult::allowed()->cachePerPermissions();
     }
 
+    $is_owner = ($entity instanceof EntityOwnerInterface)
+      && ((int) $entity->getOwnerId() === (int) $account->id());
+
     switch ($operation) {
       case 'view':
-        return AccessResult::allowedIfHasPermission($account, 'view hive inspection');
+        return $this->checkOwnershipAccess($account, $is_owner, 'view any hive inspection', 'view own hive inspection');
 
       case 'update':
-        return AccessResult::allowedIfHasPermission($account, 'edit hive inspection');
+        return $this->checkOwnershipAccess($account, $is_owner, 'edit any hive inspection', 'edit own hive inspection');
 
       case 'delete':
-        return AccessResult::allowedIfHasPermission($account, 'delete hive inspection');
+        return $this->checkOwnershipAccess($account, $is_owner, 'delete any hive inspection', 'delete own hive inspection');
     }
 
     return AccessResult::neutral();
@@ -42,6 +46,19 @@ class HiveInspectionAccessControlHandler extends EntityAccessControlHandler {
       'administer hivelog',
       'add hive inspection',
     ], 'OR');
+  }
+
+  /**
+   * Checks access based on "any" and "own" permissions.
+   */
+  protected function checkOwnershipAccess(AccountInterface $account, bool $is_owner, string $any_permission, string $own_permission): AccessResult {
+    if ($account->hasPermission($any_permission)) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+    if ($is_owner && $account->hasPermission($own_permission)) {
+      return AccessResult::allowed()->cachePerPermissions()->cachePerUser();
+    }
+    return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
   }
 
 }

--- a/src/HiveInspectionAccessControlHandler.php
+++ b/src/HiveInspectionAccessControlHandler.php
@@ -6,12 +6,18 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\user\EntityOwnerInterface;
 
 /**
  * Access control handler for Hive Inspection entities.
+ *
+ * Access is scoped to the parent apiary (via hive → apiary):
+ * - view: site-wide "any" OR apiary member OR public apiary.
+ * - update: site-wide "any" OR apiary member.
+ * - delete: site-wide "any" OR apiary owner OR beekeeper who created it.
  */
 class HiveInspectionAccessControlHandler extends EntityAccessControlHandler {
+
+  use ApiaryAccessTrait;
 
   /**
    * {@inheritdoc}
@@ -21,18 +27,17 @@ class HiveInspectionAccessControlHandler extends EntityAccessControlHandler {
       return AccessResult::allowed()->cachePerPermissions();
     }
 
-    $is_owner = ($entity instanceof EntityOwnerInterface)
-      && ((int) $entity->getOwnerId() === (int) $account->id());
+    $apiary = $this->resolveApiary($entity);
 
     switch ($operation) {
       case 'view':
-        return $this->checkOwnershipAccess($account, $is_owner, 'view any hive inspection', 'view own hive inspection');
+        return $this->checkApiaryViewAccess($apiary, $account, 'view any hive inspection', 'view own hive inspection');
 
       case 'update':
-        return $this->checkOwnershipAccess($account, $is_owner, 'edit any hive inspection', 'edit own hive inspection');
+        return $this->checkApiaryEditAccess($apiary, $account, 'edit any hive inspection', 'edit own hive inspection');
 
       case 'delete':
-        return $this->checkOwnershipAccess($account, $is_owner, 'delete any hive inspection', 'delete own hive inspection');
+        return $this->checkApiaryMemberDeleteAccess($apiary, $entity, $account, 'delete any hive inspection', 'delete own hive inspection');
     }
 
     return AccessResult::neutral();
@@ -46,19 +51,6 @@ class HiveInspectionAccessControlHandler extends EntityAccessControlHandler {
       'administer hivelog',
       'add hive inspection',
     ], 'OR');
-  }
-
-  /**
-   * Checks access based on "any" and "own" permissions.
-   */
-  protected function checkOwnershipAccess(AccountInterface $account, bool $is_owner, string $any_permission, string $own_permission): AccessResult {
-    if ($account->hasPermission($any_permission)) {
-      return AccessResult::allowed()->cachePerPermissions();
-    }
-    if ($is_owner && $account->hasPermission($own_permission)) {
-      return AccessResult::allowed()->cachePerPermissions()->cachePerUser();
-    }
-    return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
   }
 
 }

--- a/src/QueenAccessControlHandler.php
+++ b/src/QueenAccessControlHandler.php
@@ -6,12 +6,19 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\user\EntityOwnerInterface;
 
 /**
  * Access control handler for Queen entities.
+ *
+ * Access is scoped to the parent apiary (via queen → hive → apiary).
+ * Queens without a hive fall back to uid-based ownership check.
+ * - view: site-wide "any" OR apiary member OR public apiary.
+ * - update: site-wide "any" OR apiary member.
+ * - delete: site-wide "any" OR apiary owner only.
  */
 class QueenAccessControlHandler extends EntityAccessControlHandler {
+
+  use ApiaryAccessTrait;
 
   /**
    * {@inheritdoc}
@@ -21,18 +28,17 @@ class QueenAccessControlHandler extends EntityAccessControlHandler {
       return AccessResult::allowed()->cachePerPermissions();
     }
 
-    $is_owner = ($entity instanceof EntityOwnerInterface)
-      && ((int) $entity->getOwnerId() === (int) $account->id());
+    $apiary = $this->resolveApiary($entity);
 
     switch ($operation) {
       case 'view':
-        return $this->checkOwnershipAccess($account, $is_owner, 'view any queen', 'view own queen');
+        return $this->checkApiaryViewAccess($apiary, $account, 'view any queen', 'view own queen');
 
       case 'update':
-        return $this->checkOwnershipAccess($account, $is_owner, 'edit any queen', 'edit own queen');
+        return $this->checkApiaryEditAccess($apiary, $account, 'edit any queen', 'edit own queen');
 
       case 'delete':
-        return $this->checkOwnershipAccess($account, $is_owner, 'delete any queen', 'delete own queen');
+        return $this->checkApiaryOwnerDeleteAccess($apiary, $account, 'delete any queen', 'delete own queen');
     }
 
     return AccessResult::neutral();
@@ -46,19 +52,6 @@ class QueenAccessControlHandler extends EntityAccessControlHandler {
       'administer hivelog',
       'add queen',
     ], 'OR');
-  }
-
-  /**
-   * Checks access based on "any" and "own" permissions.
-   */
-  protected function checkOwnershipAccess(AccountInterface $account, bool $is_owner, string $any_permission, string $own_permission): AccessResult {
-    if ($account->hasPermission($any_permission)) {
-      return AccessResult::allowed()->cachePerPermissions();
-    }
-    if ($is_owner && $account->hasPermission($own_permission)) {
-      return AccessResult::allowed()->cachePerPermissions()->cachePerUser();
-    }
-    return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
   }
 
 }

--- a/src/QueenAccessControlHandler.php
+++ b/src/QueenAccessControlHandler.php
@@ -6,6 +6,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\user\EntityOwnerInterface;
 
 /**
  * Access control handler for Queen entities.
@@ -20,15 +21,18 @@ class QueenAccessControlHandler extends EntityAccessControlHandler {
       return AccessResult::allowed()->cachePerPermissions();
     }
 
+    $is_owner = ($entity instanceof EntityOwnerInterface)
+      && ((int) $entity->getOwnerId() === (int) $account->id());
+
     switch ($operation) {
       case 'view':
-        return AccessResult::allowedIfHasPermission($account, 'view queen');
+        return $this->checkOwnershipAccess($account, $is_owner, 'view any queen', 'view own queen');
 
       case 'update':
-        return AccessResult::allowedIfHasPermission($account, 'edit queen');
+        return $this->checkOwnershipAccess($account, $is_owner, 'edit any queen', 'edit own queen');
 
       case 'delete':
-        return AccessResult::allowedIfHasPermission($account, 'delete queen');
+        return $this->checkOwnershipAccess($account, $is_owner, 'delete any queen', 'delete own queen');
     }
 
     return AccessResult::neutral();
@@ -42,6 +46,19 @@ class QueenAccessControlHandler extends EntityAccessControlHandler {
       'administer hivelog',
       'add queen',
     ], 'OR');
+  }
+
+  /**
+   * Checks access based on "any" and "own" permissions.
+   */
+  protected function checkOwnershipAccess(AccountInterface $account, bool $is_owner, string $any_permission, string $own_permission): AccessResult {
+    if ($account->hasPermission($any_permission)) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+    if ($is_owner && $account->hasPermission($own_permission)) {
+      return AccessResult::allowed()->cachePerPermissions()->cachePerUser();
+    }
+    return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
   }
 
 }

--- a/src/QueenObservationAccessControlHandler.php
+++ b/src/QueenObservationAccessControlHandler.php
@@ -6,6 +6,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\user\EntityOwnerInterface;
 
 /**
  * Access control handler for Queen Observation entities.
@@ -20,15 +21,18 @@ class QueenObservationAccessControlHandler extends EntityAccessControlHandler {
       return AccessResult::allowed()->cachePerPermissions();
     }
 
+    $is_owner = ($entity instanceof EntityOwnerInterface)
+      && ((int) $entity->getOwnerId() === (int) $account->id());
+
     switch ($operation) {
       case 'view':
-        return AccessResult::allowedIfHasPermission($account, 'view queen observation');
+        return $this->checkOwnershipAccess($account, $is_owner, 'view any queen observation', 'view own queen observation');
 
       case 'update':
-        return AccessResult::allowedIfHasPermission($account, 'edit queen observation');
+        return $this->checkOwnershipAccess($account, $is_owner, 'edit any queen observation', 'edit own queen observation');
 
       case 'delete':
-        return AccessResult::allowedIfHasPermission($account, 'delete queen observation');
+        return $this->checkOwnershipAccess($account, $is_owner, 'delete any queen observation', 'delete own queen observation');
     }
 
     return AccessResult::neutral();
@@ -42,6 +46,19 @@ class QueenObservationAccessControlHandler extends EntityAccessControlHandler {
       'administer hivelog',
       'add queen observation',
     ], 'OR');
+  }
+
+  /**
+   * Checks access based on "any" and "own" permissions.
+   */
+  protected function checkOwnershipAccess(AccountInterface $account, bool $is_owner, string $any_permission, string $own_permission): AccessResult {
+    if ($account->hasPermission($any_permission)) {
+      return AccessResult::allowed()->cachePerPermissions();
+    }
+    if ($is_owner && $account->hasPermission($own_permission)) {
+      return AccessResult::allowed()->cachePerPermissions()->cachePerUser();
+    }
+    return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
   }
 
 }

--- a/src/QueenObservationAccessControlHandler.php
+++ b/src/QueenObservationAccessControlHandler.php
@@ -6,12 +6,18 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\user\EntityOwnerInterface;
 
 /**
  * Access control handler for Queen Observation entities.
+ *
+ * Access is scoped to the parent apiary (via observation → queen → hive → apiary).
+ * - view: site-wide "any" OR apiary member OR public apiary.
+ * - update: site-wide "any" OR apiary member.
+ * - delete: site-wide "any" OR apiary owner OR beekeeper who created it.
  */
 class QueenObservationAccessControlHandler extends EntityAccessControlHandler {
+
+  use ApiaryAccessTrait;
 
   /**
    * {@inheritdoc}
@@ -21,18 +27,17 @@ class QueenObservationAccessControlHandler extends EntityAccessControlHandler {
       return AccessResult::allowed()->cachePerPermissions();
     }
 
-    $is_owner = ($entity instanceof EntityOwnerInterface)
-      && ((int) $entity->getOwnerId() === (int) $account->id());
+    $apiary = $this->resolveApiary($entity);
 
     switch ($operation) {
       case 'view':
-        return $this->checkOwnershipAccess($account, $is_owner, 'view any queen observation', 'view own queen observation');
+        return $this->checkApiaryViewAccess($apiary, $account, 'view any queen observation', 'view own queen observation');
 
       case 'update':
-        return $this->checkOwnershipAccess($account, $is_owner, 'edit any queen observation', 'edit own queen observation');
+        return $this->checkApiaryEditAccess($apiary, $account, 'edit any queen observation', 'edit own queen observation');
 
       case 'delete':
-        return $this->checkOwnershipAccess($account, $is_owner, 'delete any queen observation', 'delete own queen observation');
+        return $this->checkApiaryMemberDeleteAccess($apiary, $entity, $account, 'delete any queen observation', 'delete own queen observation');
     }
 
     return AccessResult::neutral();
@@ -46,19 +51,6 @@ class QueenObservationAccessControlHandler extends EntityAccessControlHandler {
       'administer hivelog',
       'add queen observation',
     ], 'OR');
-  }
-
-  /**
-   * Checks access based on "any" and "own" permissions.
-   */
-  protected function checkOwnershipAccess(AccountInterface $account, bool $is_owner, string $any_permission, string $own_permission): AccessResult {
-    if ($account->hasPermission($any_permission)) {
-      return AccessResult::allowed()->cachePerPermissions();
-    }
-    if ($is_owner && $account->hasPermission($own_permission)) {
-      return AccessResult::allowed()->cachePerPermissions()->cachePerUser();
-    }
-    return AccessResult::neutral()->cachePerPermissions()->cachePerUser();
   }
 
 }

--- a/tests/src/Functional/EntityCrudJourneyTest.php
+++ b/tests/src/Functional/EntityCrudJourneyTest.php
@@ -42,7 +42,7 @@ class EntityCrudJourneyTest extends BrowserTestBase {
    */
   public function testApiaryCrudJourney(): void {
     // Create.
-    $this->drupalGet('/admin/hivelog/apiary/add');
+    $this->drupalGet('/hivelog/apiary/add');
     $this->assertSession()->statusCodeEquals(200);
     $this->submitForm([
       'name[0][value]' => 'Home Apiary',
@@ -59,7 +59,7 @@ class EntityCrudJourneyTest extends BrowserTestBase {
     $apiary = reset($apiaries);
 
     // Edit.
-    $this->drupalGet('/admin/hivelog/apiary/' . $apiary->id() . '/edit');
+    $this->drupalGet('/hivelog/apiary/' . $apiary->id() . '/edit');
     $this->assertSession()->statusCodeEquals(200);
     $this->submitForm([
       'name[0][value]' => 'Home Apiary Renamed',
@@ -68,7 +68,7 @@ class EntityCrudJourneyTest extends BrowserTestBase {
     $this->assertEquals('Home Apiary Renamed', $reloaded->label());
 
     // Delete.
-    $this->drupalGet('/admin/hivelog/apiary/' . $apiary->id() . '/delete');
+    $this->drupalGet('/hivelog/apiary/' . $apiary->id() . '/delete');
     $this->assertSession()->statusCodeEquals(200);
     $this->submitForm([], 'Delete');
     $this->assertNull(Apiary::load($apiary->id()));
@@ -83,7 +83,7 @@ class EntityCrudJourneyTest extends BrowserTestBase {
 
     // Create via the scoped /apiary/{apiary}/hive/add route so the parent
     // reference is pre-populated by HiveController::addForm().
-    $this->drupalGet('/admin/hivelog/apiary/' . $apiary->id() . '/hive/add');
+    $this->drupalGet('/hivelog/apiary/' . $apiary->id() . '/hive/add');
     $this->assertSession()->statusCodeEquals(200);
     $this->submitForm([
       'name[0][value]' => 'CRUD Hive',
@@ -99,7 +99,7 @@ class EntityCrudJourneyTest extends BrowserTestBase {
     $this->assertEquals($apiary->id(), $hive->get('apiary')->target_id);
 
     // Edit.
-    $this->drupalGet('/admin/hivelog/hive/' . $hive->id() . '/edit');
+    $this->drupalGet('/hivelog/hive/' . $hive->id() . '/edit');
     $this->assertSession()->statusCodeEquals(200);
     $this->submitForm([
       'name[0][value]' => 'CRUD Hive Renamed',
@@ -110,7 +110,7 @@ class EntityCrudJourneyTest extends BrowserTestBase {
     $this->assertEquals('inactive', $reloaded->get('status')->value);
 
     // Delete.
-    $this->drupalGet('/admin/hivelog/hive/' . $hive->id() . '/delete');
+    $this->drupalGet('/hivelog/hive/' . $hive->id() . '/delete');
     $this->assertSession()->statusCodeEquals(200);
     $this->submitForm([], 'Delete');
     $this->assertNull(Hive::load($hive->id()));
@@ -131,7 +131,7 @@ class EntityCrudJourneyTest extends BrowserTestBase {
     $hive->save();
 
     // Create via /hive/{hive}/inspection/add.
-    $this->drupalGet('/admin/hivelog/hive/' . $hive->id() . '/inspection/add');
+    $this->drupalGet('/hivelog/hive/' . $hive->id() . '/inspection/add');
     $this->assertSession()->statusCodeEquals(200);
     $this->submitForm([
       'inspection_date[0][value][date]' => '2024-06-15',
@@ -147,7 +147,7 @@ class EntityCrudJourneyTest extends BrowserTestBase {
     $this->assertEquals('2024-06-15', $inspection->get('inspection_date')->value);
 
     // Edit.
-    $this->drupalGet('/admin/hivelog/inspection/' . $inspection->id() . '/edit');
+    $this->drupalGet('/hivelog/inspection/' . $inspection->id() . '/edit');
     $this->assertSession()->statusCodeEquals(200);
     $this->submitForm([
       'notes[0][value]' => 'Updated notes.',
@@ -156,7 +156,7 @@ class EntityCrudJourneyTest extends BrowserTestBase {
     $this->assertEquals('Updated notes.', $reloaded->get('notes')->value);
 
     // Delete.
-    $this->drupalGet('/admin/hivelog/inspection/' . $inspection->id() . '/delete');
+    $this->drupalGet('/hivelog/inspection/' . $inspection->id() . '/delete');
     $this->assertSession()->statusCodeEquals(200);
     $this->submitForm([], 'Delete');
     $this->assertNull(HiveInspection::load($inspection->id()));

--- a/tests/src/Functional/PermissionMatrixTest.php
+++ b/tests/src/Functional/PermissionMatrixTest.php
@@ -74,21 +74,21 @@ class PermissionMatrixTest extends BrowserTestBase {
    */
   public function testAnonymousHasNoAccess(): void {
     $paths = [
-      '/admin/hivelog',
-      '/admin/hivelog/hives',
-      '/admin/hivelog/inspections',
-      '/admin/hivelog/apiary/add',
-      '/admin/hivelog/apiary/' . $this->apiary->id(),
-      '/admin/hivelog/apiary/' . $this->apiary->id() . '/edit',
-      '/admin/hivelog/apiary/' . $this->apiary->id() . '/delete',
-      '/admin/hivelog/apiary/' . $this->apiary->id() . '/hive/add',
-      '/admin/hivelog/hive/' . $this->hive->id(),
-      '/admin/hivelog/hive/' . $this->hive->id() . '/edit',
-      '/admin/hivelog/hive/' . $this->hive->id() . '/delete',
-      '/admin/hivelog/hive/' . $this->hive->id() . '/inspection/add',
-      '/admin/hivelog/inspection/' . $this->inspection->id(),
-      '/admin/hivelog/inspection/' . $this->inspection->id() . '/edit',
-      '/admin/hivelog/inspection/' . $this->inspection->id() . '/delete',
+      '/hivelog',
+      '/hivelog/hives',
+      '/hivelog/inspections',
+      '/hivelog/apiary/add',
+      '/hivelog/apiary/' . $this->apiary->id(),
+      '/hivelog/apiary/' . $this->apiary->id() . '/edit',
+      '/hivelog/apiary/' . $this->apiary->id() . '/delete',
+      '/hivelog/apiary/' . $this->apiary->id() . '/hive/add',
+      '/hivelog/hive/' . $this->hive->id(),
+      '/hivelog/hive/' . $this->hive->id() . '/edit',
+      '/hivelog/hive/' . $this->hive->id() . '/delete',
+      '/hivelog/hive/' . $this->hive->id() . '/inspection/add',
+      '/hivelog/inspection/' . $this->inspection->id(),
+      '/hivelog/inspection/' . $this->inspection->id() . '/edit',
+      '/hivelog/inspection/' . $this->inspection->id() . '/delete',
     ];
 
     foreach ($paths as $path) {
@@ -109,35 +109,35 @@ class PermissionMatrixTest extends BrowserTestBase {
     $this->drupalLogin($viewer);
 
     // View is allowed on collections and canonicals.
-    $this->drupalGet('/admin/hivelog');
+    $this->drupalGet('/hivelog');
     $this->assertSession()->statusCodeEquals(200);
-    $this->drupalGet('/admin/hivelog/apiary/' . $this->apiary->id());
+    $this->drupalGet('/hivelog/apiary/' . $this->apiary->id());
     $this->assertSession()->statusCodeEquals(200);
-    $this->drupalGet('/admin/hivelog/hive/' . $this->hive->id());
+    $this->drupalGet('/hivelog/hive/' . $this->hive->id());
     $this->assertSession()->statusCodeEquals(200);
-    $this->drupalGet('/admin/hivelog/inspection/' . $this->inspection->id());
+    $this->drupalGet('/hivelog/inspection/' . $this->inspection->id());
     $this->assertSession()->statusCodeEquals(200);
 
     // Add/edit/delete routes are denied.
     foreach ([
-      '/admin/hivelog/apiary/add',
-      '/admin/hivelog/apiary/' . $this->apiary->id() . '/edit',
-      '/admin/hivelog/apiary/' . $this->apiary->id() . '/delete',
-      '/admin/hivelog/apiary/' . $this->apiary->id() . '/hive/add',
-      '/admin/hivelog/hive/' . $this->hive->id() . '/edit',
-      '/admin/hivelog/hive/' . $this->hive->id() . '/delete',
-      '/admin/hivelog/hive/' . $this->hive->id() . '/inspection/add',
-      '/admin/hivelog/inspection/' . $this->inspection->id() . '/edit',
-      '/admin/hivelog/inspection/' . $this->inspection->id() . '/delete',
+      '/hivelog/apiary/add',
+      '/hivelog/apiary/' . $this->apiary->id() . '/edit',
+      '/hivelog/apiary/' . $this->apiary->id() . '/delete',
+      '/hivelog/apiary/' . $this->apiary->id() . '/hive/add',
+      '/hivelog/hive/' . $this->hive->id() . '/edit',
+      '/hivelog/hive/' . $this->hive->id() . '/delete',
+      '/hivelog/hive/' . $this->hive->id() . '/inspection/add',
+      '/hivelog/inspection/' . $this->inspection->id() . '/edit',
+      '/hivelog/inspection/' . $this->inspection->id() . '/delete',
     ] as $denied_path) {
       $this->drupalGet($denied_path);
       $this->assertSession()->statusCodeEquals(403);
     }
 
     // On canonical pages the Edit and Delete tabs must NOT be visible.
-    $this->drupalGet('/admin/hivelog/apiary/' . $this->apiary->id());
-    $this->assertSession()->linkByHrefNotExists('/admin/hivelog/apiary/' . $this->apiary->id() . '/edit');
-    $this->assertSession()->linkByHrefNotExists('/admin/hivelog/apiary/' . $this->apiary->id() . '/delete');
+    $this->drupalGet('/hivelog/apiary/' . $this->apiary->id());
+    $this->assertSession()->linkByHrefNotExists('/hivelog/apiary/' . $this->apiary->id() . '/edit');
+    $this->assertSession()->linkByHrefNotExists('/hivelog/apiary/' . $this->apiary->id() . '/delete');
   }
 
   /**
@@ -148,21 +148,21 @@ class PermissionMatrixTest extends BrowserTestBase {
     $this->drupalLogin($admin);
 
     $routes = [
-      '/admin/hivelog',
-      '/admin/hivelog/hives',
-      '/admin/hivelog/inspections',
-      '/admin/hivelog/apiary/add',
-      '/admin/hivelog/apiary/' . $this->apiary->id(),
-      '/admin/hivelog/apiary/' . $this->apiary->id() . '/edit',
-      '/admin/hivelog/apiary/' . $this->apiary->id() . '/delete',
-      '/admin/hivelog/apiary/' . $this->apiary->id() . '/hive/add',
-      '/admin/hivelog/hive/' . $this->hive->id(),
-      '/admin/hivelog/hive/' . $this->hive->id() . '/edit',
-      '/admin/hivelog/hive/' . $this->hive->id() . '/delete',
-      '/admin/hivelog/hive/' . $this->hive->id() . '/inspection/add',
-      '/admin/hivelog/inspection/' . $this->inspection->id(),
-      '/admin/hivelog/inspection/' . $this->inspection->id() . '/edit',
-      '/admin/hivelog/inspection/' . $this->inspection->id() . '/delete',
+      '/hivelog',
+      '/hivelog/hives',
+      '/hivelog/inspections',
+      '/hivelog/apiary/add',
+      '/hivelog/apiary/' . $this->apiary->id(),
+      '/hivelog/apiary/' . $this->apiary->id() . '/edit',
+      '/hivelog/apiary/' . $this->apiary->id() . '/delete',
+      '/hivelog/apiary/' . $this->apiary->id() . '/hive/add',
+      '/hivelog/hive/' . $this->hive->id(),
+      '/hivelog/hive/' . $this->hive->id() . '/edit',
+      '/hivelog/hive/' . $this->hive->id() . '/delete',
+      '/hivelog/hive/' . $this->hive->id() . '/inspection/add',
+      '/hivelog/inspection/' . $this->inspection->id(),
+      '/hivelog/inspection/' . $this->inspection->id() . '/edit',
+      '/hivelog/inspection/' . $this->inspection->id() . '/delete',
     ];
 
     foreach ($routes as $path) {
@@ -171,9 +171,9 @@ class PermissionMatrixTest extends BrowserTestBase {
     }
 
     // Canonical apiary page exposes Edit and Delete tabs for admins.
-    $this->drupalGet('/admin/hivelog/apiary/' . $this->apiary->id());
-    $this->assertSession()->linkByHrefExists('/admin/hivelog/apiary/' . $this->apiary->id() . '/edit');
-    $this->assertSession()->linkByHrefExists('/admin/hivelog/apiary/' . $this->apiary->id() . '/delete');
+    $this->drupalGet('/hivelog/apiary/' . $this->apiary->id());
+    $this->assertSession()->linkByHrefExists('/hivelog/apiary/' . $this->apiary->id() . '/edit');
+    $this->assertSession()->linkByHrefExists('/hivelog/apiary/' . $this->apiary->id() . '/delete');
   }
 
   /**
@@ -186,17 +186,17 @@ class PermissionMatrixTest extends BrowserTestBase {
     ]);
     $this->drupalLogin($editor);
 
-    $this->drupalGet('/admin/hivelog/hive/' . $this->hive->id());
+    $this->drupalGet('/hivelog/hive/' . $this->hive->id());
     $this->assertSession()->statusCodeEquals(200);
 
     // Edit tab is visible; Delete tab is not.
-    $this->assertSession()->linkByHrefExists('/admin/hivelog/hive/' . $this->hive->id() . '/edit');
-    $this->assertSession()->linkByHrefNotExists('/admin/hivelog/hive/' . $this->hive->id() . '/delete');
+    $this->assertSession()->linkByHrefExists('/hivelog/hive/' . $this->hive->id() . '/edit');
+    $this->assertSession()->linkByHrefNotExists('/hivelog/hive/' . $this->hive->id() . '/delete');
 
-    $this->drupalGet('/admin/hivelog/hive/' . $this->hive->id() . '/edit');
+    $this->drupalGet('/hivelog/hive/' . $this->hive->id() . '/edit');
     $this->assertSession()->statusCodeEquals(200);
 
-    $this->drupalGet('/admin/hivelog/hive/' . $this->hive->id() . '/delete');
+    $this->drupalGet('/hivelog/hive/' . $this->hive->id() . '/delete');
     $this->assertSession()->statusCodeEquals(403);
   }
 

--- a/tests/src/Functional/PermissionMatrixTest.php
+++ b/tests/src/Functional/PermissionMatrixTest.php
@@ -102,9 +102,9 @@ class PermissionMatrixTest extends BrowserTestBase {
    */
   public function testViewOnlyPermissions(): void {
     $viewer = $this->drupalCreateUser([
-      'view apiary',
-      'view hive',
-      'view hive inspection',
+      'view any apiary',
+      'view any hive',
+      'view any hive inspection',
     ]);
     $this->drupalLogin($viewer);
 
@@ -181,8 +181,8 @@ class PermissionMatrixTest extends BrowserTestBase {
    */
   public function testEditOnlyPermission(): void {
     $editor = $this->drupalCreateUser([
-      'view hive',
-      'edit hive',
+      'view any hive',
+      'edit any hive',
     ]);
     $this->drupalLogin($editor);
 

--- a/tests/src/Kernel/ApiaryScopedAccessTest.php
+++ b/tests/src/Kernel/ApiaryScopedAccessTest.php
@@ -1,0 +1,485 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\hivelog\Kernel;
+
+use Drupal\hivelog\Entity\Apiary;
+use Drupal\hivelog\Entity\Hive;
+use Drupal\hivelog\Entity\HiveInspection;
+use Drupal\hivelog\Entity\Queen;
+use Drupal\hivelog\Entity\QueenObservation;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\Role;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests apiary-scoped access control for all hivelog entity types.
+ *
+ * Verifies that access to apiaries, hives, inspections, queens and
+ * queen observations is gated by apiary membership (owner + beekeepers)
+ * and the apiary's visibility setting (public / private).
+ */
+#[Group('hivelog')]
+#[RunTestsInSeparateProcesses]
+class ApiaryScopedAccessTest extends KernelTestBase {
+
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'datetime',
+    'options',
+    'file',
+    'image',
+    'geofield',
+    'hivelog',
+  ];
+
+  protected User $owner;
+  protected User $beekeeper;
+  protected User $outsider;
+  protected Apiary $apiary;
+  protected Hive $hive;
+  protected HiveInspection $inspection;
+  protected Queen $queen;
+  protected QueenObservation $observation;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('apiary');
+    $this->installEntitySchema('hive');
+    $this->installEntitySchema('hive_inspection');
+    $this->installEntitySchema('queen');
+    $this->installEntitySchema('queen_observation');
+    $this->installSchema('file', ['file_usage']);
+
+    // Create a role with all "own" permissions (apiary-member scoped).
+    $role = Role::create([
+      'id' => 'beekeeper',
+      'label' => 'Beekeeper',
+    ]);
+    $role->grantPermission('view own apiary');
+    $role->grantPermission('edit own apiary');
+    $role->grantPermission('delete own apiary');
+    $role->grantPermission('view own hive');
+    $role->grantPermission('edit own hive');
+    $role->grantPermission('delete own hive');
+    $role->grantPermission('view own hive inspection');
+    $role->grantPermission('edit own hive inspection');
+    $role->grantPermission('delete own hive inspection');
+    $role->grantPermission('view own queen');
+    $role->grantPermission('edit own queen');
+    $role->grantPermission('delete own queen');
+    $role->grantPermission('view own queen observation');
+    $role->grantPermission('edit own queen observation');
+    $role->grantPermission('delete own queen observation');
+    $role->grantPermission('add hive');
+    $role->grantPermission('add hive inspection');
+    $role->grantPermission('add queen');
+    $role->grantPermission('add queen observation');
+    $role->save();
+
+    $this->owner = User::create(['name' => 'owner', 'mail' => 'owner@example.com']);
+    $this->owner->addRole('beekeeper');
+    $this->owner->save();
+
+    $this->beekeeper = User::create(['name' => 'beekeeper', 'mail' => 'beekeeper@example.com']);
+    $this->beekeeper->addRole('beekeeper');
+    $this->beekeeper->save();
+
+    $this->outsider = User::create(['name' => 'outsider', 'mail' => 'outsider@example.com']);
+    $this->outsider->addRole('beekeeper');
+    $this->outsider->save();
+
+    // Create a private apiary owned by $owner with $beekeeper as a member.
+    $this->apiary = Apiary::create([
+      'name' => 'Test Apiary',
+      'uid' => $this->owner->id(),
+      'visibility' => 'private',
+      'beekeepers' => [$this->beekeeper->id()],
+    ]);
+    $this->apiary->save();
+
+    $this->hive = Hive::create([
+      'name' => 'Test Hive',
+      'apiary' => $this->apiary->id(),
+      'status' => 'active',
+      'uid' => $this->owner->id(),
+    ]);
+    $this->hive->save();
+
+    $this->inspection = HiveInspection::create([
+      'hive' => $this->hive->id(),
+      'inspection_date' => '2025-06-15',
+      'uid' => $this->beekeeper->id(),
+    ]);
+    $this->inspection->save();
+
+    $this->queen = Queen::create([
+      'name' => 'Q-test',
+      'hive' => $this->hive->id(),
+      'queen_year' => 2025,
+      'status' => 'active',
+      'uid' => $this->owner->id(),
+    ]);
+    $this->queen->save();
+
+    $this->observation = QueenObservation::create([
+      'queen' => $this->queen->id(),
+      'observation_date' => '2025-06-20',
+      'health' => 'good',
+      'uid' => $this->beekeeper->id(),
+    ]);
+    $this->observation->save();
+  }
+
+  // -----------------------------------------------------------------------
+  // Apiary::isApiaryMember()
+  // -----------------------------------------------------------------------
+
+  public function testIsApiaryMemberOwner(): void {
+    $this->assertTrue($this->apiary->isApiaryMember($this->owner));
+  }
+
+  public function testIsApiaryMemberBeekeeper(): void {
+    $this->assertTrue($this->apiary->isApiaryMember($this->beekeeper));
+  }
+
+  public function testIsApiaryMemberOutsider(): void {
+    $this->assertFalse($this->apiary->isApiaryMember($this->outsider));
+  }
+
+  public function testIsPublicDefault(): void {
+    $this->assertFalse($this->apiary->isPublic());
+  }
+
+  // -----------------------------------------------------------------------
+  // Private apiary: owner access
+  // -----------------------------------------------------------------------
+
+  public function testOwnerCanViewPrivateApiary(): void {
+    $this->assertTrue($this->apiary->access('view', $this->owner));
+  }
+
+  public function testOwnerCanEditPrivateApiary(): void {
+    $this->assertTrue($this->apiary->access('update', $this->owner));
+  }
+
+  public function testOwnerCanDeletePrivateApiary(): void {
+    $this->assertTrue($this->apiary->access('delete', $this->owner));
+  }
+
+  public function testOwnerCanViewHive(): void {
+    $this->assertTrue($this->hive->access('view', $this->owner));
+  }
+
+  public function testOwnerCanEditHive(): void {
+    $this->assertTrue($this->hive->access('update', $this->owner));
+  }
+
+  public function testOwnerCanDeleteHive(): void {
+    $this->assertTrue($this->hive->access('delete', $this->owner));
+  }
+
+  public function testOwnerCanViewInspection(): void {
+    $this->assertTrue($this->inspection->access('view', $this->owner));
+  }
+
+  public function testOwnerCanEditInspection(): void {
+    $this->assertTrue($this->inspection->access('update', $this->owner));
+  }
+
+  public function testOwnerCanDeleteInspection(): void {
+    $this->assertTrue($this->inspection->access('delete', $this->owner));
+  }
+
+  // -----------------------------------------------------------------------
+  // Private apiary: beekeeper access
+  // -----------------------------------------------------------------------
+
+  public function testBeekeeperCanViewPrivateApiary(): void {
+    $this->assertTrue($this->apiary->access('view', $this->beekeeper));
+  }
+
+  public function testBeekeeperCannotEditApiary(): void {
+    $this->assertFalse($this->apiary->access('update', $this->beekeeper));
+  }
+
+  public function testBeekeeperCannotDeleteApiary(): void {
+    $this->assertFalse($this->apiary->access('delete', $this->beekeeper));
+  }
+
+  public function testBeekeeperCanViewHive(): void {
+    $this->assertTrue($this->hive->access('view', $this->beekeeper));
+  }
+
+  public function testBeekeeperCanEditHive(): void {
+    $this->assertTrue($this->hive->access('update', $this->beekeeper));
+  }
+
+  public function testBeekeeperCannotDeleteHive(): void {
+    // Only apiary owner can delete hives.
+    $this->assertFalse($this->hive->access('delete', $this->beekeeper));
+  }
+
+  public function testBeekeeperCanViewInspection(): void {
+    $this->assertTrue($this->inspection->access('view', $this->beekeeper));
+  }
+
+  public function testBeekeeperCanEditInspection(): void {
+    $this->assertTrue($this->inspection->access('update', $this->beekeeper));
+  }
+
+  public function testBeekeeperCanDeleteOwnInspection(): void {
+    // Beekeeper created this inspection, so they can delete it.
+    $this->assertTrue($this->inspection->access('delete', $this->beekeeper));
+  }
+
+  public function testBeekeeperCannotDeleteOthersInspection(): void {
+    // Create an inspection owned by the apiary owner.
+    $owner_inspection = HiveInspection::create([
+      'hive' => $this->hive->id(),
+      'inspection_date' => '2025-07-01',
+      'uid' => $this->owner->id(),
+    ]);
+    $owner_inspection->save();
+    // Beekeeper is a member but did not create this one.
+    $this->assertFalse($owner_inspection->access('delete', $this->beekeeper));
+  }
+
+  // -----------------------------------------------------------------------
+  // Private apiary: outsider access (denied)
+  // -----------------------------------------------------------------------
+
+  public function testOutsiderCannotViewPrivateApiary(): void {
+    $this->assertFalse($this->apiary->access('view', $this->outsider));
+  }
+
+  public function testOutsiderCannotViewPrivateHive(): void {
+    $this->assertFalse($this->hive->access('view', $this->outsider));
+  }
+
+  public function testOutsiderCannotEditPrivateHive(): void {
+    $this->assertFalse($this->hive->access('update', $this->outsider));
+  }
+
+  public function testOutsiderCannotViewPrivateInspection(): void {
+    $this->assertFalse($this->inspection->access('view', $this->outsider));
+  }
+
+  // -----------------------------------------------------------------------
+  // Public apiary: outsider can view but not edit
+  // -----------------------------------------------------------------------
+
+  public function testOutsiderCanViewPublicApiary(): void {
+    $this->apiary->set('visibility', 'public');
+    $this->apiary->save();
+    $this->assertTrue($this->apiary->access('view', $this->outsider));
+  }
+
+  public function testOutsiderCanViewPublicHive(): void {
+    $this->apiary->set('visibility', 'public');
+    $this->apiary->save();
+    $this->assertTrue($this->hive->access('view', $this->outsider));
+  }
+
+  public function testOutsiderCannotEditPublicHive(): void {
+    $this->apiary->set('visibility', 'public');
+    $this->apiary->save();
+    $this->assertFalse($this->hive->access('update', $this->outsider));
+  }
+
+  public function testOutsiderCanViewPublicInspection(): void {
+    $this->apiary->set('visibility', 'public');
+    $this->apiary->save();
+    $this->assertTrue($this->inspection->access('view', $this->outsider));
+  }
+
+  public function testOutsiderCannotEditPublicInspection(): void {
+    $this->apiary->set('visibility', 'public');
+    $this->apiary->save();
+    $this->assertFalse($this->inspection->access('update', $this->outsider));
+  }
+
+  // -----------------------------------------------------------------------
+  // Queen and observation access follows apiary scope
+  // -----------------------------------------------------------------------
+
+  public function testBeekeeperCanViewQueen(): void {
+    $this->assertTrue($this->queen->access('view', $this->beekeeper));
+  }
+
+  public function testBeekeeperCanEditQueen(): void {
+    $this->assertTrue($this->queen->access('update', $this->beekeeper));
+  }
+
+  public function testOutsiderCannotViewPrivateQueen(): void {
+    $this->assertFalse($this->queen->access('view', $this->outsider));
+  }
+
+  public function testBeekeeperCanViewObservation(): void {
+    $this->assertTrue($this->observation->access('view', $this->beekeeper));
+  }
+
+  public function testBeekeeperCanEditObservation(): void {
+    $this->assertTrue($this->observation->access('update', $this->beekeeper));
+  }
+
+  public function testBeekeeperCanDeleteOwnObservation(): void {
+    $this->assertTrue($this->observation->access('delete', $this->beekeeper));
+  }
+
+  public function testOutsiderCannotViewPrivateObservation(): void {
+    $this->assertFalse($this->observation->access('view', $this->outsider));
+  }
+
+  // -----------------------------------------------------------------------
+  // Site-wide "any" permissions bypass apiary membership
+  // -----------------------------------------------------------------------
+
+  public function testAnyPermissionBypassesMembership(): void {
+    $any_role = Role::create(['id' => 'site_viewer', 'label' => 'Site viewer']);
+    $any_role->grantPermission('view any hive');
+    $any_role->save();
+
+    $viewer = User::create(['name' => 'site-viewer', 'mail' => 'viewer@example.com']);
+    $viewer->addRole('site_viewer');
+    $viewer->save();
+
+    $this->assertTrue($this->hive->access('view', $viewer));
+  }
+
+  // -----------------------------------------------------------------------
+  // Cross-user scenario: userB editing userA's entities.
+  //
+  // UserA (owner) creates an apiary, hive, and inspection. UserB has the
+  // same role/permissions but is NOT an apiary member. Verify userB
+  // cannot view or edit anything. Then add userB as a beekeeper and
+  // verify they gain view + edit access to child entities but NOT to the
+  // apiary itself.
+  // -----------------------------------------------------------------------
+
+  public function testCrossUserEditScenario(): void {
+    // Setup: userA creates everything, userB is a stranger.
+    $userA = User::create(['name' => 'userA', 'mail' => 'a@example.com']);
+    $userA->addRole('beekeeper');
+    $userA->save();
+
+    $userB = User::create(['name' => 'userB', 'mail' => 'b@example.com']);
+    $userB->addRole('beekeeper');
+    $userB->save();
+
+    $apiaryA = Apiary::create([
+      'name' => 'UserA Apiary',
+      'uid' => $userA->id(),
+      'visibility' => 'private',
+    ]);
+    $apiaryA->save();
+
+    $hiveA = Hive::create([
+      'name' => 'UserA Hive',
+      'apiary' => $apiaryA->id(),
+      'status' => 'active',
+      'uid' => $userA->id(),
+    ]);
+    $hiveA->save();
+
+    $inspectionA = HiveInspection::create([
+      'hive' => $hiveA->id(),
+      'inspection_date' => '2025-08-01',
+      'uid' => $userA->id(),
+    ]);
+    $inspectionA->save();
+
+    $queenA = Queen::create([
+      'name' => 'Q-userA',
+      'hive' => $hiveA->id(),
+      'queen_year' => 2025,
+      'status' => 'active',
+      'uid' => $userA->id(),
+    ]);
+    $queenA->save();
+
+    $observationA = QueenObservation::create([
+      'queen' => $queenA->id(),
+      'observation_date' => '2025-08-05',
+      'health' => 'good',
+      'uid' => $userA->id(),
+    ]);
+    $observationA->save();
+
+    // --- Phase 1: userB is NOT a member → all access denied. ---
+    $this->assertFalse($apiaryA->access('view', $userB), 'Non-member userB cannot view private apiary.');
+    $this->assertFalse($apiaryA->access('update', $userB), 'Non-member userB cannot edit apiary.');
+    $this->assertFalse($hiveA->access('view', $userB), 'Non-member userB cannot view hive.');
+    $this->assertFalse($hiveA->access('update', $userB), 'Non-member userB cannot edit hive.');
+    $this->assertFalse($inspectionA->access('view', $userB), 'Non-member userB cannot view inspection.');
+    $this->assertFalse($inspectionA->access('update', $userB), 'Non-member userB cannot edit inspection.');
+    $this->assertFalse($queenA->access('view', $userB), 'Non-member userB cannot view queen.');
+    $this->assertFalse($queenA->access('update', $userB), 'Non-member userB cannot edit queen.');
+    $this->assertFalse($observationA->access('view', $userB), 'Non-member userB cannot view observation.');
+    $this->assertFalse($observationA->access('update', $userB), 'Non-member userB cannot edit observation.');
+
+    // --- Phase 2: add userB as a beekeeper on the apiary. ---
+    $apiaryA->set('beekeepers', [$userB->id()]);
+    $apiaryA->save();
+
+    // Reset entity storage and access static caches so Phase 1 results
+    // are not reused and entity references resolve the updated apiary.
+    $etm = \Drupal::entityTypeManager();
+    foreach (['apiary', 'hive', 'hive_inspection', 'queen', 'queen_observation'] as $type) {
+      $etm->getStorage($type)->resetCache();
+      $etm->getAccessControlHandler($type)->resetCache();
+    }
+
+    // Reload entities to ensure fresh access checks.
+    $apiaryA = Apiary::load($apiaryA->id());
+    $hiveA = Hive::load($hiveA->id());
+    $inspectionA = HiveInspection::load($inspectionA->id());
+    $queenA = Queen::load($queenA->id());
+    $observationA = QueenObservation::load($observationA->id());
+
+    // userB can now VIEW all entities in the apiary.
+    $this->assertTrue($apiaryA->access('view', $userB), 'Beekeeper userB can view apiary.');
+    $this->assertTrue($hiveA->access('view', $userB), 'Beekeeper userB can view hive.');
+    $this->assertTrue($inspectionA->access('view', $userB), 'Beekeeper userB can view inspection.');
+    $this->assertTrue($queenA->access('view', $userB), 'Beekeeper userB can view queen.');
+    $this->assertTrue($observationA->access('view', $userB), 'Beekeeper userB can view observation.');
+
+    // userB can EDIT hives, inspections, queens, and observations.
+    $this->assertTrue($hiveA->access('update', $userB), 'Beekeeper userB can edit hive created by userA.');
+    $this->assertTrue($inspectionA->access('update', $userB), 'Beekeeper userB can edit inspection created by userA.');
+    $this->assertTrue($queenA->access('update', $userB), 'Beekeeper userB can edit queen created by userA.');
+    $this->assertTrue($observationA->access('update', $userB), 'Beekeeper userB can edit observation created by userA.');
+
+    // userB CANNOT edit or delete the apiary itself (owner-only).
+    $this->assertFalse($apiaryA->access('update', $userB), 'Beekeeper userB cannot edit apiary (owner-only).');
+    $this->assertFalse($apiaryA->access('delete', $userB), 'Beekeeper userB cannot delete apiary (owner-only).');
+
+    // userB CANNOT delete hives or queens (owner-only).
+    $this->assertFalse($hiveA->access('delete', $userB), 'Beekeeper userB cannot delete hive (owner-only).');
+    $this->assertFalse($queenA->access('delete', $userB), 'Beekeeper userB cannot delete queen (owner-only).');
+
+    // userB CANNOT delete inspections/observations created by userA.
+    $this->assertFalse($inspectionA->access('delete', $userB), 'Beekeeper userB cannot delete inspection created by userA.');
+    $this->assertFalse($observationA->access('delete', $userB), 'Beekeeper userB cannot delete observation created by userA.');
+
+    // --- Phase 3: userB creates their own inspection → can delete it. ---
+    $inspectionB = HiveInspection::create([
+      'hive' => $hiveA->id(),
+      'inspection_date' => '2025-08-10',
+      'uid' => $userB->id(),
+    ]);
+    $inspectionB->save();
+    $this->assertTrue($inspectionB->access('delete', $userB), 'Beekeeper userB can delete their own inspection.');
+
+    // userA (owner) can also delete userB's inspection.
+    $this->assertTrue($inspectionB->access('delete', $userA), 'Apiary owner userA can delete inspection created by userB.');
+  }
+
+}

--- a/tests/src/Kernel/ApiaryTest.php
+++ b/tests/src/Kernel/ApiaryTest.php
@@ -195,13 +195,13 @@ class ApiaryTest extends KernelTestBase {
       'id' => 'apiary_view_only',
       'label' => 'Apiary view only',
     ]);
-    $role->grantPermission('view apiary');
+    $role->grantPermission('view any apiary');
     $role->save();
     $authenticated = Role::load('authenticated');
     if ($authenticated) {
-      $authenticated->revokePermission('view hive');
-      $authenticated->revokePermission('edit hive');
-      $authenticated->revokePermission('delete hive');
+      $authenticated->revokePermission('view any hive');
+      $authenticated->revokePermission('edit any hive');
+      $authenticated->revokePermission('delete any hive');
       $authenticated->save();
     }
     $viewer->addRole('apiary_view_only');
@@ -235,10 +235,10 @@ class ApiaryTest extends KernelTestBase {
     $this->assertEquals('/admin/hivelog/inspections', $inspection_route->getPath());
     $this->assertEquals('/admin/hivelog/queens', $queen_route->getPath());
     $this->assertEquals('/admin/hivelog/queen-observations', $observation_route->getPath());
-    $this->assertEquals('view hive+administer hivelog', $hive_route->getRequirement('_permission'));
-    $this->assertEquals('view hive inspection+administer hivelog', $inspection_route->getRequirement('_permission'));
-    $this->assertEquals('view queen+administer hivelog', $queen_route->getRequirement('_permission'));
-    $this->assertEquals('view queen observation+administer hivelog', $observation_route->getRequirement('_permission'));
+    $this->assertEquals('view own hive+view any hive+administer hivelog', $hive_route->getRequirement('_permission'));
+    $this->assertEquals('view own hive inspection+view any hive inspection+administer hivelog', $inspection_route->getRequirement('_permission'));
+    $this->assertEquals('view own queen+view any queen+administer hivelog', $queen_route->getRequirement('_permission'));
+    $this->assertEquals('view own queen observation+view any queen observation+administer hivelog', $observation_route->getRequirement('_permission'));
 
     $menu_links = \Drupal::service('plugin.manager.menu.link')->getDefinitions();
     $this->assertArrayHasKey('hivelog.hives', $menu_links);

--- a/tests/src/Kernel/ApiaryTest.php
+++ b/tests/src/Kernel/ApiaryTest.php
@@ -231,10 +231,10 @@ class ApiaryTest extends KernelTestBase {
     $queen_route = $route_provider->getRouteByName('entity.queen.collection');
     $observation_route = $route_provider->getRouteByName('entity.queen_observation.collection');
 
-    $this->assertEquals('/admin/hivelog/hives', $hive_route->getPath());
-    $this->assertEquals('/admin/hivelog/inspections', $inspection_route->getPath());
-    $this->assertEquals('/admin/hivelog/queens', $queen_route->getPath());
-    $this->assertEquals('/admin/hivelog/queen-observations', $observation_route->getPath());
+    $this->assertEquals('/hivelog/hives', $hive_route->getPath());
+    $this->assertEquals('/hivelog/inspections', $inspection_route->getPath());
+    $this->assertEquals('/hivelog/queens', $queen_route->getPath());
+    $this->assertEquals('/hivelog/queen-observations', $observation_route->getPath());
     $this->assertEquals('view own hive+view any hive+administer hivelog', $hive_route->getRequirement('_permission'));
     $this->assertEquals('view own hive inspection+view any hive inspection+administer hivelog', $inspection_route->getRequirement('_permission'));
     $this->assertEquals('view own queen+view any queen+administer hivelog', $queen_route->getRequirement('_permission'));

--- a/tests/src/Kernel/ControllerCacheMetadataTest.php
+++ b/tests/src/Kernel/ControllerCacheMetadataTest.php
@@ -64,7 +64,7 @@ class ControllerCacheMetadataTest extends KernelTestBase {
 
     // FormBuilder requires a session on the current request; ensure one is
     // present since the controllers build forms.
-    $request = Request::create('/admin/hivelog/apiary/1', 'GET');
+    $request = Request::create('/hivelog/apiary/1', 'GET');
     $request->setSession(new Session(new MockArraySessionStorage()));
     \Drupal::service('request_stack')->push($request);
   }

--- a/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
+++ b/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
@@ -66,7 +66,7 @@ class EmbeddedTableFilterPaginationTest extends KernelTestBase {
    * Pushes a request with the given query parameters onto the request stack.
    */
   protected function pushRequestWithQuery(array $query): void {
-    $request = Request::create('/admin/hivelog/apiary/1', 'GET', $query);
+    $request = Request::create('/hivelog/apiary/1', 'GET', $query);
     // FormBuilder requires a session on the current request.
     $request->setSession(new Session(new MockArraySessionStorage()));
     \Drupal::service('request_stack')->push($request);

--- a/tests/src/Kernel/HiveInspectionTest.php
+++ b/tests/src/Kernel/HiveInspectionTest.php
@@ -464,9 +464,9 @@ class HiveInspectionTest extends KernelTestBase {
       'id' => 'inspection_editor',
       'label' => 'Inspection editor',
     ]);
-    $role->grantPermission('view hive inspection');
-    $role->grantPermission('edit hive inspection');
-    $role->grantPermission('delete hive inspection');
+    $role->grantPermission('view any hive inspection');
+    $role->grantPermission('edit any hive inspection');
+    $role->grantPermission('delete any hive inspection');
     $role->save();
     $this->user->addRole('inspection_editor');
     $this->user->save();

--- a/tests/src/Kernel/QueenObservationTest.php
+++ b/tests/src/Kernel/QueenObservationTest.php
@@ -179,9 +179,9 @@ class QueenObservationTest extends KernelTestBase {
       'id' => 'observation_editor',
       'label' => 'Observation editor',
     ]);
-    $role->grantPermission('view queen observation');
-    $role->grantPermission('edit queen observation');
-    $role->grantPermission('delete queen observation');
+    $role->grantPermission('view any queen observation');
+    $role->grantPermission('edit any queen observation');
+    $role->grantPermission('delete any queen observation');
     $role->save();
     $user->addRole('observation_editor');
     $user->save();

--- a/tests/src/Kernel/QueenTest.php
+++ b/tests/src/Kernel/QueenTest.php
@@ -292,9 +292,9 @@ class QueenTest extends KernelTestBase {
       'id' => 'queen_editor',
       'label' => 'Queen editor',
     ]);
-    $role->grantPermission('view queen');
-    $role->grantPermission('edit queen');
-    $role->grantPermission('delete queen');
+    $role->grantPermission('view any queen');
+    $role->grantPermission('edit any queen');
+    $role->grantPermission('delete any queen');
     $role->save();
     $user->addRole('queen_editor');
     $user->save();

--- a/tests/src/Unit/Breadcrumb/HivelogBreadcrumbBuilderTest.php
+++ b/tests/src/Unit/Breadcrumb/HivelogBreadcrumbBuilderTest.php
@@ -209,13 +209,11 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(3, $links);
+    $this->assertCount(2, $links);
     $this->assertEquals('Home', (string) $links[0]->getText());
     $this->assertEquals('<front>', $links[0]->getUrl()->getRouteName());
-    $this->assertEquals('Structure', (string) $links[1]->getText());
-    $this->assertEquals('system.admin_structure', $links[1]->getUrl()->getRouteName());
-    $this->assertEquals('HiveLog', (string) $links[2]->getText());
-    $this->assertEquals('entity.apiary.collection', $links[2]->getUrl()->getRouteName());
+    $this->assertEquals('HiveLog', (string) $links[1]->getText());
+    $this->assertEquals('entity.apiary.collection', $links[1]->getUrl()->getRouteName());
     $this->assertContains('route', $breadcrumb->getCacheContexts());
   }
 
@@ -235,7 +233,7 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(3, $links);
+    $this->assertCount(2, $links);
     $this->assertContains('apiary:1', $breadcrumb->getCacheTags());
   }
 
@@ -254,10 +252,10 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(4, $links);
-    $this->assertEquals('Mountain Apiary', (string) $links[3]->getText());
-    $this->assertEquals('entity.apiary.canonical', $links[3]->getUrl()->getRouteName());
-    $this->assertEquals(['apiary' => 2], $links[3]->getUrl()->getRouteParameters());
+    $this->assertCount(3, $links);
+    $this->assertEquals('Mountain Apiary', (string) $links[2]->getText());
+    $this->assertEquals('entity.apiary.canonical', $links[2]->getUrl()->getRouteName());
+    $this->assertEquals(['apiary' => 2], $links[2]->getUrl()->getRouteParameters());
     $this->assertContains('apiary:2', $breadcrumb->getCacheTags());
   }
 
@@ -278,9 +276,9 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(4, $links);
-    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
-    $this->assertEquals('entity.apiary.canonical', $links[3]->getUrl()->getRouteName());
+    $this->assertCount(3, $links);
+    $this->assertEquals('Home Apiary', (string) $links[2]->getText());
+    $this->assertEquals('entity.apiary.canonical', $links[2]->getUrl()->getRouteName());
     $this->assertContains('apiary:1', $breadcrumb->getCacheTags());
     $this->assertContains('hive:5', $breadcrumb->getCacheTags());
   }
@@ -301,11 +299,11 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(5, $links);
-    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
-    $this->assertEquals('Hive Alpha', (string) $links[4]->getText());
-    $this->assertEquals('entity.hive.canonical', $links[4]->getUrl()->getRouteName());
-    $this->assertEquals(['hive' => 5], $links[4]->getUrl()->getRouteParameters());
+    $this->assertCount(4, $links);
+    $this->assertEquals('Home Apiary', (string) $links[2]->getText());
+    $this->assertEquals('Hive Alpha', (string) $links[3]->getText());
+    $this->assertEquals('entity.hive.canonical', $links[3]->getUrl()->getRouteName());
+    $this->assertEquals(['hive' => 5], $links[3]->getUrl()->getRouteParameters());
   }
 
   /**
@@ -326,9 +324,9 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(5, $links);
-    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
-    $this->assertEquals('Hive Alpha', (string) $links[4]->getText());
+    $this->assertCount(4, $links);
+    $this->assertEquals('Home Apiary', (string) $links[2]->getText());
+    $this->assertEquals('Hive Alpha', (string) $links[3]->getText());
     $this->assertContains('hive_inspection:10', $breadcrumb->getCacheTags());
     $this->assertContains('hive:5', $breadcrumb->getCacheTags());
     $this->assertContains('apiary:1', $breadcrumb->getCacheTags());
@@ -352,12 +350,12 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(6, $links);
-    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
-    $this->assertEquals('Hive Alpha', (string) $links[4]->getText());
-    $this->assertEquals('Inspection on 2024-06-15', (string) $links[5]->getText());
-    $this->assertEquals('entity.hive_inspection.canonical', $links[5]->getUrl()->getRouteName());
-    $this->assertEquals(['hive_inspection' => 10], $links[5]->getUrl()->getRouteParameters());
+    $this->assertCount(5, $links);
+    $this->assertEquals('Home Apiary', (string) $links[2]->getText());
+    $this->assertEquals('Hive Alpha', (string) $links[3]->getText());
+    $this->assertEquals('Inspection on 2024-06-15', (string) $links[4]->getText());
+    $this->assertEquals('entity.hive_inspection.canonical', $links[4]->getUrl()->getRouteName());
+    $this->assertEquals(['hive_inspection' => 10], $links[4]->getUrl()->getRouteParameters());
   }
 
   /**
@@ -376,9 +374,9 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(4, $links);
-    $this->assertEquals('Garden Apiary', (string) $links[3]->getText());
-    $this->assertEquals('entity.apiary.canonical', $links[3]->getUrl()->getRouteName());
+    $this->assertCount(3, $links);
+    $this->assertEquals('Garden Apiary', (string) $links[2]->getText());
+    $this->assertEquals('entity.apiary.canonical', $links[2]->getUrl()->getRouteName());
   }
 
   /**
@@ -398,10 +396,10 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(5, $links);
-    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
-    $this->assertEquals('Hive Beta', (string) $links[4]->getText());
-    $this->assertEquals('entity.hive.canonical', $links[4]->getUrl()->getRouteName());
+    $this->assertCount(4, $links);
+    $this->assertEquals('Home Apiary', (string) $links[2]->getText());
+    $this->assertEquals('Hive Beta', (string) $links[3]->getText());
+    $this->assertEquals('entity.hive.canonical', $links[3]->getUrl()->getRouteName());
   }
 
   /**
@@ -423,9 +421,9 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(5, $links);
-    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
-    $this->assertEquals('Hive Alpha', (string) $links[4]->getText());
+    $this->assertCount(4, $links);
+    $this->assertEquals('Home Apiary', (string) $links[2]->getText());
+    $this->assertEquals('Hive Alpha', (string) $links[3]->getText());
     $this->assertContains('queen:20', $breadcrumb->getCacheTags());
     $this->assertContains('hive:5', $breadcrumb->getCacheTags());
     $this->assertContains('apiary:1', $breadcrumb->getCacheTags());
@@ -450,12 +448,12 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(6, $links);
-    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
-    $this->assertEquals('Hive Alpha', (string) $links[4]->getText());
-    $this->assertEquals('Q-2024-001', (string) $links[5]->getText());
-    $this->assertEquals('entity.queen.canonical', $links[5]->getUrl()->getRouteName());
-    $this->assertEquals(['queen' => 20], $links[5]->getUrl()->getRouteParameters());
+    $this->assertCount(5, $links);
+    $this->assertEquals('Home Apiary', (string) $links[2]->getText());
+    $this->assertEquals('Hive Alpha', (string) $links[3]->getText());
+    $this->assertEquals('Q-2024-001', (string) $links[4]->getText());
+    $this->assertEquals('entity.queen.canonical', $links[4]->getUrl()->getRouteName());
+    $this->assertEquals(['queen' => 20], $links[4]->getUrl()->getRouteParameters());
   }
 
   /**
@@ -480,10 +478,10 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(6, $links);
-    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
-    $this->assertEquals('Hive Alpha', (string) $links[4]->getText());
-    $this->assertEquals('Q-2024-001', (string) $links[5]->getText());
+    $this->assertCount(5, $links);
+    $this->assertEquals('Home Apiary', (string) $links[2]->getText());
+    $this->assertEquals('Hive Alpha', (string) $links[3]->getText());
+    $this->assertEquals('Q-2024-001', (string) $links[4]->getText());
     $this->assertContains('queen_observation:30', $breadcrumb->getCacheTags());
     $this->assertContains('queen:20', $breadcrumb->getCacheTags());
     $this->assertContains('hive:5', $breadcrumb->getCacheTags());
@@ -511,12 +509,12 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(7, $links);
-    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
-    $this->assertEquals('Hive Alpha', (string) $links[4]->getText());
-    $this->assertEquals('Q-2024-001', (string) $links[5]->getText());
-    $this->assertEquals('Observation A', (string) $links[6]->getText());
-    $this->assertEquals('entity.queen_observation.canonical', $links[6]->getUrl()->getRouteName());
+    $this->assertCount(6, $links);
+    $this->assertEquals('Home Apiary', (string) $links[2]->getText());
+    $this->assertEquals('Hive Alpha', (string) $links[3]->getText());
+    $this->assertEquals('Q-2024-001', (string) $links[4]->getText());
+    $this->assertEquals('Observation A', (string) $links[5]->getText());
+    $this->assertEquals('entity.queen_observation.canonical', $links[5]->getUrl()->getRouteName());
   }
 
   /**
@@ -539,11 +537,11 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(6, $links);
-    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
-    $this->assertEquals('Hive Alpha', (string) $links[4]->getText());
-    $this->assertEquals('Q-2024-001', (string) $links[5]->getText());
-    $this->assertEquals('entity.queen.canonical', $links[5]->getUrl()->getRouteName());
+    $this->assertCount(5, $links);
+    $this->assertEquals('Home Apiary', (string) $links[2]->getText());
+    $this->assertEquals('Hive Alpha', (string) $links[3]->getText());
+    $this->assertEquals('Q-2024-001', (string) $links[4]->getText());
+    $this->assertEquals('entity.queen.canonical', $links[4]->getUrl()->getRouteName());
   }
 
   /**
@@ -564,10 +562,10 @@ class HivelogBreadcrumbBuilderTest extends UnitTestCase {
     $breadcrumb = $this->builder->build($route_match);
     $links = $breadcrumb->getLinks();
 
-    $this->assertCount(5, $links);
-    $this->assertEquals('Home Apiary', (string) $links[3]->getText());
-    $this->assertEquals('Hive Gamma', (string) $links[4]->getText());
-    $this->assertEquals('entity.hive.canonical', $links[4]->getUrl()->getRouteName());
+    $this->assertCount(4, $links);
+    $this->assertEquals('Home Apiary', (string) $links[2]->getText());
+    $this->assertEquals('Hive Gamma', (string) $links[3]->getText());
+    $this->assertEquals('entity.hive.canonical', $links[3]->getUrl()->getRouteName());
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR implements a comprehensive access control overhaul for HiveLog, moving from a flat permission model to apiary-scoped, membership-based access control.

### Changes

**1. Ownership-based permissions (Closes #64)**
Split flat permissions (`view apiary`, `edit hive`, etc.) into `own`/`any` variants. `any` permissions are site-wide admin overrides; `own` permissions are scoped to apiary membership.

**2. Route relocation (Closes #65)**
Move all HiveLog routes from `/admin/hivelog/...` to `/hivelog/...` so non-admin users can access the module. Re-parent menu link from `system.admin_structure` to the main menu.

**3. Permission migration (update hook 10012)**
Migrate existing roles from old permission names to new `any` equivalents so existing access is preserved.

**4. Apiary-scoped access control (Closes #66)**
- Add `beekeepers` (multi-value user reference) and `visibility` (public/private) fields to Apiary.
- Redefine `own` permission semantics from "entity I created" to "entity in an apiary I'm a member of".
- Access to all child entities cascades through the parent apiary via `ApiaryAccessTrait`:
  - **Apiary owner**: full access to the apiary and all children.
  - **Approved beekeepers**: can view and edit hives, inspections, queens, observations; cannot edit/delete the apiary or delete hives/queens.
  - **Beekeepers**: can delete inspections/observations they personally created.
  - **Public apiaries**: viewable by any user with `view own *` permission.
  - **Private apiaries**: restricted to members only.

### Update hooks
- `hivelog_update_10012`: Migrate old permission names to own/any variants.
- `hivelog_update_10013`: Install `beekeepers` and `visibility` fields on Apiary.

### Tests
- 41 new kernel tests in `ApiaryScopedAccessTest` covering owner, beekeeper, outsider, public/private, and cross-user edit scenarios.
- All 176 tests pass (2352 assertions).

---
[Conversation](https://app.warp.dev/conversation/e99378bc-b6e3-4210-8675-90c8b4a7a1ca) | [Plan](https://app.warp.dev/drive/notebook/I8PZTON11vDXCZytAEg0MG)

Co-Authored-By: Oz <oz-agent@warp.dev>