### PR TITLE
Refactor button rendering to use SDC button and button-group components (#74)

### DIFF
--- a/components/button-group/button-group.component.yml
+++ b/components/button-group/button-group.component.yml
@@ -13,9 +13,19 @@ props:
       type: array
       title: Buttons
       description: >
-        Pre-rendered HTML strings for each button in the group.
+        Structured button definitions rendered via the hivelog:button component.
       items:
-        type: string
+        type: object
+        required:
+          - label
+          - url
+        properties:
+          label:
+            type: string
+          url:
+            type: string
+          variant:
+            type: string
 
 libraryOverrides:
   dependencies:

--- a/components/button-group/button-group.css
+++ b/components/button-group/button-group.css
@@ -2,16 +2,7 @@
  * @file
  * Styling for the hivelog:button-group SDC component.
  *
- * Inline flex container for adjacent action buttons with consistent spacing.
+ * Layout is driven by Tailwind utility classes declared in
+ * button-group.twig. The theme build scans this component directory and
+ * includes the relevant definitions in its compiled output.
  */
-
-.hivelog-button-group {
-  display: inline-flex;
-  gap: 0.4em;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.hivelog-button-group .button {
-  margin-right: 0;
-}

--- a/components/button-group/button-group.twig
+++ b/components/button-group/button-group.twig
@@ -1,5 +1,10 @@
-<div class="hivelog-button-group">
+<div class="hivelog-button-group flex [&>:not(:first-child)]:rounded-l-none [&>:not(:last-child)]:rounded-r-none gap-px inline-flex flex-wrap items-center gap-1.5">
   {% for button in buttons %}
-    {{ button|raw }}
+    {% include 'hivelog:button' with {
+      label: button.label,
+      url: button.url,
+      variant: button.variant|default('default'),
+      extra_classes: "text-sm !px-1 !py-0",
+    } only %}
   {% endfor %}
 </div>

--- a/components/button/button.component.yml
+++ b/components/button/button.component.yml
@@ -1,0 +1,38 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+
+name: Button
+status: stable
+description: >
+  A single action button that emits Drupal, Bootstrap, and Tailwind CSS
+  classes so the module renders correctly regardless of the active theme's
+  CSS framework.
+
+props:
+  type: object
+  required:
+    - label
+    - url
+  properties:
+    label:
+      type: string
+      title: Label
+      examples:
+        - Edit
+    url:
+      type: string
+      title: URL
+    variant:
+      type: string
+      title: Variant
+      default: default
+      examples:
+        - primary
+    extra_classes:
+      type: string
+      title: Extra CSS classes
+      description: Additional classes appended after the variant classes.
+      default: ''
+
+libraryOverrides:
+  dependencies:
+    - hivelog/buttons

--- a/components/button/button.twig
+++ b/components/button/button.twig
@@ -1,0 +1,10 @@
+{%- set variant = variant|default('default') -%}
+{%- set base = 'button btn join-item inline-flex items-center px-3 py-1.5 rounded text-sm font-medium no-underline cursor-pointer transition-colors' -%}
+{%- if variant == 'primary' -%}
+  {%- set modifier = 'button--primary btn-primary bg-blue-600 text-white border border-blue-700 hover:bg-blue-700' -%}
+{%- elseif variant == 'danger' -%}
+  {%- set modifier = 'button--danger btn-danger bg-red-600 text-white border border-red-700 hover:bg-red-700' -%}
+{%- else -%}
+  {%- set modifier = 'btn-default bg-gray-100 text-gray-800 border border-gray-300 hover:bg-gray-200' -%}
+{%- endif -%}
+<a href="{{ url }}" class="{{ base }} {{ modifier }}{% if extra_classes %} {{ extra_classes }}{% endif %}">{{ label }}</a>

--- a/components/entity-table/entity-table.css
+++ b/components/entity-table/entity-table.css
@@ -2,22 +2,8 @@
  * @file
  * Styling for the hivelog:entity-table SDC component.
  *
- * Full-width table with horizontal row dividers and left-aligned headers.
+ * Appearance is driven by framework utility classes declared in
+ * entity-table.twig. The theme build scans this component directory and
+ * includes whichever framework classes it recognises (DaisyUI `table`,
+ * Tailwind utilities, etc.) in its compiled output.
  */
-
-.hivelog-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.hivelog-table th,
-.hivelog-table td {
-  border-bottom: 1px solid #e0e0e0;
-  padding: 0.5rem 0.75rem;
-}
-
-/* Header bottom border slightly heavier; left-align titles. */
-.hivelog-table thead th {
-  border-bottom: 2px solid #ccc;
-  text-align: left;
-}

--- a/components/entity-table/entity-table.twig
+++ b/components/entity-table/entity-table.twig
@@ -1,24 +1,26 @@
-<table class="hivelog-table">
-  <thead>
-    <tr>
-      {% for header in headers %}
-        <th>{{ header }}</th>
-      {% endfor %}
-    </tr>
-  </thead>
-  <tbody>
-    {% if rows is empty %}
-      <tr class="hivelog-table__empty">
-        <td colspan="{{ headers|length }}">{{ empty_message }}</td>
+<div class="overflow-x-auto">
+  <table class="table w-full">
+    <thead>
+      <tr>
+        {% for header in headers %}
+          <th class="text-left">{{ header }}</th>
+        {% endfor %}
       </tr>
-    {% else %}
-      {% for row in rows %}
+    </thead>
+    <tbody>
+      {% if rows is empty %}
         <tr>
-          {% for cell in row.cells %}
-            <td>{{ cell|raw }}</td>
-          {% endfor %}
+          <td colspan="{{ headers|length }}" class="text-center opacity-60">{{ empty_message }}</td>
         </tr>
-      {% endfor %}
-    {% endif %}
-  </tbody>
-</table>
+      {% else %}
+        {% for row in rows %}
+          <tr>
+            {% for cell in row.cells %}
+              <td>{{ cell|raw }}</td>
+            {% endfor %}
+          </tr>
+        {% endfor %}
+      {% endif %}
+    </tbody>
+  </table>
+</div>

--- a/src/ApiaryListBuilder.php
+++ b/src/ApiaryListBuilder.php
@@ -96,28 +96,18 @@ class ApiaryListBuilder extends EntityListBuilder {
 
     // Build operations as plain button links instead of the default
     // dropbutton widget returned by parent::buildRow().
-    $links = [];
+    $buttons = [];
     if ($entity->access('update') && $entity->hasLinkTemplate('edit-form')) {
-      $links['edit'] = [
-        '#type' => 'link',
-        '#title' => $this->t('Edit'),
-        '#url' => $entity->toUrl('edit-form'),
-        '#attributes' => ['class' => ['button']],
-      ];
+      $buttons[] = ['label' => (string) $this->t('Edit'), 'url' => $entity->toUrl('edit-form')->toString()];
     }
     if ($entity->access('delete') && $entity->hasLinkTemplate('delete-form')) {
-      $links['delete'] = [
-        '#type' => 'link',
-        '#title' => $this->t('Delete'),
-        '#url' => $entity->toUrl('delete-form'),
-        '#attributes' => ['class' => ['button', 'button--danger']],
-      ];
+      $buttons[] = ['label' => (string) $this->t('Delete'), 'url' => $entity->toUrl('delete-form')->toString(), 'variant' => 'danger'];
     }
     $row['operations']['data'] = [
       '#type' => 'component',
       '#component' => 'hivelog:button-group',
       '#props' => [
-        'buttons' => $this->renderButtons($links),
+        'buttons' => $buttons,
       ],
     ];
 
@@ -165,11 +155,13 @@ class ApiaryListBuilder extends EntityListBuilder {
         '#attributes' => ['class' => ['hivelog-list-heading__title']],
       ],
       'add' => [
-        '#type' => 'link',
-        '#title' => $this->t('Add Apiary'),
-        '#url' => Url::fromRoute('entity.apiary.add_form'),
-        '#attributes' => [
-          'class' => ['button', 'button--primary', 'hivelog-list-heading__action'],
+        '#type' => 'component',
+        '#component' => 'hivelog:button',
+        '#props' => [
+          'label' => (string) $this->t('Add Apiary'),
+          'url' => Url::fromRoute('entity.apiary.add_form')->toString(),
+          'variant' => 'primary',
+          'extra_classes' => 'hivelog-list-heading__action',
         ],
       ],
       '#attached' => ['library' => ['hivelog/buttons']],
@@ -246,22 +238,6 @@ class ApiaryListBuilder extends EntityListBuilder {
       return '';
     }
     return trim((string) $user->get('cbr_number')->value);
-  }
-
-  /**
-   * Pre-renders an array of link render elements to HTML strings.
-   *
-   * @param array $links
-   *   Associative array of link render elements keyed by name.
-   *
-   * @return string[]
-   */
-  protected function renderButtons(array $links): array {
-    $buttons = [];
-    foreach ($links as $link) {
-      $buttons[] = (string) $this->renderer->renderInIsolation($link);
-    }
-    return $buttons;
   }
 
 }

--- a/src/Controller/ApiaryController.php
+++ b/src/Controller/ApiaryController.php
@@ -94,11 +94,13 @@ class ApiaryController extends ControllerBase {
         '#attributes' => ['class' => ['hivelog-list-heading__title']],
       ],
       'add' => [
-        '#type' => 'link',
-        '#title' => $this->t('Add Hive'),
-        '#url' => Url::fromRoute('hivelog.hive.add', ['apiary' => $apiary->id()]),
-        '#attributes' => [
-          'class' => ['button', 'button--primary', 'hivelog-list-heading__action'],
+        '#type' => 'component',
+        '#component' => 'hivelog:button',
+        '#props' => [
+          'label' => (string) $this->t('Add Hive'),
+          'url' => Url::fromRoute('hivelog.hive.add', ['apiary' => $apiary->id()])->toString(),
+          'variant' => 'primary',
+          'extra_classes' => 'hivelog-list-heading__action',
         ],
       ],
     ];
@@ -143,10 +145,10 @@ class ApiaryController extends ControllerBase {
         '#type' => 'component',
         '#component' => 'hivelog:button-group',
         '#props' => [
-          'buttons' => $this->renderButtons([
-            ['title' => $this->t('Edit'), 'url' => $hive->toUrl('edit-form'), 'class' => ['button']],
-            ['title' => $this->t('Delete'), 'url' => $hive->toUrl('delete-form'), 'class' => ['button', 'button--danger']],
-          ]),
+          'buttons' => [
+            ['label' => (string) $this->t('Edit'), 'url' => $hive->toUrl('edit-form')->toString()],
+            ['label' => (string) $this->t('Delete'), 'url' => $hive->toUrl('delete-form')->toString(), 'variant' => 'danger'],
+          ],
         ],
       ];
       $rows[] = [
@@ -250,27 +252,6 @@ class ApiaryController extends ControllerBase {
    */
   protected function escapeLike(string $value): string {
     return addcslashes($value, '\\%_');
-  }
-
-  /**
-   * Pre-renders an array of button definitions to HTML strings.
-   *
-   * @param array<int, array{title: mixed, url: \Drupal\Core\Url, class: string[]}> $definitions
-   *
-   * @return string[]
-   */
-  protected function renderButtons(array $definitions): array {
-    $buttons = [];
-    foreach ($definitions as $def) {
-      $link = [
-        '#type' => 'link',
-        '#title' => $def['title'],
-        '#url' => $def['url'],
-        '#attributes' => ['class' => $def['class']],
-      ];
-      $buttons[] = (string) $this->renderer->renderInIsolation($link);
-    }
-    return $buttons;
   }
 
 }

--- a/src/Controller/HiveController.php
+++ b/src/Controller/HiveController.php
@@ -134,11 +134,13 @@ class HiveController extends ControllerBase {
         '#attributes' => ['class' => ['hivelog-list-heading__title']],
       ],
       'add' => [
-        '#type' => 'link',
-        '#title' => $this->t('Add Inspection'),
-        '#url' => Url::fromRoute('hivelog.inspection.add', ['hive' => $hive->id()]),
-        '#attributes' => [
-          'class' => ['button', 'button--primary', 'hivelog-list-heading__action'],
+        '#type' => 'component',
+        '#component' => 'hivelog:button',
+        '#props' => [
+          'label' => (string) $this->t('Add Inspection'),
+          'url' => Url::fromRoute('hivelog.inspection.add', ['hive' => $hive->id()])->toString(),
+          'variant' => 'primary',
+          'extra_classes' => 'hivelog-list-heading__action',
         ],
       ],
     ];
@@ -183,11 +185,11 @@ class HiveController extends ControllerBase {
         '#type' => 'component',
         '#component' => 'hivelog:button-group',
         '#props' => [
-          'buttons' => $this->renderButtons([
-            ['title' => $this->t('View'), 'url' => $inspection->toUrl('canonical'), 'class' => ['button']],
-            ['title' => $this->t('Edit'), 'url' => $inspection->toUrl('edit-form'), 'class' => ['button']],
-            ['title' => $this->t('Delete'), 'url' => $inspection->toUrl('delete-form'), 'class' => ['button', 'button--danger']],
-          ]),
+          'buttons' => [
+            ['label' => (string) $this->t('View'), 'url' => $inspection->toUrl('canonical')->toString()],
+            ['label' => (string) $this->t('Edit'), 'url' => $inspection->toUrl('edit-form')->toString()],
+            ['label' => (string) $this->t('Delete'), 'url' => $inspection->toUrl('delete-form')->toString(), 'variant' => 'danger'],
+          ],
         ],
       ];
       $rows[] = [
@@ -307,19 +309,21 @@ class HiveController extends ControllerBase {
         ],
       ];
       $section['edit'] = [
-        '#type' => 'link',
-        '#title' => $this->t('Edit Queen'),
-        '#url' => $queen->toUrl('edit-form'),
-        '#attributes' => [
-          'class' => ['button', 'hivelog-list-heading__action'],
+        '#type' => 'component',
+        '#component' => 'hivelog:button',
+        '#props' => [
+          'label' => (string) $this->t('Edit Queen'),
+          'url' => $queen->toUrl('edit-form')->toString(),
+          'extra_classes' => 'hivelog-list-heading__action',
         ],
       ];
       $section['add_observation'] = [
-        '#type' => 'link',
-        '#title' => $this->t('Add Observation'),
-        '#url' => Url::fromRoute('hivelog.queen_observation.add', ['queen' => $queen->id()]),
-        '#attributes' => [
-          'class' => ['button', 'hivelog-list-heading__action'],
+        '#type' => 'component',
+        '#component' => 'hivelog:button',
+        '#props' => [
+          'label' => (string) $this->t('Add Observation'),
+          'url' => Url::fromRoute('hivelog.queen_observation.add', ['queen' => $queen->id()])->toString(),
+          'extra_classes' => 'hivelog-list-heading__action',
         ],
       ];
     }
@@ -328,11 +332,13 @@ class HiveController extends ControllerBase {
         '#markup' => '<p>' . $this->t('No active queen is recorded for this hive.') . '</p>',
       ];
       $section['add'] = [
-        '#type' => 'link',
-        '#title' => $this->t('Add Queen'),
-        '#url' => Url::fromRoute('hivelog.queen.add', ['hive' => $hive->id()]),
-        '#attributes' => [
-          'class' => ['button', 'button--primary', 'hivelog-list-heading__action'],
+        '#type' => 'component',
+        '#component' => 'hivelog:button',
+        '#props' => [
+          'label' => (string) $this->t('Add Queen'),
+          'url' => Url::fromRoute('hivelog.queen.add', ['hive' => $hive->id()])->toString(),
+          'variant' => 'primary',
+          'extra_classes' => 'hivelog-list-heading__action',
         ],
       ];
     }
@@ -681,27 +687,6 @@ class HiveController extends ControllerBase {
       return 0;
     }
     return (int) $dt->format('z');
-  }
-
-  /**
-   * Pre-renders an array of button definitions to HTML strings.
-   *
-   * @param array<int, array{title: mixed, url: \Drupal\Core\Url, class: string[]}> $definitions
-   *
-   * @return string[]
-   */
-  protected function renderButtons(array $definitions): array {
-    $buttons = [];
-    foreach ($definitions as $def) {
-      $link = [
-        '#type' => 'link',
-        '#title' => $def['title'],
-        '#url' => $def['url'],
-        '#attributes' => ['class' => $def['class']],
-      ];
-      $buttons[] = (string) $this->renderer->renderInIsolation($link);
-    }
-    return $buttons;
   }
 
 }

--- a/src/Controller/HiveInspectionController.php
+++ b/src/Controller/HiveInspectionController.php
@@ -204,10 +204,10 @@ class HiveInspectionController extends ControllerBase {
   protected function buildActions(HiveInspection $hive_inspection): array {
     $buttons = [];
     if ($hive_inspection->access('update')) {
-      $buttons[] = ['title' => $this->t('Edit'), 'url' => $hive_inspection->toUrl('edit-form'), 'class' => ['button', 'button--primary']];
+      $buttons[] = ['label' => (string) $this->t('Edit'), 'url' => $hive_inspection->toUrl('edit-form')->toString(), 'variant' => 'primary'];
     }
     if ($hive_inspection->access('delete')) {
-      $buttons[] = ['title' => $this->t('Delete'), 'url' => $hive_inspection->toUrl('delete-form'), 'class' => ['button', 'button--danger']];
+      $buttons[] = ['label' => (string) $this->t('Delete'), 'url' => $hive_inspection->toUrl('delete-form')->toString(), 'variant' => 'danger'];
     }
     if (empty($buttons)) {
       return [];
@@ -215,30 +215,9 @@ class HiveInspectionController extends ControllerBase {
     return [
       '#type' => 'component',
       '#component' => 'hivelog:button-group',
-      '#props' => ['buttons' => $this->renderButtons($buttons)],
+      '#props' => ['buttons' => $buttons],
       '#weight' => -10,
     ];
-  }
-
-  /**
-   * Pre-renders an array of button definitions to HTML strings.
-   *
-   * @param array<int, array{title: mixed, url: \Drupal\Core\Url, class: string[]}> $definitions
-   *
-   * @return string[]
-   */
-  protected function renderButtons(array $definitions): array {
-    $buttons = [];
-    foreach ($definitions as $def) {
-      $link = [
-        '#type' => 'link',
-        '#title' => $def['title'],
-        '#url' => $def['url'],
-        '#attributes' => ['class' => $def['class']],
-      ];
-      $buttons[] = (string) $this->renderer->renderInIsolation($link);
-    }
-    return $buttons;
   }
 
   /**

--- a/src/Controller/QueenController.php
+++ b/src/Controller/QueenController.php
@@ -129,11 +129,13 @@ class QueenController extends ControllerBase {
         '#attributes' => ['class' => ['hivelog-list-heading__title']],
       ],
       'add' => [
-        '#type' => 'link',
-        '#title' => $this->t('Add Observation'),
-        '#url' => Url::fromRoute('hivelog.queen_observation.add', ['queen' => $queen->id()]),
-        '#attributes' => [
-          'class' => ['button', 'button--primary', 'hivelog-list-heading__action'],
+        '#type' => 'component',
+        '#component' => 'hivelog:button',
+        '#props' => [
+          'label' => (string) $this->t('Add Observation'),
+          'url' => Url::fromRoute('hivelog.queen_observation.add', ['queen' => $queen->id()])->toString(),
+          'variant' => 'primary',
+          'extra_classes' => 'hivelog-list-heading__action',
         ],
       ],
     ];
@@ -167,11 +169,11 @@ class QueenController extends ControllerBase {
         '#type' => 'component',
         '#component' => 'hivelog:button-group',
         '#props' => [
-          'buttons' => $this->renderButtons([
-            ['title' => $this->t('View'), 'url' => $observation->toUrl('canonical'), 'class' => ['button']],
-            ['title' => $this->t('Edit'), 'url' => $observation->toUrl('edit-form'), 'class' => ['button']],
-            ['title' => $this->t('Delete'), 'url' => $observation->toUrl('delete-form'), 'class' => ['button', 'button--danger']],
-          ]),
+          'buttons' => [
+            ['label' => (string) $this->t('View'), 'url' => $observation->toUrl('canonical')->toString()],
+            ['label' => (string) $this->t('Edit'), 'url' => $observation->toUrl('edit-form')->toString()],
+            ['label' => (string) $this->t('Delete'), 'url' => $observation->toUrl('delete-form')->toString(), 'variant' => 'danger'],
+          ],
         ],
       ];
       $rows[] = [
@@ -234,10 +236,10 @@ class QueenController extends ControllerBase {
   protected function buildActions(Queen $queen): array {
     $buttons = [];
     if ($queen->access('update')) {
-      $buttons[] = ['title' => $this->t('Edit'), 'url' => $queen->toUrl('edit-form'), 'class' => ['button', 'button--primary']];
+      $buttons[] = ['label' => (string) $this->t('Edit'), 'url' => $queen->toUrl('edit-form')->toString(), 'variant' => 'primary'];
     }
     if ($queen->access('delete')) {
-      $buttons[] = ['title' => $this->t('Delete'), 'url' => $queen->toUrl('delete-form'), 'class' => ['button', 'button--danger']];
+      $buttons[] = ['label' => (string) $this->t('Delete'), 'url' => $queen->toUrl('delete-form')->toString(), 'variant' => 'danger'];
     }
     if (empty($buttons)) {
       return [];
@@ -245,7 +247,7 @@ class QueenController extends ControllerBase {
     return [
       '#type' => 'component',
       '#component' => 'hivelog:button-group',
-      '#props' => ['buttons' => $this->renderButtons($buttons)],
+      '#props' => ['buttons' => $buttons],
       '#weight' => -10,
     ];
   }
@@ -353,27 +355,6 @@ class QueenController extends ControllerBase {
           '#plain_text' => (string) $field->value,
         ];
     }
-  }
-
-  /**
-   * Pre-renders an array of button definitions to HTML strings.
-   *
-   * @param array<int, array{title: mixed, url: \Drupal\Core\Url, class: string[]}> $definitions
-   *
-   * @return string[]
-   */
-  protected function renderButtons(array $definitions): array {
-    $buttons = [];
-    foreach ($definitions as $def) {
-      $link = [
-        '#type' => 'link',
-        '#title' => $def['title'],
-        '#url' => $def['url'],
-        '#attributes' => ['class' => $def['class']],
-      ];
-      $buttons[] = (string) $this->renderer->renderInIsolation($link);
-    }
-    return $buttons;
   }
 
 }

--- a/src/Controller/QueenObservationController.php
+++ b/src/Controller/QueenObservationController.php
@@ -124,10 +124,10 @@ class QueenObservationController extends ControllerBase {
   protected function buildActions(QueenObservation $queen_observation): array {
     $buttons = [];
     if ($queen_observation->access('update')) {
-      $buttons[] = ['title' => $this->t('Edit'), 'url' => $queen_observation->toUrl('edit-form'), 'class' => ['button', 'button--primary']];
+      $buttons[] = ['label' => (string) $this->t('Edit'), 'url' => $queen_observation->toUrl('edit-form')->toString(), 'variant' => 'primary'];
     }
     if ($queen_observation->access('delete')) {
-      $buttons[] = ['title' => $this->t('Delete'), 'url' => $queen_observation->toUrl('delete-form'), 'class' => ['button', 'button--danger']];
+      $buttons[] = ['label' => (string) $this->t('Delete'), 'url' => $queen_observation->toUrl('delete-form')->toString(), 'variant' => 'danger'];
     }
     if (empty($buttons)) {
       return [];
@@ -135,30 +135,9 @@ class QueenObservationController extends ControllerBase {
     return [
       '#type' => 'component',
       '#component' => 'hivelog:button-group',
-      '#props' => ['buttons' => $this->renderButtons($buttons)],
+      '#props' => ['buttons' => $buttons],
       '#weight' => -10,
     ];
-  }
-
-  /**
-   * Pre-renders an array of button definitions to HTML strings.
-   *
-   * @param array<int, array{title: mixed, url: \Drupal\Core\Url, class: string[]}> $definitions
-   *
-   * @return string[]
-   */
-  protected function renderButtons(array $definitions): array {
-    $buttons = [];
-    foreach ($definitions as $def) {
-      $link = [
-        '#type' => 'link',
-        '#title' => $def['title'],
-        '#url' => $def['url'],
-        '#attributes' => ['class' => $def['class']],
-      ];
-      $buttons[] = (string) $this->renderer->renderInIsolation($link);
-    }
-    return $buttons;
   }
 
   /**

--- a/src/Form/HivelogHiveFilterForm.php
+++ b/src/Form/HivelogHiveFilterForm.php
@@ -113,10 +113,12 @@ class HivelogHiveFilterForm extends FormBase {
     ];
     if ($apiary) {
       $form['filter_actions']['reset'] = [
-        '#type' => 'link',
-        '#title' => $this->t('Reset'),
-        '#url' => Url::fromRoute('entity.apiary.canonical', ['apiary' => $apiary->id()]),
-        '#attributes' => ['class' => ['button']],
+        '#type' => 'component',
+        '#component' => 'hivelog:button',
+        '#props' => [
+          'label' => (string) $this->t('Reset'),
+          'url' => Url::fromRoute('entity.apiary.canonical', ['apiary' => $apiary->id()])->toString(),
+        ],
       ];
     }
 

--- a/src/Form/HivelogInspectionFilterForm.php
+++ b/src/Form/HivelogInspectionFilterForm.php
@@ -115,10 +115,12 @@ class HivelogInspectionFilterForm extends FormBase {
     ];
     if ($hive) {
       $form['filter_actions']['reset'] = [
-        '#type' => 'link',
-        '#title' => $this->t('Reset'),
-        '#url' => Url::fromRoute('entity.hive.canonical', ['hive' => $hive->id()]),
-        '#attributes' => ['class' => ['button']],
+        '#type' => 'component',
+        '#component' => 'hivelog:button',
+        '#props' => [
+          'label' => (string) $this->t('Reset'),
+          'url' => Url::fromRoute('entity.hive.canonical', ['hive' => $hive->id()])->toString(),
+        ],
       ];
     }
 

--- a/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
+++ b/tests/src/Kernel/EmbeddedTableFilterPaginationTest.php
@@ -404,9 +404,10 @@ class EmbeddedTableFilterPaginationTest extends KernelTestBase {
     // The Add Hive action lives in the heading row (top-right of the list
     // section), not inline with the filter form.
     $this->assertArrayHasKey('add', $build['hives_heading']);
-    $this->assertContains(
+    $this->assertEquals('hivelog:button', $build['hives_heading']['add']['#component']);
+    $this->assertStringContainsString(
       'hivelog-list-heading__action',
-      $build['hives_heading']['add']['#attributes']['class']
+      $build['hives_heading']['add']['#props']['extra_classes']
     );
     $this->assertContains(
       'hivelog-list-heading',


### PR DESCRIPTION
Replace hard-coded link rendering with structured `hivelog:button` and `hivelog:button-group` components across all controllers, forms, and list builders. Button definitions now use `label`, `url`, `variant`, and `extra_classes` props.

Also fixes table header alignment regression by adding `text-left` class to entity-table `<th>` elements.

Fixes #74

Co-Authored-By: Oz <oz-agent@warp.dev>