### PR TITLE
feat(responsive): mobile UX — tables, filter form, map & image grid (tasks 0005–0008)

### DIFF
--- a/components/entity-table/entity-table.component.yml
+++ b/components/entity-table/entity-table.component.yml
@@ -33,3 +33,4 @@ props:
 libraryOverrides:
   dependencies:
     - hivelog/buttons
+    - hivelog/responsive

--- a/components/entity-table/entity-table.css
+++ b/components/entity-table/entity-table.css
@@ -7,3 +7,68 @@
  * includes whichever framework classes it recognises (DaisyUI `table`,
  * Tailwind utilities, etc.) in its compiled output.
  */
+
+/**
+ * Responsive: collapse the table into stacked, labelled cards on small screens
+ * (task 0004 convention, ADR-0011) so dense lists — e.g. the 8-column hive
+ * inspection list — stay readable without horizontal pinching. Desktop
+ * (>768px) is unaffected; per-cell labels come from the data-label attribute
+ * set in entity-table.twig.
+ */
+@media (max-width: 768px) {
+  .hivelog-entity-table,
+  .hivelog-entity-table thead,
+  .hivelog-entity-table tbody,
+  .hivelog-entity-table tr,
+  .hivelog-entity-table td {
+    display: block;
+    width: 100%;
+  }
+
+  /* Visually hide the header row; per-cell labels come from data-label. */
+  .hivelog-entity-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    border: 0;
+    white-space: nowrap;
+  }
+
+  /* Each row becomes a bordered card. */
+  .hivelog-entity-table tr {
+    margin-bottom: var(--hivelog-gap, 1rem);
+    padding: var(--hivelog-gap-tight, 0.5rem) var(--hivelog-mobile-gutter, 0.75rem);
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+  }
+
+  /* Labelled cells: column name on the left, value on the right. */
+  .hivelog-entity-table td[data-label] {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--hivelog-gap, 1rem);
+    padding: 0.35rem 0;
+    border: 0;
+    text-align: right;
+  }
+
+  .hivelog-entity-table td[data-label]::before {
+    content: attr(data-label);
+    font-weight: 600;
+    text-align: left;
+    color: #374151;
+  }
+
+  /* Empty-state cell spans the card without a label. */
+  .hivelog-entity-table td:not([data-label]) {
+    padding: var(--hivelog-gap, 1rem) 0;
+    text-align: center;
+    opacity: 0.6;
+  }
+}

--- a/components/entity-table/entity-table.twig
+++ b/components/entity-table/entity-table.twig
@@ -1,5 +1,5 @@
 <div class="overflow-x-auto">
-  <table class="table w-full">
+  <table class="hivelog-entity-table table w-full">
     <thead>
       <tr>
         {% for header in headers %}
@@ -16,7 +16,7 @@
         {% for row in rows %}
           <tr>
             {% for cell in row.cells %}
-              <td>{{ cell|raw }}</td>
+              <td data-label="{{ headers[loop.index0] }}">{{ cell|raw }}</td>
             {% endfor %}
           </tr>
         {% endfor %}

--- a/css/hivelog.filter-form.css
+++ b/css/hivelog.filter-form.css
@@ -64,3 +64,48 @@
 .hivelog-filter-form__actions .button {
   margin: 0;
 }
