### PR TITLE
release: 1.5.1 — bump version

### DIFF
--- a/hivelog.info.yml
+++ b/hivelog.info.yml
@@ -3,7 +3,7 @@ type: module
 description: 'Beekeeping activity logger for managing apiaries, hives, and inspections.'
 core_version_requirement: ^11
 package: Custom
-version: '1.5.0'
+version: '1.5.1'
 dependencies:
   - drupal:datetime
   - drupal:file


### PR DESCRIPTION
Patch release: bumps `hivelog.info.yml` version to 1.5.1 for the Seasonal Calendar heading button-layout fix (#107).