### PR TITLE
feat(forms): add vertical tabs and field spacing to HiveForm

### DIFF
--- a/src/Form/HiveForm.php
+++ b/src/Form/HiveForm.php
@@ -13,6 +13,67 @@ class HiveForm extends ContentEntityForm {
   /**
    * {@inheritdoc}
    */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    $form['#prefix'] = '<div class="hivelog-entity-form">';
+    $form['#suffix'] = '</div>';
+    $form['#attached']['library'][] = 'hivelog/forms';
+
+    $form['hive_sections'] = [
+      '#type' => 'vertical_tabs',
+      '#title' => $this->t('Hive details'),
+      '#weight' => 10,
+    ];
+
+    $sections = [
+      'hive_overview' => [
+        'title' => $this->t('Overview'),
+        'weight' => 0,
+        'open' => TRUE,
+        'fields' => ['name', 'apiary', 'status', 'uid'],
+      ],
+      'hive_equipment' => [
+        'title' => $this->t('Equipment'),
+        'weight' => 1,
+        'open' => FALSE,
+        'fields' => ['hive_type', 'hive_material'],
+      ],
+      'hive_colony' => [
+        'title' => $this->t('Colony'),
+        'weight' => 2,
+        'open' => FALSE,
+        'fields' => ['bee_breed', 'temperament'],
+      ],
+      'hive_notes' => [
+        'title' => $this->t('Notes & photos'),
+        'weight' => 3,
+        'open' => FALSE,
+        'fields' => ['notes', 'images'],
+      ],
+    ];
+
+    foreach ($sections as $section_key => $section) {
+      $form[$section_key] = [
+        '#type' => 'details',
+        '#title' => $section['title'],
+        '#group' => 'hive_sections',
+        '#weight' => $section['weight'],
+        '#open' => $section['open'],
+      ];
+      foreach ($section['fields'] as $field_name) {
+        if (isset($form[$field_name])) {
+          $form[$field_name]['#group'] = $section_key;
+        }
+      }
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function save(array $form, FormStateInterface $form_state) {
     $entity = $this->entity;
     $status = $entity->save();


### PR DESCRIPTION
Closes #102

Adds `form()` method to `HiveForm` with four vertical tab sections — Overview, Equipment, Colony, Notes & photos — plus the `hivelog-entity-form` wrapper and `hivelog/forms` library attachment. Consistent with HiveInspectionForm, QueenForm, and QueenObservationForm. 178/178 tests green.