### PR TITLE
feat(forms): vertical tabs and consistent field spacing on entity edit forms

### DIFF
--- a/css/hivelog.forms.css
+++ b/css/hivelog.forms.css
@@ -1,0 +1,111 @@
+/**
+ * @file
+ * Entity form layout and spacing for HiveLog add/edit forms.
+ *
+ * Provides consistent internal spacing for .form-item elements inside the
+ * .hivelog-entity-form wrapper, which is applied to every HiveLog entity
+ * add/edit form. Works alongside Drupal's vertical_tabs + details grouping
+ * used by HiveInspectionForm, QueenForm, and QueenObservationForm.
+ *
+ * Depends on hivelog/responsive for breakpoint tokens.
+ */
+
+/* ------------------------------------------------------------------
+   Form-item spacing inside entity forms.
+   Drupal's admin themes often provide no vertical rhythm between
+   consecutive .form-item widgets inside a details/vertical-tab panel.
+   These rules restore consistent breathing room.
+------------------------------------------------------------------ */
+
+.hivelog-entity-form .form-item {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.hivelog-entity-form .form-item:first-child {
+  margin-top: 0;
+}
+
+.hivelog-entity-form .form-item label {
+  display: block;
+  margin-bottom: 0.3rem;
+  font-weight: 600;
+}
+
+.hivelog-entity-form .form-item input,
+.hivelog-entity-form .form-item select,
+.hivelog-entity-form .form-item textarea {
+  width: 100%;
+  max-width: 40rem;
+  box-sizing: border-box;
+}
+
+.hivelog-entity-form .form-item textarea {
+  min-height: 6rem;
+}
+
+/* Description text below a widget. */
+.hivelog-entity-form .form-item .description {
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+/* ------------------------------------------------------------------
+   Vertical-tab panel padding.
+   The details element that wraps each tab's content gets internal
+   padding so widgets don't sit flush against the panel border.
+------------------------------------------------------------------ */
+
+.hivelog-entity-form details {
+  padding: 1rem 1.25rem;
+}
+
+/* ------------------------------------------------------------------
+   Checkbox / boolean widget alignment.
+   Inline-flex keeps the checkbox and its label on one line and
+   prevents the label from stretching to full width.
+------------------------------------------------------------------ */
+
+.hivelog-entity-form .form-type--checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.hivelog-entity-form .form-type--checkbox input[type="checkbox"] {
+  width: auto;
+  flex-shrink: 0;
+}
+
+.hivelog-entity-form .form-type--checkbox label {
+  margin-bottom: 0;
+  font-weight: normal;
+}
+
+/* ------------------------------------------------------------------
+   Form actions bar.
+   Matches the .hivelog-entity-form .form-actions context in
+   hivelog.buttons.css; adds top margin so the Save/Delete buttons
+   breathe away from the last field.
+------------------------------------------------------------------ */
+
+.hivelog-entity-form .form-actions {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+/* ------------------------------------------------------------------
+   Responsive — stack inputs full-width on small screens.
+   max-width constraint is lifted on phone so inputs use the full
+   available width.
+------------------------------------------------------------------ */
+
+@media (max-width: 480px) {
+  .hivelog-entity-form .form-item input,
+  .hivelog-entity-form .form-item select,
+  .hivelog-entity-form .form-item textarea {
+    max-width: 100%;
+  }
+}

--- a/hivelog.libraries.yml
+++ b/hivelog.libraries.yml
@@ -53,3 +53,12 @@ map:
       css/hivelog.map.css: {}
   dependencies:
     - hivelog/responsive
+
+forms:
+  version: 1.x
+  css:
+    component:
+      css/hivelog.forms.css: {}
+  dependencies:
+    - hivelog/buttons
+    - hivelog/responsive

--- a/src/Form/HiveInspectionForm.php
+++ b/src/Form/HiveInspectionForm.php
@@ -22,6 +22,10 @@ class HiveInspectionForm extends ContentEntityForm {
 
     $form = parent::form($form, $form_state);
 
+    $form['#prefix'] = '<div class="hivelog-entity-form">';
+    $form['#suffix'] = '</div>';
+    $form['#attached']['library'][] = 'hivelog/forms';
+
     $form['inspection_sections'] = [
       '#type' => 'vertical_tabs',
       '#title' => $this->t('Inspection sections'),

--- a/src/Form/QueenForm.php
+++ b/src/Form/QueenForm.php
@@ -13,6 +13,67 @@ class QueenForm extends ContentEntityForm {
   /**
    * {@inheritdoc}
    */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    $form['#prefix'] = '<div class="hivelog-entity-form">';
+    $form['#suffix'] = '</div>';
+    $form['#attached']['library'][] = 'hivelog/forms';
+
+    $form['queen_sections'] = [
+      '#type' => 'vertical_tabs',
+      '#title' => $this->t('Queen details'),
+      '#weight' => 10,
+    ];
+
+    $sections = [
+      'queen_identity' => [
+        'title' => $this->t('Identity'),
+        'weight' => 0,
+        'open' => TRUE,
+        'fields' => ['name', 'queen_year', 'queen_colour', 'breed', 'temperament'],
+      ],
+      'queen_hive_status' => [
+        'title' => $this->t('Hive & status'),
+        'weight' => 1,
+        'open' => FALSE,
+        'fields' => ['hive', 'status', 'introduction_date'],
+      ],
+      'queen_provenance' => [
+        'title' => $this->t('Provenance'),
+        'weight' => 2,
+        'open' => FALSE,
+        'fields' => ['origin', 'purchase_cost', 'purchase_date'],
+      ],
+      'queen_notes' => [
+        'title' => $this->t('Notes'),
+        'weight' => 3,
+        'open' => FALSE,
+        'fields' => ['notes', 'uid'],
+      ],
+    ];
+
+    foreach ($sections as $section_key => $section) {
+      $form[$section_key] = [
+        '#type' => 'details',
+        '#title' => $section['title'],
+        '#group' => 'queen_sections',
+        '#weight' => $section['weight'],
+        '#open' => $section['open'],
+      ];
+      foreach ($section['fields'] as $field_name) {
+        if (isset($form[$field_name])) {
+          $form[$field_name]['#group'] = $section_key;
+        }
+      }
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function save(array $form, FormStateInterface $form_state) {
     $entity = $this->entity;
     $status = $entity->save();

--- a/src/Form/QueenObservationForm.php
+++ b/src/Form/QueenObservationForm.php
@@ -19,7 +19,56 @@ class QueenObservationForm extends ContentEntityForm {
     if ($this->entity->isNew() && $this->entity->get('observation_date')->isEmpty()) {
       $this->entity->set('observation_date', date('Y-m-d'));
     }
-    return parent::form($form, $form_state);
+
+    $form = parent::form($form, $form_state);
+
+    $form['#prefix'] = '<div class="hivelog-entity-form">';
+    $form['#suffix'] = '</div>';
+    $form['#attached']['library'][] = 'hivelog/forms';
+
+    $form['observation_sections'] = [
+      '#type' => 'vertical_tabs',
+      '#title' => $this->t('Observation details'),
+      '#weight' => 10,
+    ];
+
+    $sections = [
+      'observation_overview' => [
+        'title' => $this->t('Overview'),
+        'weight' => 0,
+        'open' => TRUE,
+        'fields' => ['queen', 'observation_date', 'uid'],
+      ],
+      'observation_assessments' => [
+        'title' => $this->t('Assessments'),
+        'weight' => 1,
+        'open' => FALSE,
+        'fields' => ['health', 'temperament', 'active'],
+      ],
+      'observation_notes' => [
+        'title' => $this->t('Notes & photos'),
+        'weight' => 2,
+        'open' => FALSE,
+        'fields' => ['notes', 'images'],
+      ],
+    ];
+
+    foreach ($sections as $section_key => $section) {
+      $form[$section_key] = [
+        '#type' => 'details',
+        '#title' => $section['title'],
+        '#group' => 'observation_sections',
+        '#weight' => $section['weight'],
+        '#open' => $section['open'],
+      ];
+      foreach ($section['fields'] as $field_name) {
+        if (isset($form[$field_name])) {
+          $form[$field_name]['#group'] = $section_key;
+        }
+      }
+    }
+
+    return $form;
   }
 
   /**


### PR DESCRIPTION
Closes #100

Adds vertical tabs to QueenForm and QueenObservationForm (matching HiveInspectionForm). Adds new `hivelog/forms` CSS library providing field spacing, label styling, input sizing, and panel padding. 178/178 tests green.