### PR TITLE
release: 1.6.0 — bump version

### DIFF
--- a/hivelog.info.yml
+++ b/hivelog.info.yml
@@ -3,7 +3,7 @@ type: module
 description: 'Beekeeping activity logger for managing apiaries, hives, and inspections.'
 core_version_requirement: ^11
 package: Custom
-version: '1.5.1'
+version: '1.6.0'
 dependencies:
   - drupal:datetime
   - drupal:file


### PR DESCRIPTION
Minor release: bumps `hivelog.info.yml` version to 1.6.0, covering the Full Calendar page reformatting (#109), its Edit/Delete destination fix (#110), and the filter-label contrast fix (#111).