### PR TITLE
feat(calendar): format Full Calendar page like other tables

### DIFF
--- a/src/Controller/ApiaryController.php
+++ b/src/Controller/ApiaryController.php
@@ -14,6 +14,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\hivelog\Entity\Apiary;
 use Drupal\hivelog\Form\HivelogCalendarFilterForm;
+use Drupal\hivelog\Form\HivelogFullCalendarFilterForm;
 use Drupal\hivelog\Form\HivelogHiveFilterForm;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -32,6 +33,20 @@ class ApiaryController extends ControllerBase {
    * Pager element id for the embedded hive table.
    */
   protected const HIVES_PAGER_ELEMENT = 0;
+
+  /**
+   * Default number of calendar actions shown per page on the Full Calendar page.
+   */
+  public const CALENDAR_ACTIONS_PER_PAGE = 20;
+
+  /**
+   * Pager element id for the Full Calendar page's table.
+   *
+   * A standalone page (unlike the embedded hive/inspection tables), so
+   * element 0 is safe to reuse — there is only ever one paginated list on
+   * this page.
+   */
+  protected const CALENDAR_ACTIONS_PAGER_ELEMENT = 0;
 
   /**
    * The request stack.
@@ -408,31 +423,57 @@ class ApiaryController extends ControllerBase {
   }
 
   /**
-   * Displays every enabled calendar action for an apiary, both scopes.
+   * Displays every calendar action for an apiary, both scopes.
    *
-   * Reference/management view only — no Status/Report buttons here; actual
+   * Reference/management view — no Status/Report buttons here; actual
    * reporting still happens on the apiary page (for apiary-scoped items) or
-   * each hive's page (for hive-scoped items). Sorted by week_start, with a
-   * Scope column so it's visually clear which is which.
+   * each hive's page (for hive-scoped items). Formatted like every other
+   * embedded/collection table in the module (heading + Add action, a GET
+   * filter form, a paginated `hivelog:entity-table`, and per-row Edit/
+   * Delete operations), rather than the plain read-only table this page
+   * originally shipped with. Sorted by week_start, with a Scope column so
+   * it's visually clear which is which.
    */
   public function fullCalendar(Apiary $apiary) {
     $build = [];
 
+    // Heading row: title on the left, Add Calendar Action on the right —
+    // same layout as the Hives heading on the apiary page.
     $build['heading'] = [
-      '#type' => 'html_tag',
-      '#tag' => 'h2',
-      '#value' => $this->t('Full Calendar: @apiary', ['@apiary' => $apiary->label()]),
+      '#type' => 'container',
+      '#attributes' => ['class' => ['hivelog-list-heading']],
       '#weight' => 0,
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h2',
+        '#value' => $this->t('Full Calendar: @apiary', ['@apiary' => $apiary->label()]),
+        '#attributes' => ['class' => ['hivelog-list-heading__title']],
+      ],
+      'add' => [
+        '#type' => 'component',
+        '#component' => 'hivelog:button',
+        '#props' => [
+          'label' => (string) $this->t('Add Calendar Action'),
+          'url' => Url::fromRoute('hivelog.calendar_action.add', ['apiary' => $apiary->id()])->toString(),
+          'variant' => 'primary',
+          'extra_classes' => 'hivelog-list-heading__action',
+        ],
+      ],
     ];
 
-    $calendar_action_ids = $this->entityTypeManager
+    $build['filter'] = $this->formBuilder->getForm(HivelogFullCalendarFilterForm::class, $apiary);
+    $build['filter']['#weight'] = 1;
+
+    $filters = $this->extractFullCalendarFilters();
+    $query = $this->entityTypeManager
       ->getStorage('calendar_action')
       ->getQuery()
       ->accessCheck(TRUE)
       ->condition('apiary', $apiary->id())
-      ->condition('enabled', TRUE)
       ->sort('week_start', 'ASC')
-      ->execute();
+      ->pager(static::CALENDAR_ACTIONS_PER_PAGE, static::CALENDAR_ACTIONS_PAGER_ELEMENT);
+    $this->applyFullCalendarFilters($query, $filters);
+    $calendar_action_ids = $query->execute();
 
     $calendar_actions = $calendar_action_ids
       ? $this->entityTypeManager->getStorage('calendar_action')->loadMultiple($calendar_action_ids)
@@ -452,6 +493,8 @@ class ApiaryController extends ControllerBase {
       $this->t('Scope'),
       $this->t('Week(s)'),
       $this->t('Category'),
+      $this->t('Enabled'),
+      $this->t('Operations'),
     ];
 
     $rows = [];
@@ -470,12 +513,33 @@ class ApiaryController extends ControllerBase {
         ? ($calendar_action->get('category')->getSetting('allowed_values')[$category] ?? $category)
         : '';
 
+      $enabled_display = $calendar_action->get('enabled')->value ? (string) $this->t('Yes') : (string) $this->t('Disabled');
+
+      $buttons = [];
+      if ($calendar_action->access('update')) {
+        $buttons[] = ['label' => (string) $this->t('Edit'), 'url' => $calendar_action->toUrl('edit-form')->toString()];
+      }
+      if ($calendar_action->access('delete')) {
+        $buttons[] = [
+          'label' => (string) $this->t('Delete'),
+          'url' => $calendar_action->toUrl('delete-form')->toString(),
+          'variant' => 'danger',
+        ];
+      }
+      $actions = [
+        '#type' => 'component',
+        '#component' => 'hivelog:button-group',
+        '#props' => ['buttons' => $buttons],
+      ];
+
       $rows[] = [
         'cells' => [
           $calendar_action->toLink()->toString(),
           $scope_display,
           (string) $weeks,
           (string) $category_label,
+          $enabled_display,
+          $this->renderer->renderInIsolation($actions),
         ],
       ];
     }
@@ -486,13 +550,21 @@ class ApiaryController extends ControllerBase {
       '#props' => [
         'headers' => array_map('strval', $header),
         'rows' => $rows,
-        'empty_message' => (string) $this->t('No calendar actions have been added to this apiary yet.'),
+        'empty_message' => (string) (!empty($filters)
+          ? $this->t('No calendar actions match the current filters.')
+          : $this->t('No calendar actions have been added to this apiary yet.')),
       ],
-      '#weight' => 1,
+      '#weight' => 2,
+    ];
+
+    $build['pager'] = [
+      '#type' => 'pager',
+      '#element' => static::CALENDAR_ACTIONS_PAGER_ELEMENT,
+      '#weight' => 3,
     ];
 
     $cache = CacheableMetadata::createFromRenderArray($build)
-      ->addCacheContexts(['user.permissions'])
+      ->addCacheContexts(['url.query_args', 'user.permissions'])
       ->addCacheableDependency($apiary)
       ->addCacheTags($this->entityTypeManager->getDefinition('calendar_action')->getListCacheTags());
     foreach ($calendar_actions as $calendar_action) {
@@ -501,6 +573,77 @@ class ApiaryController extends ControllerBase {
     $cache->applyTo($build);
 
     return $build;
+  }
+
+  /**
+   * Extracts Full Calendar filter values from the current request.
+   *
+   * Unlike the other filter-value keys, `enabled` is only included when
+   * it differs from its default (`1`, "Enabled only") — this is what lets
+   * `!empty($filters)` keep distinguishing "no calendar actions exist at
+   * all" from "none match the current filters" for the empty-state
+   * message, while `applyFullCalendarFilters()` still treats a missing
+   * `enabled` key as the default rather than "no restriction".
+   *
+   * @return array<string, string>
+   *   Associative array keyed by filter name. Only non-default values are
+   *   included.
+   */
+  protected function extractFullCalendarFilters(): array {
+    $request = $this->requestStack->getCurrentRequest();
+    if (!$request) {
+      return [];
+    }
+
+    $filters = [];
+
+    $scope = trim((string) $request->query->get('scope', ''));
+    if ($scope !== '') {
+      $filters['scope'] = $scope;
+    }
+
+    $category = trim((string) $request->query->get('category', ''));
+    if ($category !== '') {
+      $filters['category'] = $category;
+    }
+
+    $enabled = trim((string) $request->query->get('enabled', '1'));
+    if (!in_array($enabled, ['', '0', '1'], TRUE)) {
+      $enabled = '1';
+    }
+    if ($enabled !== '1') {
+      $filters['enabled'] = $enabled;
+    }
+
+    $title = trim((string) $request->query->get('title', ''));
+    if ($title !== '') {
+      $filters['title'] = $title;
+    }
+
+    return $filters;
+  }
+
+  /**
+   * Applies Full Calendar filters to an entity query.
+   */
+  protected function applyFullCalendarFilters(QueryInterface $query, array $filters): void {
+    if (isset($filters['scope'])) {
+      $query->condition('scope', $filters['scope']);
+    }
+    if (isset($filters['category'])) {
+      $query->condition('category', $filters['category']);
+    }
+    if (isset($filters['title'])) {
+      $query->condition('title', '%' . $this->escapeLike($filters['title']) . '%', 'LIKE');
+    }
+    // A missing key means the default ("Enabled only", `1`) applies — this
+    // is what preserves the page's original "hide disabled actions"
+    // behaviour. An explicit empty string ("- Any -") means no
+    // restriction at all.
+    $enabled = $filters['enabled'] ?? '1';
+    if ($enabled !== '') {
+      $query->condition('enabled', $enabled === '1');
+    }
   }
 
   /**

--- a/src/Form/HivelogFullCalendarFilterForm.php
+++ b/src/Form/HivelogFullCalendarFilterForm.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\hivelog\Form;
+
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\hivelog\Entity\Apiary;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Filter form for the Full Calendar page (task 0027 follow-up).
+ *
+ * Submits via GET so filter state is reflected in the URL query string and
+ * plays nicely with Drupal's pager, mirroring HivelogHiveFilterForm's
+ * established pattern exactly.
+ */
+class HivelogFullCalendarFilterForm extends FormBase {
+
+  /**
+   * The entity field manager.
+   */
+  protected EntityFieldManagerInterface $entityFieldManager;
+
+  public function __construct(RequestStack $request_stack, EntityFieldManagerInterface $entity_field_manager) {
+    $this->requestStack = $request_stack;
+    $this->entityFieldManager = $entity_field_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('request_stack'),
+      $container->get('entity_field.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'hivelog_full_calendar_filter_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?Apiary $apiary = NULL): array {
+    $request = $this->requestStack->getCurrentRequest();
+    $query = $request ? $request->query : NULL;
+
+    $form['#method'] = 'get';
+    $form['#attributes']['class'][] = 'hivelog-filter-form';
+    $form['#attached']['library'][] = 'hivelog/filter_form';
+    $form['#cache']['contexts'][] = 'url.query_args';
+
+    $calendar_action_fields = $this->entityFieldManager->getBaseFieldDefinitions('calendar_action');
+
+    $form['filters'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['hivelog-filter-form__filters']],
+    ];
+
+    $form['filters']['scope'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Scope'),
+      '#options' => ['' => $this->t('- Any -')] + $calendar_action_fields['scope']->getSetting('allowed_values'),
+      '#default_value' => $query ? (string) $query->get('scope', '') : '',
+    ];
+
+    $form['filters']['category'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Category'),
+      '#options' => ['' => $this->t('- Any -')] + $calendar_action_fields['category']->getSetting('allowed_values'),
+      '#default_value' => $query ? (string) $query->get('category', '') : '',
+    ];
+
+    // Defaults to "Enabled only" so the page's default view matches its
+    // original (task 0027) behaviour of hiding disabled actions; "Disabled
+    // only" and "- Any -" let a beekeeper find and manage a disabled
+    // action directly from this page.
+    $form['filters']['enabled'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Enabled'),
+      '#options' => [
+        '1' => $this->t('Enabled only'),
+        '0' => $this->t('Disabled only'),
+        '' => $this->t('- Any -'),
+      ],
+      '#default_value' => $query ? (string) $query->get('enabled', '1') : '1',
+    ];
+
+    $form['filters']['title'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Title contains'),
+      '#size' => 20,
+      '#default_value' => $query ? (string) $query->get('title', '') : '',
+    ];
+
+    // Deliberately named 'filter_actions' (not 'actions') and typed as a
+    // plain container — see HivelogHiveFilterForm for why (Gin admin theme
+    // compatibility).
+    $form['filter_actions'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['hivelog-filter-form__actions']],
+    ];
+    $form['filter_actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Filter'),
+      '#button_type' => 'primary',
+      '#attributes' => ['class' => ['hivelog-filter-form__submit']],
+    ];
+    if ($apiary) {
+      $form['filter_actions']['reset'] = [
+        '#type' => 'component',
+        '#component' => 'hivelog:button',
+        '#props' => [
+          'label' => (string) $this->t('Reset'),
+          'url' => Url::fromRoute('hivelog.apiary.calendar_action.collection', ['apiary' => $apiary->id()])->toString(),
+        ],
+      ];
+    }
+
+    // GET forms don't need CSRF / build id tokens; hide them so they don't
+    // end up as query string noise.
+    foreach (['form_build_id', 'form_token', 'form_id'] as $element) {
+      if (isset($form[$element])) {
+        $form[$element]['#access'] = FALSE;
+      }
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    // Intentionally empty: the form uses GET, so submission simply reloads
+    // the current URL with the filter values as query string parameters.
+  }
+
+}

--- a/tests/src/Kernel/ApiaryCalendarChecklistTest.php
+++ b/tests/src/Kernel/ApiaryCalendarChecklistTest.php
@@ -269,6 +269,7 @@ class ApiaryCalendarChecklistTest extends KernelTestBase {
     ]);
     $disabled_action->save();
 
