### PR TITLE
Style hivelog tables: full-width, dividers, left-aligned headers, solid dropdown background

### DIFF
--- a/css/hivelog.tables.css
+++ b/css/hivelog.tables.css
@@ -28,6 +28,14 @@
   padding: 0.5rem 0.75rem;
 }
 
+/* Solid background for operations dropdown so underlying text is hidden. */
+.hivelog-table .dropbutton-wrapper .dropbutton-widget,
+.hivelog-inspection-table .dropbutton-wrapper .dropbutton-widget,
+.hivelog-queen-table .dropbutton-wrapper .dropbutton-widget,
+.hivelog-queen-observation-table .dropbutton-wrapper .dropbutton-widget {
+  background-color: #fff;
+}
+
 /* Header bottom border slightly heavier; left-align titles. */
 .hivelog-table thead th,
 .hivelog-inspection-table thead th,

--- a/css/hivelog.tables.css
+++ b/css/hivelog.tables.css
@@ -28,10 +28,11 @@
   padding: 0.5rem 0.75rem;
 }
 
-/* Header bottom border slightly heavier. */
+/* Header bottom border slightly heavier; left-align titles. */
 .hivelog-table thead th,
 .hivelog-inspection-table thead th,
 .hivelog-queen-table thead th,
 .hivelog-queen-observation-table thead th {
   border-bottom: 2px solid #ccc;
+  text-align: left;
 }

--- a/css/hivelog.tables.css
+++ b/css/hivelog.tables.css
@@ -1,0 +1,37 @@
+/**
+ * @file
+ * Table styling for HiveLog entity list tables.
+ *
+ * Ensures tables span the full available width and display horizontal
+ * dividing lines between rows for readability.
+ */
+
+/* Full-width tables. */
+.hivelog-table,
+.hivelog-inspection-table,
+.hivelog-queen-table,
+.hivelog-queen-observation-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+/* Horizontal dividers between rows. */
+.hivelog-table th,
+.hivelog-table td,
+.hivelog-inspection-table th,
+.hivelog-inspection-table td,
+.hivelog-queen-table th,
+.hivelog-queen-table td,
+.hivelog-queen-observation-table th,
+.hivelog-queen-observation-table td {
+  border-bottom: 1px solid #e0e0e0;
+  padding: 0.5rem 0.75rem;
+}
+
+/* Header bottom border slightly heavier. */
+.hivelog-table thead th,
+.hivelog-inspection-table thead th,
+.hivelog-queen-table thead th,
+.hivelog-queen-observation-table thead th {
+  border-bottom: 2px solid #ccc;
+}

--- a/hivelog.libraries.yml
+++ b/hivelog.libraries.yml
@@ -10,6 +10,12 @@ images:
     component:
       css/hivelog.images.css: {}
 
+tables:
+  version: 1.x
+  css:
+    component:
+      css/hivelog.tables.css: {}
+
 filter_form:
   version: 1.x
   css:

--- a/src/Controller/ApiaryController.php
+++ b/src/Controller/ApiaryController.php
@@ -161,6 +161,8 @@ class ApiaryController extends ControllerBase {
         ? $this->t('No hives match the current filters.')
         : $this->t('No hives have been added to this apiary yet.'),
       '#weight' => 12,
+      '#attributes' => ['class' => ['hivelog-table']],
+      '#attached' => ['library' => ['hivelog/tables']],
     ];
 
     $build['hives_pager'] = [

--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -208,6 +208,8 @@ class HiveController extends ControllerBase {
         ? $this->t('No inspections match the current filters.')
         : $this->t('No inspections have been recorded for this hive yet.'),
       '#weight' => 12,
+      '#attributes' => ['class' => ['hivelog-table']],
+      '#attached' => ['library' => ['hivelog/tables']],
     ];
 
     $build['inspections_pager'] = [
@@ -290,6 +292,8 @@ class HiveController extends ControllerBase {
       $section['details'] = [
         '#type' => 'table',
         '#header' => [$this->t('Field'), $this->t('Value')],
+        '#attributes' => ['class' => ['hivelog-table']],
+        '#attached' => ['library' => ['hivelog/tables']],
         '#rows' => [
           [$this->t('Queen ID'), $queen->toLink()->toString()],
           [$this->t('Colour'), $colour_label],

--- a/src/Controller/HiveInspectionController.php
+++ b/src/Controller/HiveInspectionController.php
@@ -255,6 +255,7 @@ class HiveInspectionController extends ControllerBase {
         '#attributes' => [
           'class' => ['hivelog-inspection-table'],
         ],
+        '#attached' => ['library' => ['hivelog/tables']],
       ],
     ];
   }

--- a/src/Controller/QueenController.php
+++ b/src/Controller/QueenController.php
@@ -187,6 +187,8 @@ class QueenController extends ControllerBase {
       '#rows' => $rows,
       '#empty' => $this->t('No observations have been recorded for this queen yet.'),
       '#weight' => 21,
+      '#attributes' => ['class' => ['hivelog-table']],
+      '#attached' => ['library' => ['hivelog/tables']],
     ];
 
     $build['observations_pager'] = [
@@ -280,6 +282,7 @@ class QueenController extends ControllerBase {
         '#attributes' => [
           'class' => ['hivelog-queen-table'],
         ],
+        '#attached' => ['library' => ['hivelog/tables']],
       ],
     ];
   }

--- a/src/Controller/QueenObservationController.php
+++ b/src/Controller/QueenObservationController.php
@@ -226,6 +226,7 @@ class QueenObservationController extends ControllerBase {
         '#attributes' => [
           'class' => ['hivelog-queen-observation-table'],
         ],
+        '#attached' => ['library' => ['hivelog/tables']],
       ],
     ];
   }


### PR DESCRIPTION
## Summary

Improves the visual presentation of all HiveLog tables (hive lists, inspection lists, observation lists, and detail section tables).

### Changes

- **Full-width tables**: All hivelog tables now span the full available width.
- **Horizontal dividers**: Row divider lines between all rows for readability, with a heavier border under the header.
- **Left-aligned headers**: Column titles are left-aligned instead of centered.
- **Solid dropdown background**: The operations dropdown widget (Edit/Delete) now has a white background so underlying text doesn't show through.

### Files changed

- `css/hivelog.tables.css` — new stylesheet with table rules
- `hivelog.libraries.yml` — registered `hivelog/tables` library
- 5 controllers — attached the library and added `hivelog-table` CSS class to all table render arrays

---
[Conversation](https://app.warp.dev/conversation/e99378bc-b6e3-4210-8675-90c8b4a7a1ca)

Co-Authored-By: Oz <oz-agent@warp.dev>