### PR TITLE
fix(breadcrumb): raise service priority to 1004 to outrank easy_breadcrumb

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,13 +196,20 @@ in `css/hivelog.buttons.css`. See ADR-0012 and ADR-0024 in
 ### Services
 
 Only one service is registered (`hivelog.services.yml`):
-`hivelog.breadcrumb` — a `BreadcrumbBuilder` with priority 100 that produces
+`hivelog.breadcrumb` — a `BreadcrumbBuilder` with priority **1004** that produces
 the Apiary → Hive → … trail on any hivelog route. `applies()` matches by
 route-name prefix (`entity.apiary.`, `entity.hive.`, `entity.hive_inspection.`,
 `entity.queen.`, `entity.queen_observation.`, `hivelog.`). When adding new
 routes under `/hivelog/...` make sure `applies()` still matches them — and
 explicitly exclude any non-page routes (e.g. file-download endpoints) so
 they do not get an incorrect breadcrumb.
+
+The priority of 1004 is intentional — it must exceed the `easy_breadcrumb`
+module's priority of 1003, which is commonly installed on Drupal sites and
+uses a catch-all `applies()`. If the hivelog builder does not outrank it,
+`easy_breadcrumb` intercepts all hivelog routes and produces path-based trails
+instead of the correct entity-hierarchy trails. Do not lower this priority
+below 1004 without confirming `easy_breadcrumb` is not installed.
 
 ### Tests
 

--- a/docs/project-management/tasks/0009-mobile-qa-and-tap-targets.md
+++ b/docs/project-management/tasks/0009-mobile-qa-and-tap-targets.md
@@ -1,7 +1,7 @@
 ---
 type: task
 tags: [hivelog/task]
-status: backlog
+status: in-progress
 priority: medium
 project: "[[mobile-ux-improvements]]"
 area: tests
@@ -46,12 +46,36 @@ risk. This task is the gate that confirms the project goal is met.
 - Cross-project: [[action-button-consistency]] (tap-target sizing overlaps
   [[0011-unify-button-group-sizing]]).
 
-## QA matrix (fill in during QA)
-- Apiary canonical — 360 / 414 / 768: 
-- Hive canonical — 360 / 414 / 768: 
-- Inspection list — 360 / 414 / 768: 
-- Queen canonical — 360 / 414 / 768: 
+## Defects found during QA
+
+### Defect 1 — Breadcrumbs incorrect on all entity hierarchy routes (FIXED)
+**Root cause:** `hivelog.breadcrumb` was registered at priority 100 in
+`hivelog.services.yml`. The `easy_breadcrumb` contrib module (priority 1003)
+was installed on the test site and its catch-all `applies()` was intercepting
+all hivelog routes first, producing path-based trails instead of the correct
+entity-hierarchy trails.
+
+**Fix:** Raised `hivelog.breadcrumb` priority to 1004 in `hivelog.services.yml`.
+AGENTS.md updated to document the intentional priority and the reason it must
+remain above 1003.
+
+**Pages affected:** Hive canonical, Hive edit form, Inspection canonical,
+Queen canonical, Queen observation canonical, Queen observation edit form.
+
+## QA matrix (first pass — 360px, all pages)
+
+| Page | Scroll | Buttons joined/coloured | Tap targets | Breadcrumb | Notes |
+|---|---|---|---|---|---|
+| Apiary list | ✓ | ✓ | ✓ | ✓ | Pass |
+| Apiary canonical | ✓ | ✓ | ✓ | ✓ | Pass — breadcrumb: Home › HiveLog › Meadow Apiary |
+| Hive canonical | pending re-test | pending | pending | fixed | Re-test required after breadcrumb fix |
+| Hive canonical (no queen) | ✓ | ✓ | ✓ | pending | Pass for layout/buttons |
+| Inspection canonical | pending re-test | pending | pending | fixed | Re-test required |
+| Hive edit form | pending re-test | pending | pending | fixed | Re-test required |
+| Queen canonical | pending re-test | pending | pending | fixed | Re-test required |
+| Queen observation canonical | pending re-test | pending | pending | fixed | Re-test required |
+| Queen observation edit | pending re-test | pending | pending | fixed | Re-test required |
 
 ## Related
 - Project:: [[mobile-ux-improvements]]
-- Commits:: 
+- Defect fix:: hivelog.services.yml priority 100 → 1004 (PR #97)

--- a/hivelog.services.yml
+++ b/hivelog.services.yml
@@ -3,4 +3,4 @@ services:
     class: Drupal\hivelog\Breadcrumb\HivelogBreadcrumbBuilder
     arguments: ['@entity_type.manager']
     tags:
-      - { name: breadcrumb_builder, priority: 100 }
+      - { name: breadcrumb_builder, priority: 1004 }


### PR DESCRIPTION
Closes #97

Raises `hivelog.breadcrumb` priority from 100 to 1004 so it wins over the `easy_breadcrumb` contrib module (priority 1003) on all hivelog entity routes. Documents the intentional priority in AGENTS.md. 178/178 tests green.