### PR TITLE
Apply table styling to apiaries list and theme action buttons

### DIFF
--- a/css/hivelog.buttons.css
+++ b/css/hivelog.buttons.css
@@ -1,0 +1,78 @@
+/**
+ * @file
+ * Button styling for HiveLog action buttons.
+ *
+ * Provides visible theming for Add, Edit, Delete, Filter, and Reset buttons
+ * so they are clearly identifiable as clickable actions regardless of the
+ * active admin theme.
+ */
+
+/* Base button styling within HiveLog contexts. */
+.hivelog-list-heading .button,
+.hivelog-filter-form__actions .button,
+.hivelog-inspection-actions .button,
+.hivelog-queen-actions .button,
+.hivelog-queen-observation-actions .button,
+.hivelog-entity-form .form-actions .button {
+  display: inline-block;
+  padding: 0.45em 1em;
+  border: 1px solid #8e929c;
+  border-radius: 4px;
+  background-color: #f3f4f6;
+  color: #222;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  text-decoration: none;
+  cursor: pointer;
+  margin-right: 0.5em;
+}
+
+.hivelog-list-heading .button:hover,
+.hivelog-filter-form__actions .button:hover,
+.hivelog-inspection-actions .button:hover,
+.hivelog-queen-actions .button:hover,
+.hivelog-queen-observation-actions .button:hover,
+.hivelog-entity-form .form-actions .button:hover {
+  background-color: #e5e7eb;
+  border-color: #6b7280;
+}
+
+/* Primary buttons (Add, Filter, Save). */
+.hivelog-list-heading .button--primary,
+.hivelog-filter-form__actions .button--primary,
+.hivelog-inspection-actions .button--primary,
+.hivelog-queen-actions .button--primary,
+.hivelog-queen-observation-actions .button--primary,
+.hivelog-entity-form .form-actions .button--primary {
+  background-color: #2563eb;
+  border-color: #1d4ed8;
+  color: #fff;
+}
+
+.hivelog-list-heading .button--primary:hover,
+.hivelog-filter-form__actions .button--primary:hover,
+.hivelog-inspection-actions .button--primary:hover,
+.hivelog-queen-actions .button--primary:hover,
+.hivelog-queen-observation-actions .button--primary:hover,
+.hivelog-entity-form .form-actions .button--primary:hover {
+  background-color: #1d4ed8;
+  border-color: #1e40af;
+}
+
+/* Danger buttons (Delete). */
+.hivelog-inspection-actions .button--danger,
+.hivelog-queen-actions .button--danger,
+.hivelog-queen-observation-actions .button--danger,
+.hivelog-entity-form .form-actions .button--danger {
+  background-color: #dc2626;
+  border-color: #b91c1c;
+  color: #fff;
+}
+
+.hivelog-inspection-actions .button--danger:hover,
+.hivelog-queen-actions .button--danger:hover,
+.hivelog-queen-observation-actions .button--danger:hover,
+.hivelog-entity-form .form-actions .button--danger:hover {
+  background-color: #b91c1c;
+  border-color: #991b1b;
+}

--- a/hivelog.libraries.yml
+++ b/hivelog.libraries.yml
@@ -10,14 +10,24 @@ images:
     component:
       css/hivelog.images.css: {}
 
+buttons:
+  version: 1.x
+  css:
+    component:
+      css/hivelog.buttons.css: {}
+
 tables:
   version: 1.x
   css:
     component:
       css/hivelog.tables.css: {}
+  dependencies:
+    - hivelog/buttons
 
 filter_form:
   version: 1.x
   css:
     component:
       css/hivelog.filter-form.css: {}
+  dependencies:
+    - hivelog/buttons

--- a/hivelog.module
+++ b/hivelog.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_entity_base_field_info().
@@ -40,4 +41,30 @@ function hivelog_entity_base_field_info(EntityTypeInterface $entity_type) {
     ->setDisplayConfigurable('view', TRUE);
 
   return $fields;
+}
+
+/**
+ * Implements hook_form_alter().
+ *
+ * Attaches the HiveLog button styling library to all HiveLog entity forms
+ * (add/edit) so that action buttons (Save, Delete) are visually themed.
+ */
+function hivelog_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  $hivelog_form_ids = [
+    'apiary_add_form',
+    'apiary_edit_form',
+    'hive_add_form',
+    'hive_edit_form',
+    'hive_inspection_add_form',
+    'hive_inspection_edit_form',
+    'queen_add_form',
+    'queen_edit_form',
+    'queen_observation_add_form',
+    'queen_observation_edit_form',
+  ];
+
+  if (in_array($form_id, $hivelog_form_ids, TRUE)) {
+    $form['#attributes']['class'][] = 'hivelog-entity-form';
+    $form['#attached']['library'][] = 'hivelog/buttons';
+  }
 }

--- a/src/ApiaryListBuilder.php
+++ b/src/ApiaryListBuilder.php
@@ -87,6 +87,10 @@ class ApiaryListBuilder extends EntityListBuilder {
   public function render() {
     $build = parent::render();
 
+    // Apply the shared table styling (full-width, solid dropdown background).
+    $build['table']['#attributes']['class'][] = 'hivelog-table';
+    $build['table']['#attached']['library'][] = 'hivelog/tables';
+
     /** @var \Drupal\user\UserInterface|null $current */
     $current = $this->userStorage->load($this->currentUser->id());
     $cbr = $this->extractCbr($current);


### PR DESCRIPTION
## Summary

Applies the table styling from PR #68 to the apiaries list on `/hivelog` and adds visible theming for action buttons across the module.

### Changes

- **Apiaries table styling**: Attached `hivelog/tables` library and `hivelog-table` CSS class to `ApiaryListBuilder::render()` so the `/hivelog` table gets full-width layout and a solid operations-dropdown background.
- **Button theming**: New `css/hivelog.buttons.css` stylesheet with visible styling for primary (Add, Filter, Save), default (Reset, Edit Queen), and danger (Delete) buttons.
- **Library wiring**: Registered `hivelog/buttons` as a dependency of `tables` and `filter_form` so it loads automatically on all HiveLog pages.
- **Entity form support**: Added `hook_form_alter` in `hivelog.module` to attach the buttons library and a `hivelog-entity-form` wrapper class to all HiveLog entity add/edit forms, covering Save and Delete buttons.

### Files changed

- `src/ApiaryListBuilder.php` — attach table library and CSS class
- `css/hivelog.buttons.css` — new button stylesheet
- `hivelog.libraries.yml` — register buttons library, add as dependency
- `hivelog.module` — form alter hook for entity form button styling

Closes #69

---
[Conversation](https://app.warp.dev/conversation/ecf94179-160a-46fc-9834-1183227b569b)

Co-Authored-By: Oz <oz-agent@warp.dev>