### PR TITLE
fix(css): explicit filter label colour for contrast against grey row

### DIFF
--- a/css/hivelog.filter-form.css
+++ b/css/hivelog.filter-form.css
@@ -45,10 +45,19 @@
   margin: 0;
 }
 
+/* Explicit, high-contrast colour against the filter row's #fafafa
+   background (see .hivelog-filter-form above). Admin themes (e.g. Gin)
+   often render unfocused field labels in a low-contrast "muted" tone
+   that's legible against a plain white page background but disappears
+   against this row's light grey one — only becoming visible once the
+   field gains focus (:focus-within). Setting the colour explicitly here,
+   rather than leaving it to the active theme, keeps every filter label
+   readable regardless of focus state. */
 .hivelog-filter-form .form-item label {
   display: block;
   font-size: 0.85rem;
   margin-bottom: 0.15rem;
+  color: #1a1a1a;
 }
 
 /* Push the Filter / Reset actions to the right end of the filter row so


### PR DESCRIPTION
Every table filter form (Hives, Inspections, Seasonal Calendar checklist, Full Calendar) shares `.hivelog-filter-form`, whose row has a light grey (`#fafafa`) background. Field labels had no explicit colour set, so they inherited whatever "muted" tone the active admin theme (e.g. Gin) applies to unfocused labels — legible against a plain white page background, but low enough contrast against this row's grey background to be effectively invisible until the field gains focus (`:focus-within`), at which point the theme brightens it back up.

## Fix
Sets an explicit, always-visible colour on `.hivelog-filter-form .form-item label` so every filter label is legible regardless of focus state or the active admin theme's own styling. This applies to all four filter forms module-wide (they all share the same CSS class).

## Testing
- CSS-only change; no PHP behaviour affected. Full kernel + unit suite re-run for safety: 289 tests / 4119 assertions, green (unchanged).
- `composer lint` unaffected (CSS isn't linted by phpcs).