+
+/* Responsive: stack the heading and filter form on small screens (task 0004
+   convention, ADR-0011). Desktop (>768px) keeps the single-row layout. */
+@media (max-width: 768px) {
+  /* Heading: title above, action below at its natural width. */
+  .hivelog-list-heading {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .hivelog-list-heading__action {
+    align-self: flex-start;
+    white-space: normal;
+  }
+
+  /* Filter form: single full-width column. */
+  .hivelog-filter-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  /* Undo display:contents so the filters stack instead of sharing one row. */
+  .hivelog-filter-form__filters {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+  }
+
+  .hivelog-filter-form .form-item {
+    width: 100%;
+  }
+
+  .hivelog-filter-form .form-item input,
+  .hivelog-filter-form .form-item select {
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  /* Actions span the row instead of being pushed to the right edge. */
+  .hivelog-filter-form__actions {
+    width: 100%;
+    margin: 0;
+  }
+}

--- a/css/hivelog.images.css
+++ b/css/hivelog.images.css
@@ -36,3 +36,13 @@
 .hivelog-photos-grid__item:focus img {
   transform: scale(1.03);
 }
+
+/* Responsive: guarantee a tidy 2-column thumbnail grid on phones (task 0004
+   convention, ADR-0011). The auto-fill track above already reflows, but very
+   narrow phones (~320px) would otherwise collapse to a single column.
+   Desktop / tablet keep the auto-fill behaviour. */
+@media (max-width: 480px) {
+  .hivelog-photos-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/css/hivelog.map.css
+++ b/css/hivelog.map.css
@@ -9,13 +9,17 @@
  *
  * Scope & specificity:
  * - This library is attached only on the apiary view (see ApiaryController),
- *   and the selector is limited to the geofield map, so it never affects other
- *   Leaflet maps.
- * - `!important` is required to override the formatter's *inline* height; the
- *   tight scoping keeps that safe.
+ *   which has a single Leaflet map, so the selectors below stay safe.
+ * - The contrib formatter renders the map div with an id from
+ *   Html::getUniqueId('leaflet_map') (=> "leaflet-map…") plus an inline height.
+ *   The field wrapper class and Leaflet's runtime `.leaflet-container` class are
+ *   not reliably present, so we match the id prefix (always in the markup) and
+ *   keep `.leaflet-container` as a post-init fallback.
+ * - `!important` is required to beat the formatter's *inline* height.
  */
 @media (max-width: 768px) {
-  .field--type-geofield .leaflet-container {
+  [id^="leaflet-map"],
+  .leaflet-container {
     height: 40vh !important;
     min-height: 200px;
   }

--- a/css/hivelog.map.css
+++ b/css/hivelog.map.css
@@ -1,0 +1,22 @@
+/**
+ * @file
+ * Responsive sizing for the apiary Leaflet map (task 0008).
+ *
+ * The contrib Leaflet field formatter renders the map with a fixed inline
+ * height (200px, set in the Apiary geolocation view display). On small screens
+ * that is a little cramped, so we give the map a taller, viewport-relative
+ * height. Desktop (>768px) keeps the formatter's 200px.
+ *
+ * Scope & specificity:
+ * - This library is attached only on the apiary view (see ApiaryController),
+ *   and the selector is limited to the geofield map, so it never affects other
+ *   Leaflet maps.
+ * - `!important` is required to override the formatter's *inline* height; the
+ *   tight scoping keeps that safe.
+ */
+@media (max-width: 768px) {
+  .field--type-geofield .leaflet-container {
+    height: 40vh !important;
+    min-height: 200px;
+  }
+}

--- a/css/hivelog.tables.css
+++ b/css/hivelog.tables.css
@@ -32,3 +32,37 @@
   border-bottom: 2px solid #ccc;
   text-align: left;
 }
+
+/* Responsive: keep the Field/Value detail tables legible on small screens
+   (task 0004 convention, ADR-0011). The label column is capped so the value
+   column keeps usable width, and long values (notes, entity links) wrap rather
+   than forcing horizontal scroll. Desktop (>768px) is unaffected. */
+@media (max-width: 768px) {
+  .hivelog-inspection-table,
+  .hivelog-queen-table,
+  .hivelog-queen-observation-table {
+    table-layout: fixed;
+  }
+
+  .hivelog-inspection-table th,
+  .hivelog-inspection-table td,
+  .hivelog-queen-table th,
+  .hivelog-queen-table td,
+  .hivelog-queen-observation-table th,
+  .hivelog-queen-observation-table td {
+    padding: 0.4rem 0.5rem;
+    vertical-align: top;
+    overflow-wrap: anywhere;
+  }
+
+  /* Cap the Field (label) column so the Value column keeps room. */
+  .hivelog-inspection-table th:first-child,
+  .hivelog-inspection-table td:first-child,
+  .hivelog-queen-table th:first-child,
+  .hivelog-queen-table td:first-child,
+  .hivelog-queen-observation-table th:first-child,
+  .hivelog-queen-observation-table td:first-child {
+    width: 40%;
+    font-weight: 600;
+  }
+}

--- a/docs/project-management/tasks/0005-responsive-entity-list-tables.md
+++ b/docs/project-management/tasks/0005-responsive-entity-list-tables.md
@@ -1,7 +1,7 @@
 ---
 type: task
 tags: [hivelog/task]
-status: in-progress
+status: done
 priority: high
 project: "[[mobile-ux-improvements]]"
 area: theme
@@ -46,8 +46,8 @@ deferred to [[0011-unify-button-group-sizing]].
       via the shared component.
 - [x] Empty-state row still renders (its cell has no `data-label`, styled
       separately).
-- [ ] Desktop (`>768px`) layout unchanged — by construction (additive class /
-      attribute + gated `@media`); **manual visual check pending** (dev release).
+- [x] Desktop (`>768px`) layout unchanged — verified on the test site by
+      resizing the hive inspection screen (including below 768px).
 
 ## Implementation notes
 - If choosing the stacked pattern, the SDC needs each `<td>` to carry its header

--- a/docs/project-management/tasks/0005-responsive-entity-list-tables.md
+++ b/docs/project-management/tasks/0005-responsive-entity-list-tables.md
@@ -1,7 +1,7 @@
 ---
 type: task
 tags: [hivelog/task]
-status: backlog
+status: in-progress
 priority: high
 project: "[[mobile-ux-improvements]]"
 area: theme
@@ -21,16 +21,33 @@ page's **eight-column** inspection list built in
 Honey, Temperament, Population, Operations). On a phone this overflows or
 crushes columns. Part of [[mobile-ux-improvements]].
 
+## Resolution
+**Stacked "card" pattern** at `≤768px` (per [[0011-responsive-design-strategy]]),
+implemented in the shared `hivelog:entity-table` SDC so every entity list
+benefits:
+- `entity-table.twig`: the table gains a `hivelog-entity-table` class and each
+  data `<td>` gets `data-label="{{ headers[loop.index0] }}"` — reusing the
+  existing `headers` prop, so **no component-contract change**.
+- `entity-table.css`: `@media (max-width: 768px)` collapses rows into labelled
+  cards (`td[data-label]::before` shows the column name), visually hides the
+  header row, and centres the label-less empty-state cell.
+- `entity-table.component.yml`: now also depends on `hivelog/responsive` for the
+  shared spacing tokens.
+Desktop (`>768px`) is untouched. Operations-cell **tap-target** sizing is
+deferred to [[0011-unify-button-group-sizing]].
+
 ## Acceptance criteria
-- [ ] At `<=480px`, the inspection list is readable without horizontal pinching
-      — via either a stacked/"card" layout (label per cell) or an enhanced
-      horizontal scroll with a sticky first column (decision recorded).
-- [ ] The "Operations" cell (a `hivelog:button-group`) stays usable at mobile
-      widths; coordinate sizing with [[0011-unify-button-group-sizing]].
-- [ ] The same treatment covers other list builders rendered through the SDC
-      (apiary→hives, etc.), not just inspections.
-- [ ] Empty-state row (`colspan = headers|length`) still renders correctly.
-- [ ] Desktop (`>768px`) layout unchanged.
+- [x] At `≤768px` the list is readable without horizontal pinching — **stacked
+      card layout** (label per cell via `data-label`).
+- [ ] The "Operations" cell stays usable — buttons render inside the card;
+      **tap-target sizing pending [[0011-unify-button-group-sizing]]** + visual
+      check.
+- [x] Same treatment covers all SDC-rendered lists (apiary→hives, queens, etc.)
+      via the shared component.
+- [x] Empty-state row still renders (its cell has no `data-label`, styled
+      separately).
+- [ ] Desktop (`>768px`) layout unchanged — by construction (additive class /
+      attribute + gated `@media`); **manual visual check pending** (dev release).
 
 ## Implementation notes
 - If choosing the stacked pattern, the SDC needs each `<td>` to carry its header
@@ -48,5 +65,5 @@ crushes columns. Part of [[mobile-ux-improvements]].
 
 ## Related
 - Project:: [[mobile-ux-improvements]]
-- Decisions:: responsive-strategy ADR (from 0004)
+- Decisions:: [[0011-responsive-design-strategy]]
 - Commits:: 

--- a/docs/project-management/tasks/0006-responsive-detail-tables.md
+++ b/docs/project-management/tasks/0006-responsive-detail-tables.md
@@ -1,7 +1,7 @@
 ---
 type: task
 tags: [hivelog/task]
-status: in-progress
+status: done
 priority: medium
 project: "[[mobile-ux-improvements]]"
 area: theme
@@ -43,8 +43,7 @@ key/value pairs.
       than letting the value column overflow.
 - [x] Long values (notes, links) wrap (`overflow-wrap: anywhere`) instead of
       forcing horizontal scroll.
-- [ ] Desktop (`>768px`) appearance unchanged — by construction (gated `@media`);
-      **manual visual check pending** (dev release).
+- [x] Desktop (`>768px`) appearance unchanged — verified on the test site.
 
 ## Implementation notes
 - All three selectors live in `css/hivelog.tables.css`; add `@media` rules there

--- a/docs/project-management/tasks/0006-responsive-detail-tables.md
+++ b/docs/project-management/tasks/0006-responsive-detail-tables.md
@@ -1,7 +1,7 @@
 ---
 type: task
 tags: [hivelog/task]
-status: todo
+status: in-progress
 priority: medium
 project: "[[mobile-ux-improvements]]"
 area: theme
@@ -22,13 +22,29 @@ two-column table) is the most common one; the inspection and observation detail
 tables carry more columns and are tighter on phones. Part of
 [[mobile-ux-improvements]].
 
+## Resolution
+**Shrink-and-wrap** at `≤768px` in `css/hivelog.tables.css` (per
+[[0011-responsive-design-strategy]]); CSS-only, desktop unchanged. All three
+detail tables are uniform 2-column Field/Value tables
+(`.hivelog-inspection-table`, `.hivelog-queen-table`,
+`.hivelog-queen-observation-table`, built by each controller's `buildSection()`):
+- `table-layout: fixed` with the Field (label) column capped at 40% so the
+  Value column keeps usable width;
+- reduced cell padding and `overflow-wrap: anywhere` so long values (notes,
+  entity links) wrap instead of forcing horizontal scroll;
+- label column emphasised (`font-weight: 600`).
+Kept the 2-col layout (shrink) rather than stacking, since these are short
+key/value pairs.
+
 ## Acceptance criteria
-- [ ] At `<=480px`, detail tables remain legible: no clipped content, sensible
-      wrapping, reduced horizontal padding.
-- [ ] Two-column Field/Value tables (e.g. the queen summary) stack or shrink
-      gracefully rather than letting the value column overflow.
-- [ ] Long values (notes, links) wrap instead of forcing horizontal scroll.
-- [ ] Desktop (`>768px`) appearance unchanged.
+- [x] At `≤480px` detail tables remain legible: reduced padding, capped label
+      column, no clipped content.
+- [x] Two-column Field/Value tables shrink gracefully (fixed 40/60 split) rather
+      than letting the value column overflow.
+- [x] Long values (notes, links) wrap (`overflow-wrap: anywhere`) instead of
+      forcing horizontal scroll.
+- [ ] Desktop (`>768px`) appearance unchanged — by construction (gated `@media`);
+      **manual visual check pending** (dev release).
 
 ## Implementation notes
 - All three selectors live in `css/hivelog.tables.css`; add `@media` rules there
@@ -45,5 +61,5 @@ tables carry more columns and are tighter on phones. Part of
 
 ## Related
 - Project:: [[mobile-ux-improvements]]
-- Decisions:: responsive-strategy ADR (from 0004)
+- Decisions:: [[0011-responsive-design-strategy]]
 - Commits:: 

--- a/docs/project-management/tasks/0006-responsive-detail-tables.md
+++ b/docs/project-management/tasks/0006-responsive-detail-tables.md
@@ -1,7 +1,7 @@
 ---
 type: task
 tags: [hivelog/task]
-status: backlog
+status: todo
 priority: medium
 project: "[[mobile-ux-improvements]]"
 area: theme

--- a/docs/project-management/tasks/0007-responsive-filter-form-and-heading.md
+++ b/docs/project-management/tasks/0007-responsive-filter-form-and-heading.md
@@ -1,7 +1,7 @@
 ---
 type: task
 tags: [hivelog/task]
-status: todo
+status: in-progress
 priority: high
 project: "[[mobile-ux-improvements]]"
 area: theme
@@ -22,17 +22,30 @@ Add action, `justify-content: space-between`) also needs to behave when it
 wraps. Rendered on list pages such as the hive inspection list
 (`HiveController::view()`). Part of [[mobile-ux-improvements]].
 
+## Resolution
+**CSS-only** stacking at `≤768px` in `css/hivelog.filter-form.css` (per
+[[0011-responsive-design-strategy]]); no form/markup changes, desktop keeps its
+single-row layout.
+- `.hivelog-filter-form` becomes a full-width column; `__filters` drops
+  `display: contents` and stacks as a column; `.form-item` inputs/selects go
+  full-width.
+- `.hivelog-filter-form__actions` spans the row (no auto-left margin).
+- `.hivelog-list-heading` stacks (title above, action below at natural width;
+  `__action` allowed to wrap) — this also tidies the reused Queen-section
+  heading.
+Tap-target sizing for the action buttons is coordinated with
+[[0009-mobile-qa-and-tap-targets]].
+
 ## Acceptance criteria
-- [ ] At `<=768px`, filter controls stack vertically and inputs go full-width
-      (override `display: contents` back to a block/column flow at the
-      breakpoint).
-- [ ] Filter / Reset actions remain reachable (full-width or right-aligned row)
-      and keep adequate tap-target size — coordinate with
-      [[0009-mobile-qa-and-tap-targets]].
-- [ ] `.hivelog-list-heading` wraps cleanly: title above, Add action below,
-      without the action overflowing (`__action` is currently
-      `white-space: nowrap`).
-- [ ] Desktop single-row layout (`>768px`) unchanged.
+- [x] At `≤768px` filter controls stack vertically and inputs go full-width
+      (overrides `display: contents`).
+- [ ] Filter / Reset actions remain reachable — now a full-width row;
+      **tap-target sizing pending [[0009-mobile-qa-and-tap-targets]]** + visual
+      check.
+- [x] `.hivelog-list-heading` wraps cleanly: title above, Add action below;
+      `__action` no longer forced `nowrap`.
+- [ ] Desktop single-row layout (`>768px`) unchanged — by construction (gated
+      `@media`); **manual visual check pending** (dev release).
 
 ## Implementation notes
 - Both selectors live in `css/hivelog.filter-form.css`; the heading class is
@@ -48,5 +61,5 @@ wraps. Rendered on list pages such as the hive inspection list
 
 ## Related
 - Project:: [[mobile-ux-improvements]]
-- Decisions:: responsive-strategy ADR (from 0004)
+- Decisions:: [[0011-responsive-design-strategy]]
 - Commits:: 

--- a/docs/project-management/tasks/0007-responsive-filter-form-and-heading.md
+++ b/docs/project-management/tasks/0007-responsive-filter-form-and-heading.md
@@ -1,7 +1,7 @@
 ---
 type: task
 tags: [hivelog/task]
-status: backlog
+status: todo
 priority: high
 project: "[[mobile-ux-improvements]]"
 area: theme

--- a/docs/project-management/tasks/0007-responsive-filter-form-and-heading.md
+++ b/docs/project-management/tasks/0007-responsive-filter-form-and-heading.md
@@ -1,7 +1,7 @@
 ---
 type: task
 tags: [hivelog/task]
-status: in-progress
+status: done
 priority: high
 project: "[[mobile-ux-improvements]]"
 area: theme
@@ -44,8 +44,8 @@ Tap-target sizing for the action buttons is coordinated with
       check.
 - [x] `.hivelog-list-heading` wraps cleanly: title above, Add action below;
       `__action` no longer forced `nowrap`.
-- [ ] Desktop single-row layout (`>768px`) unchanged — by construction (gated
-      `@media`); **manual visual check pending** (dev release).
+- [x] Desktop single-row layout (`>768px`) unchanged — verified on the test site
+      (resizing across the 768px breakpoint).
 
 ## Implementation notes
 - Both selectors live in `css/hivelog.filter-form.css`; the heading class is

--- a/docs/project-management/tasks/0008-responsive-map-and-image-grid.md
+++ b/docs/project-management/tasks/0008-responsive-map-and-image-grid.md
@@ -1,7 +1,7 @@
 ---
 type: task
 tags: [hivelog/task]
-status: todo
+status: in-progress
 priority: medium
 project: "[[mobile-ux-improvements]]"
 area: theme
@@ -22,14 +22,33 @@ Two media-heavy elements need mobile attention:
    The grid column count should adapt to width.
 Part of [[mobile-ux-improvements]].
 
+## Resolution
+Mostly CSS, scoped per [[0011-responsive-design-strategy]]; desktop unchanged.
+- **Image grid** (`css/hivelog.images.css`): already fluid
+  (`auto-fill, minmax(160px, 1fr)`), but very narrow phones (~320px) collapsed
+  to one column. Added `@media (max-width: 480px)` forcing
+  `grid-template-columns: repeat(2, 1fr)` for a tidy 2-up grid; thumbnails keep
+  `aspect-ratio: 1 / 1` and stay tap-through links.
+- **Apiary map**: a new `hivelog/map` library (`css/hivelog.map.css`), attached
+  on the apiary view by `ApiaryController`, gives the Leaflet map a taller,
+  viewport-relative height on small screens. At `≤768px` it overrides the
+  formatter's inline 200px with `height: 40vh !important` (floored at 200px via
+  `min-height`), scoped to the geofield map
+  (`.field--type-geofield .leaflet-container`). Desktop keeps 200px. The
+  `!important` is required to beat the contrib formatter's inline style; the
+  override is tightly scoped (apiary view only, geofield map only) to stay safe.
+  Touch pan/zoom is Leaflet's default; marker clustering remains
+  [[0003-apiary-map-marker-clustering]].
+
 ## Acceptance criteria
-- [ ] The apiary map has a sensible responsive height at `<=480px` (e.g. a
-      viewport-relative or fixed mobile height) and is pan/zoomable by touch
-      without trapping page scroll.
-- [ ] `.hivelog-photos-grid` reflows to fewer columns on narrow screens
-      (e.g. 2 columns phone, more on desktop) with no overflow.
-- [ ] Thumbnails keep aspect ratio and remain tappable (links open full image).
-- [ ] Desktop (`>768px`) layout unchanged.
+- [x] Apiary map has a sensible responsive mobile height — `40vh` (min 200px) at
+      `≤768px` via the scoped `hivelog/map` override; full-width, no overflow.
+      (Touch pan/zoom is Leaflet's default.)
+- [x] `.hivelog-photos-grid` reflows: 2 columns at `≤480px`, auto-fill above;
+      no overflow.
+- [x] Thumbnails keep aspect ratio (`1 / 1`) and remain tappable.
+- [ ] Desktop (`>768px`) layout unchanged — by construction (gated `@media`);
+      **manual visual check pending** (dev release).
 
 ## Implementation notes
 - Image grid CSS is in `css/hivelog.images.css`; the markup is an inline
@@ -47,5 +66,5 @@ Part of [[mobile-ux-improvements]].
 
 ## Related
 - Project:: [[mobile-ux-improvements]]
-- Decisions:: [[0001-geofield-over-geolocation]], [[0002-no-geocoder-dependency]]
+- Decisions:: [[0011-responsive-design-strategy]], [[0001-geofield-over-geolocation]], [[0002-no-geocoder-dependency]]
 - Commits:: 

--- a/docs/project-management/tasks/0008-responsive-map-and-image-grid.md
+++ b/docs/project-management/tasks/0008-responsive-map-and-image-grid.md
@@ -33,10 +33,12 @@ Mostly CSS, scoped per [[0011-responsive-design-strategy]]; desktop unchanged.
   on the apiary view by `ApiaryController`, gives the Leaflet map a taller,
   viewport-relative height on small screens. At `≤768px` it overrides the
   formatter's inline 200px with `height: 40vh !important` (floored at 200px via
-  `min-height`), scoped to the geofield map
-  (`.field--type-geofield .leaflet-container`). Desktop keeps 200px. The
-  `!important` is required to beat the contrib formatter's inline style; the
-  override is tightly scoped (apiary view only, geofield map only) to stay safe.
+  `min-height`), matching the map container by id prefix (`[id^="leaflet-map"]`,
+  from `Html::getUniqueId('leaflet_map')`) plus `.leaflet-container` as a
+  runtime fallback — the field wrapper / `leaflet-container` classes are not
+  reliably in the markup. Desktop keeps 200px. The `!important` beats the
+  formatter's inline style; the override stays safe because the library loads
+  only on the apiary view (single map).
   Touch pan/zoom is Leaflet's default; marker clustering remains
   [[0003-apiary-map-marker-clustering]].
 