+    $this->pushRequestWithQuery([], '/hivelog/apiary/' . $this->apiary->id() . '/calendar');
     $controller = \Drupal::service('class_resolver')
       ->getInstanceFromDefinition(ApiaryController::class);
     $build = $controller->fullCalendar($this->apiary);
@@ -277,6 +278,120 @@ class ApiaryCalendarChecklistTest extends KernelTestBase {
     $this->assertStringContainsString('Full Calendar Hive Action', $html);
     $this->assertStringContainsString('Full Calendar Apiary Action', $html);
     $this->assertStringNotContainsString('Full Calendar Disabled Action', $html);
+  }
+
+  /**
+   * Tests that the Full Calendar page's filters narrow the result set.
+   *
+   * Covers scope, category, title, and the enabled/disabled toggle —
+   * including that "- Any -" surfaces a disabled action that the default
+   * "Enabled only" view hides.
+   */
+  public function testFullCalendarFiltersNarrowResults(): void {
+    CalendarAction::create([
+      'apiary' => $this->apiary->id(),
+      'title' => 'Filter Hive Action',
+      'description' => 'Desc.',
+      'week_start' => 10,
+      'scope' => 'hive',
+      'category' => 'feeding',
+    ])->save();
+
+    CalendarAction::create([
+      'apiary' => $this->apiary->id(),
+      'title' => 'Filter Apiary Action',
+      'description' => 'Desc.',
+      'week_start' => 20,
+      'scope' => 'apiary',
+      'category' => 'other',
+    ])->save();
+
+    CalendarAction::create([
+      'apiary' => $this->apiary->id(),
+      'title' => 'Filter Disabled Action',
+      'description' => 'Desc.',
+      'week_start' => 30,
+      'scope' => 'apiary',
+      'category' => 'other',
+      'enabled' => FALSE,
+    ])->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ApiaryController::class);
+    $path = '/hivelog/apiary/' . $this->apiary->id() . '/calendar';
+
+    // scope=hive: only the hive-scoped action.
+    $this->pushRequestWithQuery(['scope' => 'hive'], $path);
+    $build = $controller->fullCalendar($this->apiary);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('Filter Hive Action', $html);
+    $this->assertStringNotContainsString('Filter Apiary Action', $html);
+
+    // category=feeding: only the feeding-category action.
+    $this->pushRequestWithQuery(['category' => 'feeding'], $path);
+    $build = $controller->fullCalendar($this->apiary);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('Filter Hive Action', $html);
+    $this->assertStringNotContainsString('Filter Apiary Action', $html);
+
+    // title=Apiary: only the title match.
+    $this->pushRequestWithQuery(['title' => 'Apiary'], $path);
+    $build = $controller->fullCalendar($this->apiary);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('Filter Apiary Action', $html);
+    $this->assertStringNotContainsString('Filter Hive Action', $html);
+
+    // Default (no query at all): disabled action stays hidden.
+    $this->pushRequestWithQuery([], $path);
+    $build = $controller->fullCalendar($this->apiary);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringNotContainsString('Filter Disabled Action', $html);
+
+    // enabled=0: only the disabled action.
+    $this->pushRequestWithQuery(['enabled' => '0'], $path);
+    $build = $controller->fullCalendar($this->apiary);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('Filter Disabled Action', $html);
+    $this->assertStringNotContainsString('Filter Hive Action', $html);
+
+    // enabled='' (- Any -): every action, including the disabled one.
+    // Combined with a title filter to keep the result set well under the
+    // pager's page size — the apiary's 31 auto-seeded starter items are
+    // also "any enabled" matches, and would otherwise push these three
+    // test rows across a page boundary.
+    $this->pushRequestWithQuery(['enabled' => '', 'title' => 'Filter'], $path);
+    $build = $controller->fullCalendar($this->apiary);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('Filter Hive Action', $html);
+    $this->assertStringContainsString('Filter Apiary Action', $html);
+    $this->assertStringContainsString('Filter Disabled Action', $html);
+  }
+
+  /**
+   * Tests that the Full Calendar page offers Edit/Delete operations.
+   *
+   * Formatted like every other embedded/collection table in the module
+   * (Edit/Delete button-group per row), rather than the plain read-only
+   * table this page originally shipped with.
+   */
+  public function testFullCalendarHasEditAndDeleteOperations(): void {
+    $action = CalendarAction::create([
+      'apiary' => $this->apiary->id(),
+      'title' => 'Editable Full Calendar Action',
+      'description' => 'Desc.',
+      'week_start' => 10,
+      'scope' => 'apiary',
+    ]);
+    $action->save();
+
+    $this->pushRequestWithQuery([], '/hivelog/apiary/' . $this->apiary->id() . '/calendar');
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ApiaryController::class);
+    $build = $controller->fullCalendar($this->apiary);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+
+    $this->assertStringContainsString('/hivelog/calendar-action/' . $action->id() . '/edit', $html);
+    $this->assertStringContainsString('/hivelog/calendar-action/' . $action->id() . '/delete', $html);
   }
 
   /**

--- a/tests/src/Kernel/ControllerCacheMetadataTest.php
+++ b/tests/src/Kernel/ControllerCacheMetadataTest.php
@@ -287,6 +287,39 @@ class ControllerCacheMetadataTest extends KernelTestBase {
   }
 
   /**
+   * Tests that the Full Calendar page declares expected cache metadata.
+   *
+   * Unlike the plain calendar action view, this page has a GET filter
+   * form and pager, so it must also vary by `url.query_args`.
+   */
+  public function testApiaryFullCalendarCacheMetadata(): void {
+    $apiary = Apiary::create(['name' => 'Cache Apiary']);
+    $apiary->save();
+
+    $calendarAction = CalendarAction::create([
+      'apiary' => $apiary->id(),
+      'title' => 'Cache Full Calendar Action',
+      'description' => 'Desc.',
+      'week_start' => 10,
+    ]);
+    $calendarAction->save();
+
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ApiaryController::class);
+    $build = $controller->fullCalendar($apiary);
+
+    $this->assertContains('url.query_args', $build['#cache']['contexts']);
+    $this->assertContains('user.permissions', $build['#cache']['contexts']);
+
+    foreach ($apiary->getCacheTags() as $tag) {
+      $this->assertContains($tag, $build['#cache']['tags']);
+    }
+    foreach ($calendarAction->getCacheTags() as $tag) {
+      $this->assertContains($tag, $build['#cache']['tags']);
+    }
+  }
+
+  /**
    * Tests that the hive action log view declares expected cache metadata.
    *
    * Including the linked inspection's cache tags when one is set.


### PR DESCRIPTION
The apiary Full Calendar page (`/hivelog/apiary/{apiary}/calendar`) was a plain read-only table. It now matches every other embedded/collection table in the module:

- Heading row with title + "Add Calendar Action" button.
- New `HivelogFullCalendarFilterForm`: GET filter form for scope, category, title-contains, and an enabled/disabled toggle (defaults to "Enabled only", preserving the page's original behaviour).
- Paginated (20 per page, matching Hives/Inspections tables).
- New Enabled column, and an Operations column with Edit/Delete button-group per row (gated by the existing `calendar_action` access control handler — buttons only appear for users with edit/delete permission).

## Testing
- New `testFullCalendarFiltersNarrowResults` and `testFullCalendarHasEditAndDeleteOperations` in `ApiaryCalendarChecklistTest.php`; updated `testFullCalendarListsBothScopes` for the new filter-form-aware call signature; new `testApiaryFullCalendarCacheMetadata` in `ControllerCacheMetadataTest.php`.
- Full kernel + unit suite: 288 tests / 4101 assertions, green (up from 285).
- `composer lint` (phpcs, `--warning-severity=0`) clean.
- Manually verified via `drush php:eval` that Edit/Delete buttons are correctly gated by permission (hidden for anonymous, visible for uid 1).