### PR TITLE
fix(calendar): Edit/Delete on Full Calendar page return to that page

### DIFF
--- a/src/Controller/ApiaryController.php
+++ b/src/Controller/ApiaryController.php
@@ -497,6 +497,17 @@ class ApiaryController extends ControllerBase {
       $this->t('Operations'),
     ];
 
+    // The current page's own URL (including any applied filters/pager
+    // state), passed as a `destination` query parameter on the Edit/
+    // Delete links below. CalendarActionForm/CalendarActionDeleteForm
+    // otherwise always redirect back to the apiary's canonical page on
+    // save/delete — Drupal core's RedirectResponseSubscriber overrides
+    // that with `destination` whenever it's present, which is what sends
+    // the beekeeper back to this page (rather than the apiary page)
+    // without any changes needed to those two shared form classes.
+    $request = $this->requestStack->getCurrentRequest();
+    $destination = $request ? $request->getRequestUri() : Url::fromRoute('hivelog.apiary.calendar_action.collection', ['apiary' => $apiary->id()])->toString();
+
     $rows = [];
     foreach ($calendar_actions as $calendar_action) {
       $week_start = $calendar_action->get('week_start')->value;
@@ -517,12 +528,15 @@ class ApiaryController extends ControllerBase {
 
       $buttons = [];
       if ($calendar_action->access('update')) {
-        $buttons[] = ['label' => (string) $this->t('Edit'), 'url' => $calendar_action->toUrl('edit-form')->toString()];
+        $buttons[] = [
+          'label' => (string) $this->t('Edit'),
+          'url' => $calendar_action->toUrl('edit-form', ['query' => ['destination' => $destination]])->toString(),
+        ];
       }
       if ($calendar_action->access('delete')) {
         $buttons[] = [
           'label' => (string) $this->t('Delete'),
-          'url' => $calendar_action->toUrl('delete-form')->toString(),
+          'url' => $calendar_action->toUrl('delete-form', ['query' => ['destination' => $destination]])->toString(),
           'variant' => 'danger',
         ];
       }

--- a/tests/src/Kernel/ApiaryCalendarChecklistTest.php
+++ b/tests/src/Kernel/ApiaryCalendarChecklistTest.php
@@ -395,6 +395,49 @@ class ApiaryCalendarChecklistTest extends KernelTestBase {
   }
 
   /**
+   * Tests that Edit/Delete on the Full Calendar page return to that page.
+   *
+   * CalendarActionForm/CalendarActionDeleteForm always redirect to the
+   * apiary's canonical page on save/delete. Without a `destination` query
+   * parameter on the Edit/Delete links, saving or deleting from the Full
+   * Calendar page would incorrectly bounce the beekeeper back to
+   * /hivelog/apiary/{apiary} instead of back to this page — Drupal core's
+   * RedirectResponseSubscriber overrides the form's redirect with
+   * `destination` whenever it's present on the request that submitted the
+   * form, so the links here must carry it (and preserve any applied
+   * filters/pager state) to work correctly.
+   */
+  public function testFullCalendarEditDeleteLinksPreserveDestination(): void {
+    $action = CalendarAction::create([
+      'apiary' => $this->apiary->id(),
+      'title' => 'Destination Test Action',
+      'description' => 'Desc.',
+      'week_start' => 10,
+      'scope' => 'apiary',
+    ]);
+    $action->save();
+
+    // With a filter applied, the destination must round-trip that filter
+    // too, not just the bare page path.
+    $this->pushRequestWithQuery(['scope' => 'apiary'], '/hivelog/apiary/' . $this->apiary->id() . '/calendar');
+    $controller = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(ApiaryController::class);
+    $build = $controller->fullCalendar($this->apiary);
+    $html = (string) \Drupal::service('renderer')->renderInIsolation($build);
+
+    // Drupal's query-string assembly percent-encodes reserved characters
+    // like `?` and `=` within the destination value, but leaves `/`
+    // unescaped — match that encoding exactly rather than over-encoding
+    // with rawurlencode() (which would also escape the slashes).
+    $expected_destination = '/hivelog/apiary/' . $this->apiary->id() . '/calendar%3Fscope%3Dapiary';
+    $edit_href = '/hivelog/calendar-action/' . $action->id() . '/edit?destination=' . $expected_destination;
+    $delete_href = '/hivelog/calendar-action/' . $action->id() . '/delete?destination=' . $expected_destination;
+
+    $this->assertStringContainsString($edit_href, $html);
+    $this->assertStringContainsString($delete_href, $html);
+  }
+
+  /**
    * Tests that the apiary view links to the Full Calendar page.
    */
   public function testApiaryViewLinksToFullCalendar(): void {


### PR DESCRIPTION
`CalendarActionForm`/`CalendarActionDeleteForm` always redirect to the apiary's canonical page on save/delete (a pre-existing, module-wide pattern for all edit/delete forms). This meant editing or deleting a calendar action from the new Full Calendar page (#109) incorrectly bounced back to `/hivelog/apiary/{apiary}` instead of returning to the Full Calendar page.

Fixed by adding a `destination` query parameter to the Edit/Delete links on that page — the current page's own URL, including any applied filters/pager state. Drupal core's `RedirectResponseSubscriber` automatically honors `destination` over any form-set redirect, so this required no changes to the shared form classes and has no effect on Edit/Delete from any other page (apiary page, calendar action collection, etc.).

## Testing
- New `testFullCalendarEditDeleteLinksPreserveDestination` (also confirms the destination round-trips an applied filter, not just the bare page path).
- Full kernel + unit suite: 289 tests / 4119 assertions, green.
- `composer lint` clean.
- Manually verified via `drush php:eval` that the rendered Edit link carries `?destination=/hivelog/apiary/{id}/calendar`.