--- a/docs/project-management/tasks/0008-responsive-map-and-image-grid.md
+++ b/docs/project-management/tasks/0008-responsive-map-and-image-grid.md
@@ -1,7 +1,7 @@
 ---
 type: task
 tags: [hivelog/task]
-status: in-progress
+status: done
 priority: medium
 project: "[[mobile-ux-improvements]]"
 area: theme
@@ -49,8 +49,8 @@ Mostly CSS, scoped per [[0011-responsive-design-strategy]]; desktop unchanged.
 - [x] `.hivelog-photos-grid` reflows: 2 columns at `≤480px`, auto-fill above;
       no overflow.
 - [x] Thumbnails keep aspect ratio (`1 / 1`) and remain tappable.
-- [ ] Desktop (`>768px`) layout unchanged — by construction (gated `@media`);
-      **manual visual check pending** (dev release).
+- [x] Desktop (`>768px`) layout unchanged — verified on the test site (incl. the
+      taller mobile map and the 2-column photo grid).
 
 ## Implementation notes
 - Image grid CSS is in `css/hivelog.images.css`; the markup is an inline

--- a/docs/project-management/tasks/0008-responsive-map-and-image-grid.md
+++ b/docs/project-management/tasks/0008-responsive-map-and-image-grid.md
@@ -1,7 +1,7 @@
 ---
 type: task
 tags: [hivelog/task]
