### PR TITLE
fix(theme): correct button-group variant colours

### DIFF
--- a/components/button/button.twig
+++ b/components/button/button.twig
@@ -1,10 +1,10 @@
 {%- set variant = variant|default('default') -%}
-{%- set base = 'button btn join-item inline-flex items-center no-underline cursor-pointer transition-colors' -%}
+{%- set base = 'button inline-flex items-center no-underline cursor-pointer transition-colors' -%}
 {%- if variant == 'primary' -%}
-  {%- set modifier = 'button--primary btn-primary' -%}
+  {%- set modifier = 'button--primary' -%}
 {%- elseif variant == 'danger' -%}
-  {%- set modifier = 'button--danger btn-danger' -%}
+  {%- set modifier = 'button--danger' -%}
 {%- else -%}
-  {%- set modifier = 'btn-default' -%}
+  {%- set modifier = 'button--default' -%}
 {%- endif -%}
 <a href="{{ url }}" class="{{ base }} {{ modifier }}{% if extra_classes %} {{ extra_classes }}{% endif %}">{{ label }}</a>

--- a/css/hivelog.buttons.css
+++ b/css/hivelog.buttons.css
@@ -12,13 +12,14 @@
  * emits only semantic class names; it does not duplicate any value from here.
  *
  * Context wrappers that trigger HiveLog button styling:
- *   .hivelog-list-heading          heading rows (Add X actions)
- *   .hivelog-filter-form__actions  filter form Filter / Reset buttons
- *   .hivelog-inspection-actions    inspection canonical page actions
- *   .hivelog-queen-actions         queen canonical page actions
+ *   .hivelog-list-heading               heading rows (Add X actions)
+ *   .hivelog-filter-form__actions       filter form Filter / Reset buttons
+ *   .hivelog-inspection-actions         inspection canonical page actions
+ *   .hivelog-queen-actions              queen canonical page actions
  *   .hivelog-queen-observation-actions  observation canonical page actions
  *   .hivelog-entity-form .form-actions  add / edit entity forms
- *   .hivelog-table-actions         table row operations cells
+ *   .hivelog-table-actions              table row operations cells
+ *   .hivelog-button-group               grouped button clusters (View/Edit/Delete)
  */
 
 /* ------------------------------------------------------------------
@@ -27,7 +28,10 @@
    the seven context wrappers into one rule block per state.
 ------------------------------------------------------------------ */
 
-/* Base — default variant */
+/* Base — default variant.
+   .hivelog-button-group is included as the eighth context so grouped
+   buttons (View/Edit/Delete clusters) receive module token styling
+   without needing an additional outer wrapper. */
 :is(
   .hivelog-list-heading,
   .hivelog-filter-form__actions,
@@ -35,7 +39,8 @@
   .hivelog-queen-actions,
   .hivelog-queen-observation-actions,
   .hivelog-entity-form .form-actions,
-  .hivelog-table-actions
+  .hivelog-table-actions,
+  .hivelog-button-group
 ) .button {
   display: inline-block;
   padding: var(--hivelog-btn-padding);
@@ -57,7 +62,8 @@
   .hivelog-queen-actions,
   .hivelog-queen-observation-actions,
   .hivelog-entity-form .form-actions,
-  .hivelog-table-actions
+  .hivelog-table-actions,
+  .hivelog-button-group
 ) .button:hover {
   background-color: var(--hivelog-btn-bg-hover);
   border-color: var(--hivelog-btn-border-hover);
@@ -71,7 +77,8 @@
   .hivelog-queen-actions,
   .hivelog-queen-observation-actions,
   .hivelog-entity-form .form-actions,
-  .hivelog-table-actions
+  .hivelog-table-actions,
+  .hivelog-button-group
 ) .button--primary {
   background-color: var(--hivelog-btn-primary-bg);
   border-color: var(--hivelog-btn-primary-border);
@@ -85,15 +92,14 @@
   .hivelog-queen-actions,
   .hivelog-queen-observation-actions,
   .hivelog-entity-form .form-actions,
-  .hivelog-table-actions
+  .hivelog-table-actions,
+  .hivelog-button-group
 ) .button--primary:hover {
   background-color: var(--hivelog-btn-primary-bg-hover);
   border-color: var(--hivelog-btn-primary-border-hover);
 }
 
-/* Danger variant (Delete).
-   All seven context wrappers are included so any future danger button
-   added to a heading or filter form picks up the correct colour. */
+/* Danger variant (Delete). */
 :is(
   .hivelog-list-heading,
   .hivelog-filter-form__actions,
@@ -101,7 +107,8 @@
   .hivelog-queen-actions,
   .hivelog-queen-observation-actions,
   .hivelog-entity-form .form-actions,
-  .hivelog-table-actions
+  .hivelog-table-actions,
+  .hivelog-button-group
 ) .button--danger {
   background-color: var(--hivelog-btn-danger-bg);
   border-color: var(--hivelog-btn-danger-border);
@@ -115,7 +122,8 @@
   .hivelog-queen-actions,
   .hivelog-queen-observation-actions,
   .hivelog-entity-form .form-actions,
-  .hivelog-table-actions
+  .hivelog-table-actions,
+  .hivelog-button-group
 ) .button--danger:hover {
   background-color: var(--hivelog-btn-danger-bg-hover);
   border-color: var(--hivelog-btn-danger-border-hover);


### PR DESCRIPTION
Closes #87

## Summary

Fixes all buttons in a group rendering red regardless of their variant.

## Root cause

Two compounding problems — see issue #87 for full analysis.

## Changes

**`components/button/button.twig`**
- Removed theme framework classes: `btn`, `btn-primary`, `btn-danger`, `btn-default`, `join-item`
- Semantic modifier classes are now `button--primary`, `button--danger`, `button--default` only
- The module's CSS is the sole styling authority per ADR-0012

**`css/hivelog.buttons.css`**
- Added `.hivelog-button-group` as the eighth context wrapper in all `:is()` rule blocks
- Grouped buttons now receive correct token-based colours (default grey / primary blue / danger red) without needing an additional outer wrapper
- Updated file header comment to document the eighth context wrapper

## Result

| Button | Before | After |
|---|---|---|
| View | Red (theme bleed) | Grey (default) |
| Edit | Red (theme bleed) | Grey (default) |
| Delete | Red | Red (danger) |