-status: backlog
+status: todo
 priority: medium
 project: "[[mobile-ux-improvements]]"
 area: theme

--- a/hivelog.libraries.yml
+++ b/hivelog.libraries.yml
@@ -45,3 +45,11 @@ filter_form:
   dependencies:
     - hivelog/buttons
     - hivelog/responsive
+
+map:
+  version: 1.x
+  css:
+    component:
+      css/hivelog.map.css: {}
+  dependencies:
+    - hivelog/responsive

--- a/src/Controller/ApiaryController.php
+++ b/src/Controller/ApiaryController.php
@@ -79,6 +79,10 @@ class ApiaryController extends ControllerBase {
     $view_builder = $this->entityTypeManager->getViewBuilder('apiary');
     $build['apiary'] = $view_builder->view($apiary);
 
+    // Load the responsive map stylesheet so the apiary's Leaflet map gets a
+    // taller, viewport-relative height on small screens (task 0008).
+    $build['#attached']['library'][] = 'hivelog/map';
+
     // Heading row: the "Hives" title on the left, the Add Hive action on
     // the right. Placing the action here (rather than inline with the
     // filter form below) keeps it at the top-right of the list section


### PR DESCRIPTION
## Summary
Implements the build tasks of the **Mobile UX** project (`0005`–`0008`). All CSS-driven, verified on the test site across the `768px` breakpoint; desktop (`>768px`) is unchanged throughout. Builds on accepted ADR `0011` (responsive strategy) and task `0004` (already on `main`): plain-CSS `@media` at `≤480` / `≤768`, shared `:root` tokens in the `hivelog/responsive` library.

### Tasks
- **`0005` — entity-list tables:** the `entity-table` SDC collapses into labelled cards at `≤768px` (per-cell `data-label` from the existing `headers` prop; rules in `entity-table.css`). Covers every SDC-rendered list.
- **`0006` — detail tables:** Field/Value detail tables shrink-and-wrap at `≤768px` (`table-layout: fixed`, 40% label column, `overflow-wrap`) in `css/hivelog.tables.css`.
- **`0007` — filter form & list heading:** stack into a full-width column at `≤768px` (`css/hivelog.filter-form.css`); the heading drops its action below the title.
- **`0008` — map & image grid:** photo grid forces 2 columns at `≤480px` (`css/hivelog.images.css`); a new scoped `hivelog/map` library (attached via `ApiaryController`) gives the apiary Leaflet map a taller `40vh` (min 200px) height at `≤768px`.

### Deferred (tracked separately)
- Button / grouped-button **tap-target sizing** → task `0011` (action-button-consistency).
- Cross-page mobile **QA gate** → task `0009`.

### Testing
Each task was verified on the test site as a dev release; no desktop regressions observed.

Artifacts:
- Conversation: https://app.warp.dev/conversation/6a21480d-fab2-4d66-a6bc-19fc327ea9cf
- Plan: https://app.warp.dev/drive/notebook/lqrlWdA0llzjq0Q3fTd5kI

Co-Authored-By: Oz <oz-agent@warp.dev>
